### PR TITLE
Responsive UX, playlist feature, and sidebar improvements

### DIFF
--- a/apps/klank/app/app.module.css
+++ b/apps/klank/app/app.module.css
@@ -25,3 +25,9 @@
 .resizeHandle:hover {
   background: var(--klank-color-border);
 }
+
+@media (max-width: 599px) {
+  .resizeHandle {
+    display: none;
+  }
+}

--- a/apps/klank/app/app.tsx
+++ b/apps/klank/app/app.tsx
@@ -68,6 +68,19 @@ export function App() {
   }, [baseDirectory, serverMode, setBaseDirectory, setFileService, setTabSettings])
 
   useEffect(() => {
+    const container = containerRef.current
+    if (!container || typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(([entry]) => {
+      if (entry.contentRect.width === 0) return
+      if (entry.contentRect.width < 600 && isMenuExtended) {
+        toggleMenu(false)
+      }
+    })
+    ro.observe(container)
+    return () => ro.disconnect()
+  }, [isMenuExtended, toggleMenu])
+
+  useEffect(() => {
     if (needsUpdate && baseDirectory) {
       fileService
         ?.readDirectoryRecursively(

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -23,7 +23,6 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
   const toggleMenu = useKlankStore().toggleMenu
   const currentTabPath = useKlankStore().tab.path
   const setTabPath = useKlankStore().setTabPath
-  const setActivePlaylist = useKlankStore().setActivePlaylist
   const baseDirectory = useKlankStore().baseDirectory
   const setBaseDirectory = useKlankStore().setBaseDirectory
   const fileService = useKlankStore().fileService
@@ -34,9 +33,10 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
 
   const activePlaylist = playlists.find((p) => p.id === activePlaylistId) ?? null
 
-  // Navigating from the file tree / shuffle always exits playlist context.
+  // Navigating from the file tree / shuffle exits playlist navigation (hides ◁/▷)
+  // but keeps the selected playlist so + buttons remain visible.
   const handleSelectSong = (path: string) => {
-    setActivePlaylist(null)
+    useKlankStore.setState((s) => ({ ...s, activePlaylistIndex: null }))
     setTabPath(path)
   }
 

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -10,6 +10,7 @@ import {
   Toolbar,
 } from '@klank/ui'
 import { useKlankStore } from '@klank/store'
+import { PlaylistSection } from './PlaylistSection'
 
 type MenuProps = {
   tree: FileEntry[]
@@ -22,10 +23,22 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
   const toggleMenu = useKlankStore().toggleMenu
   const currentTabPath = useKlankStore().tab.path
   const setTabPath = useKlankStore().setTabPath
+  const setActivePlaylist = useKlankStore().setActivePlaylist
   const baseDirectory = useKlankStore().baseDirectory
   const setBaseDirectory = useKlankStore().setBaseDirectory
   const fileService = useKlankStore().fileService
+  const activePlaylistId = useKlankStore().activePlaylistId
+  const playlists = useKlankStore().playlists
+  const addTabToPlaylist = useKlankStore().addTabToPlaylist
   const [searchFilter, setSearchFilter] = useState<string>('')
+
+  const activePlaylist = playlists.find((p) => p.id === activePlaylistId) ?? null
+
+  // Navigating from the file tree / shuffle always exits playlist context.
+  const handleSelectSong = (path: string) => {
+    setActivePlaylist(null)
+    setTabPath(path)
+  }
 
   const handleDownloadTab = async (url: string) => {
     const sheet = await getSheetFromUG(url)
@@ -48,19 +61,26 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
         getDirectoryPath={fileService?.getDirectoryPath}
         setNeedsUpdate={setNeedsUpdate}
         setBaseDirectory={setBaseDirectory}
-        setTabPath={setTabPath}
+        setTabPath={handleSelectSong}
         tree={tree}
         onDownloadTab={handleDownloadTab}
         onSettingsClick={() => navigate('/settings')}
         isCollapsed={!isMenuExtended}
       />
       {isMenuExtended && (
-        <FileTreeView
-          currentTabPath={currentTabPath}
-          setTabPath={setTabPath}
-          searchFilter={searchFilter}
-          tree={tree}
-        />
+        <>
+          <PlaylistSection tree={tree} currentTabPath={currentTabPath} />
+          <div className={styles.treeWrapper}>
+            <FileTreeView
+              currentTabPath={currentTabPath}
+              setTabPath={handleSelectSong}
+              searchFilter={searchFilter}
+              tree={tree}
+              onAddToPlaylist={activePlaylist ? (path) => addTabToPlaylist(activePlaylist.id, path) : undefined}
+              activePlaylistPaths={activePlaylist?.paths}
+            />
+          </div>
+        </>
       )}
       <Searchbar
         toggleMenu={toggleMenu}

--- a/apps/klank/app/components/menu/PlaylistSection.tsx
+++ b/apps/klank/app/components/menu/PlaylistSection.tsx
@@ -156,40 +156,40 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
                     </button>
                   )}
 
-                  {/* Context menu trigger */}
-                  <button
-                    className={styles.menuButton}
-                    onClick={(e) => handleContextMenu(e, playlist.id)}
-                    aria-label="Playlist options"
-                  >
-                    ⋮
-                  </button>
-                </div>
-
-                {/* Context menu — rename / delete */}
-                {contextMenuId === playlist.id && (
-                  <div className={styles.contextMenu} onClick={(e) => e.stopPropagation()}>
+                  {/* Context menu trigger + menu — both inside header so menu positions relative to header height */}
+                  <div className={styles.menuButtonWrapper}>
                     <button
-                      onClick={() => {
-                        setEditingId(playlist.id)
-                        setEditingName(playlist.name)
-                        setExpandedId(playlist.id)
-                        setContextMenuId(null)
-                      }}
+                      className={styles.menuButton}
+                      onClick={(e) => handleContextMenu(e, playlist.id)}
+                      aria-label="Playlist options"
                     >
-                      Rename
+                      ⋮
                     </button>
-                    <button
-                      className={styles.dangerAction}
-                      onClick={() => {
-                        deletePlaylist(playlist.id)
-                        setContextMenuId(null)
-                      }}
-                    >
-                      Delete
-                    </button>
+                    {contextMenuId === playlist.id && (
+                      <div className={styles.contextMenu} onClick={(e) => e.stopPropagation()}>
+                        <button
+                          onClick={() => {
+                            setEditingId(playlist.id)
+                            setEditingName(playlist.name)
+                            setExpandedId(playlist.id)
+                            setContextMenuId(null)
+                          }}
+                        >
+                          Rename
+                        </button>
+                        <button
+                          className={styles.dangerAction}
+                          onClick={() => {
+                            deletePlaylist(playlist.id)
+                            setContextMenuId(null)
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    )}
                   </div>
-                )}
+                </div>
 
                 {/* Expanded song list */}
                 {isExpanded && (

--- a/apps/klank/app/components/menu/PlaylistSection.tsx
+++ b/apps/klank/app/components/menu/PlaylistSection.tsx
@@ -1,0 +1,254 @@
+import styles from './playlistSection.module.css'
+import * as React from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useKlankStore } from '@klank/store'
+import { ChevronIcon, PlusIcon } from '@klank/ui'
+import { FileEntry } from '@klank/platform-api'
+
+type PlaylistSectionProps = {
+  tree: FileEntry[]
+  currentTabPath: string
+}
+
+const getSongDisplayName = (path: string): string => {
+  const filename = path.split(/[/\\]/).slice(-1)[0] ?? ''
+  const withoutExt = filename.slice(0, -8)
+  const dashIndex = withoutExt.indexOf(' - ')
+  return dashIndex !== -1 ? withoutExt.slice(dashIndex + 3) : withoutExt
+}
+
+export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath }) => {
+  const playlists = useKlankStore().playlists
+  const activePlaylistId = useKlankStore().activePlaylistId
+  const activePlaylistIndex = useKlankStore().activePlaylistIndex
+  const createPlaylist = useKlankStore().createPlaylist
+  const deletePlaylist = useKlankStore().deletePlaylist
+  const renamePlaylist = useKlankStore().renamePlaylist
+  const addTabToPlaylist = useKlankStore().addTabToPlaylist
+  const removeTabFromPlaylist = useKlankStore().removeTabFromPlaylist
+  const setActivePlaylist = useKlankStore().setActivePlaylist
+
+  const [isCollapsed, setIsCollapsed] = useState(false)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [contextMenuId, setContextMenuId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState('')
+  const editInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editingId && editInputRef.current) {
+      editInputRef.current.focus()
+      editInputRef.current.select()
+    }
+  }, [editingId])
+
+  useEffect(() => {
+    if (contextMenuId === null) return
+    const close = () => setContextMenuId(null)
+    window.addEventListener('click', close)
+    return () => window.removeEventListener('click', close)
+  }, [contextMenuId])
+
+  const handleCreate = () => {
+    createPlaylist('New Playlist')
+    setIsCollapsed(false)
+    setTimeout(() => {
+      const store = useKlankStore.getState()
+      const newest = [...store.playlists].sort((a, b) => b.createdAt - a.createdAt)[0]
+      if (newest) {
+        setEditingId(newest.id)
+        setEditingName(newest.name)
+        setExpandedId(newest.id)
+      }
+    }, 0)
+  }
+
+  const handleRenameCommit = (id: string) => {
+    if (editingName.trim()) renamePlaylist(id, editingName.trim())
+    setEditingId(null)
+  }
+
+  const handleContextMenu = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation()
+    setContextMenuId((prev) => (prev === id ? null : id))
+  }
+
+  const handleSongClick = (path: string, playlistId: string, index: number) => {
+    const store = useKlankStore.getState()
+    const saved = store.tabSettingByPath[path]
+    useKlankStore.setState((state) => ({
+      ...state,
+      activePlaylistId: playlistId,
+      activePlaylistIndex: index,
+      tab: {
+        ...state.tab,
+        path,
+        isScrolling: false,
+        fontSize: saved?.fontSize ?? state.tab.fontSize,
+        transpose: saved?.transpose ?? 0,
+        scrollSpeed: saved?.scrollSpeed ?? state.tab.scrollSpeed,
+      },
+    }))
+  }
+
+  return (
+    <div className={styles.section}>
+      {/* Header — two separate buttons, not nested */}
+      <div className={styles.header}>
+        <button
+          className={styles.headerToggle}
+          onClick={() => setIsCollapsed((v) => !v)}
+        >
+          <ChevronIcon className={isCollapsed ? styles.rotated : ''} />
+          <span>Playlists</span>
+        </button>
+        <button
+          className={styles.addButton}
+          onClick={handleCreate}
+          title="New playlist"
+          aria-label="New playlist"
+        >
+          <PlusIcon />
+        </button>
+      </div>
+
+      {!isCollapsed && (
+        <ul className={styles.list}>
+          {playlists.length === 0 && (
+            <li className={styles.empty}>No playlists yet</li>
+          )}
+          {playlists.map((playlist) => {
+            const isActive = playlist.id === activePlaylistId
+            const isExpanded = playlist.id === expandedId
+            const isEditing = playlist.id === editingId
+
+            return (
+              <li key={playlist.id} className={styles.playlistRow}>
+                <div className={styles.playlistRowHeader}>
+                  {/* Activate / deactivate toggle */}
+                  <button
+                    className={`${styles.activateButton} ${isActive ? styles.isActive : ''}`}
+                    onClick={() => setActivePlaylist(isActive ? null : playlist.id)}
+                    title={isActive ? 'Deactivate playlist' : 'Set as active playlist'}
+                  >
+                    {isActive ? '●' : '○'}
+                  </button>
+
+                  {/* Name — click to expand / collapse song list */}
+                  {isEditing ? (
+                    <input
+                      ref={editInputRef}
+                      className={styles.playlistNameInput}
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      onBlur={() => handleRenameCommit(playlist.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleRenameCommit(playlist.id)
+                        if (e.key === 'Escape') setEditingId(null)
+                      }}
+                    />
+                  ) : (
+                    <button
+                      className={styles.nameButton}
+                      onClick={() => setExpandedId((v) => (v === playlist.id ? null : playlist.id))}
+                    >
+                      {playlist.name}
+                    </button>
+                  )}
+
+                  {/* Context menu trigger */}
+                  <button
+                    className={styles.menuButton}
+                    onClick={(e) => handleContextMenu(e, playlist.id)}
+                    aria-label="Playlist options"
+                  >
+                    ⋮
+                  </button>
+                </div>
+
+                {/* Context menu — rename / delete */}
+                {contextMenuId === playlist.id && (
+                  <div className={styles.contextMenu} onClick={(e) => e.stopPropagation()}>
+                    <button
+                      onClick={() => {
+                        setEditingId(playlist.id)
+                        setEditingName(playlist.name)
+                        setExpandedId(playlist.id)
+                        setContextMenuId(null)
+                      }}
+                    >
+                      Rename
+                    </button>
+                    <button
+                      className={styles.dangerAction}
+                      onClick={() => {
+                        deletePlaylist(playlist.id)
+                        setContextMenuId(null)
+                      }}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
+
+                {/* Expanded song list */}
+                {isExpanded && (
+                  <ul className={styles.songList}>
+                    {playlist.paths.length === 0 && (
+                      <li className={styles.empty}>Empty — add songs below</li>
+                    )}
+                    {playlist.paths.map((path, index) => {
+                      const isCurrent = isActive && activePlaylistIndex === index
+                      return (
+                        <li
+                          key={path}
+                          className={`${styles.songItem} ${isCurrent ? styles.activeSong : ''}`}
+                        >
+                          <button
+                            className={styles.songButton}
+                            onClick={() => handleSongClick(path, playlist.id, index)}
+                          >
+                            {getSongDisplayName(path)}
+                          </button>
+                          <button
+                            className={styles.removeButton}
+                            onClick={() => removeTabFromPlaylist(playlist.id, path)}
+                            title="Remove from playlist"
+                            aria-label="Remove from playlist"
+                          >
+                            ×
+                          </button>
+                        </li>
+                      )
+                    })}
+
+                    {/* Add current song — inline, visible, with state feedback */}
+                    {currentTabPath && (
+                      <li className={styles.addSongRow}>
+                        <button
+                          className={styles.addSongButton}
+                          onClick={() => addTabToPlaylist(playlist.id, currentTabPath)}
+                          disabled={playlist.paths.includes(currentTabPath)}
+                          title={
+                            playlist.paths.includes(currentTabPath)
+                              ? 'Already in this playlist'
+                              : 'Add current song to playlist'
+                          }
+                        >
+                          <PlusIcon />
+                          {playlist.paths.includes(currentTabPath)
+                            ? 'Already added'
+                            : 'Add current song'}
+                        </button>
+                      </li>
+                    )}
+                  </ul>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/klank/app/components/menu/PlaylistSection.tsx
+++ b/apps/klank/app/components/menu/PlaylistSection.tsx
@@ -31,6 +31,7 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [contextMenuId, setContextMenuId] = useState<string | null>(null)
+  const [contextMenuPos, setContextMenuPos] = useState<{ top: number; right: number } | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editingName, setEditingName] = useState('')
   const editInputRef = useRef<HTMLInputElement>(null)
@@ -44,7 +45,7 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
 
   useEffect(() => {
     if (contextMenuId === null) return
-    const close = () => setContextMenuId(null)
+    const close = () => { setContextMenuId(null); setContextMenuPos(null) }
     window.addEventListener('click', close)
     return () => window.removeEventListener('click', close)
   }, [contextMenuId])
@@ -59,6 +60,7 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
         setEditingId(newest.id)
         setEditingName(newest.name)
         setExpandedId(newest.id)
+        setActivePlaylist(newest.id)
       }
     }, 0)
   }
@@ -70,7 +72,14 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
 
   const handleContextMenu = (e: React.MouseEvent, id: string) => {
     e.stopPropagation()
-    setContextMenuId((prev) => (prev === id ? null : id))
+    if (contextMenuId === id) {
+      setContextMenuId(null)
+      setContextMenuPos(null)
+    } else {
+      const rect = (e.currentTarget as HTMLButtonElement).getBoundingClientRect()
+      setContextMenuPos({ top: rect.bottom, right: window.innerWidth - rect.right })
+      setContextMenuId(id)
+    }
   }
 
   const handleSongClick = (path: string, playlistId: string, index: number) => {
@@ -156,39 +165,14 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
                     </button>
                   )}
 
-                  {/* Context menu trigger + menu — both inside header so menu positions relative to header height */}
-                  <div className={styles.menuButtonWrapper}>
-                    <button
-                      className={styles.menuButton}
-                      onClick={(e) => handleContextMenu(e, playlist.id)}
-                      aria-label="Playlist options"
-                    >
-                      ⋮
-                    </button>
-                    {contextMenuId === playlist.id && (
-                      <div className={styles.contextMenu} onClick={(e) => e.stopPropagation()}>
-                        <button
-                          onClick={() => {
-                            setEditingId(playlist.id)
-                            setEditingName(playlist.name)
-                            setExpandedId(playlist.id)
-                            setContextMenuId(null)
-                          }}
-                        >
-                          Rename
-                        </button>
-                        <button
-                          className={styles.dangerAction}
-                          onClick={() => {
-                            deletePlaylist(playlist.id)
-                            setContextMenuId(null)
-                          }}
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    )}
-                  </div>
+                  {/* Context menu trigger */}
+                  <button
+                    className={styles.menuButton}
+                    onClick={(e) => handleContextMenu(e, playlist.id)}
+                    aria-label="Playlist options"
+                  >
+                    ⋮
+                  </button>
                 </div>
 
                 {/* Expanded song list */}
@@ -249,6 +233,41 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
           })}
         </ul>
       )}
+
+      {/* Fixed-position context menu — escapes overflow-y: auto clip boundary */}
+      {contextMenuId !== null && contextMenuPos !== null && (() => {
+        const playlist = playlists.find((p) => p.id === contextMenuId)
+        if (!playlist) return null
+        return (
+          <div
+            className={styles.contextMenu}
+            style={{ position: 'fixed', top: contextMenuPos.top, right: contextMenuPos.right }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => {
+                setEditingId(playlist.id)
+                setEditingName(playlist.name)
+                setExpandedId(playlist.id)
+                setContextMenuId(null)
+                setContextMenuPos(null)
+              }}
+            >
+              Rename
+            </button>
+            <button
+              className={styles.dangerAction}
+              onClick={() => {
+                deletePlaylist(playlist.id)
+                setContextMenuId(null)
+                setContextMenuPos(null)
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -12,7 +12,8 @@
     align-items: center;
     gap: 8px;
     font-weight: 700;
-    padding: 8px;
+    height: 34px;
+    padding: 0 8px;
     border-bottom: 1px solid var(--klank-color-border);
   }
 

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -5,7 +5,7 @@
   overflow: hidden;
   font-size: 14px;
   color: var(--klank-color-text);
-  height: 100%;
+  height: 100dvh;
 
   > li:first-of-type {
     display: flex;
@@ -16,9 +16,10 @@
     border-bottom: 1px solid var(--klank-color-border);
   }
 
-  > ul {
+  > .treeWrapper {
+    flex: 1;
     overflow-y: auto;
-    height: calc(100vh - 130px);
+    min-height: 0;
   }
 }
 

--- a/apps/klank/app/components/menu/playlistSection.module.css
+++ b/apps/klank/app/components/menu/playlistSection.module.css
@@ -2,6 +2,8 @@
   border-bottom: 1px solid var(--klank-color-border);
   font-size: 0.875rem;
   color: var(--klank-color-text);
+  max-height: 40vh;
+  overflow-y: auto;
 }
 
 /* Section header — NOT a button itself; contains two separate buttons */
@@ -10,6 +12,9 @@
   align-items: center;
   background: var(--klank-color-highlight);
   border-bottom: 1px solid var(--klank-color-border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .headerToggle {
@@ -125,8 +130,12 @@
   margin: 0.2rem 0.25rem;
 }
 
-.menuButton {
+.menuButtonWrapper {
+  position: relative;
   flex-shrink: 0;
+}
+
+.menuButton {
   padding: 0.375rem 0.5rem;
   cursor: pointer;
   color: var(--klank-color-text);
@@ -142,7 +151,7 @@
 
 .contextMenu {
   position: absolute;
-  right: 0.25rem;
+  right: 0;
   top: 100%;
   z-index: 200;
   background: var(--klank-color-background);

--- a/apps/klank/app/components/menu/playlistSection.module.css
+++ b/apps/klank/app/components/menu/playlistSection.module.css
@@ -2,7 +2,7 @@
   border-bottom: 1px solid var(--klank-color-border);
   font-size: 0.875rem;
   color: var(--klank-color-text);
-  max-height: 40vh;
+  max-height: 60vh;
   overflow-y: auto;
 }
 

--- a/apps/klank/app/components/menu/playlistSection.module.css
+++ b/apps/klank/app/components/menu/playlistSection.module.css
@@ -1,0 +1,270 @@
+.section {
+  border-bottom: 1px solid var(--klank-color-border);
+  font-size: 0.875rem;
+  color: var(--klank-color-text);
+}
+
+/* Section header — NOT a button itself; contains two separate buttons */
+.header {
+  display: flex;
+  align-items: center;
+  background: var(--klank-color-highlight);
+  border-bottom: 1px solid var(--klank-color-border);
+}
+
+.headerToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex: 1;
+  padding: 0.3rem 0.5rem;
+  font-weight: 700;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  color: var(--klank-color-text);
+  text-align: left;
+
+  &:hover {
+    background: var(--klank-color-selected);
+  }
+
+  svg {
+    flex-shrink: 0;
+    transition: transform 150ms;
+  }
+}
+
+.rotated {
+  transform: rotate(-90deg);
+}
+
+.addButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.5rem;
+  cursor: pointer;
+  color: var(--klank-color-text);
+  border-left: 1px solid var(--klank-color-border);
+
+  &:hover {
+    background: var(--klank-color-selected);
+  }
+
+  svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.playlistRow {
+  position: relative;
+  background: var(--klank-color-background);
+  border-bottom: 1px solid var(--klank-color-border);
+}
+
+.playlistRowHeader {
+  display: flex;
+  align-items: center;
+}
+
+/* ● / ○ indicator — tap to activate / deactivate */
+.activateButton {
+  flex-shrink: 0;
+  padding: 0.375rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.625rem;
+  line-height: 1;
+  color: var(--klank-color-text);
+  opacity: 0.4;
+  transition: opacity 100ms;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
+.activateButton.isActive {
+  opacity: 1;
+  color: var(--klank-color-success);
+}
+
+/* Playlist name — tap to expand song list */
+.nameButton {
+  flex: 1;
+  padding: 0.375rem 0.25rem;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+  color: var(--klank-color-text);
+  min-width: 0;
+
+  &:hover {
+    background: var(--klank-color-highlight);
+  }
+}
+
+.playlistNameInput {
+  flex: 1;
+  background: var(--klank-color-secondary-background);
+  border: 1px solid var(--klank-color-border);
+  border-radius: 3px;
+  padding: 0.2rem 0.35rem;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  color: var(--klank-color-text);
+  min-width: 0;
+  margin: 0.2rem 0.25rem;
+}
+
+.menuButton {
+  flex-shrink: 0;
+  padding: 0.375rem 0.5rem;
+  cursor: pointer;
+  color: var(--klank-color-text);
+  opacity: 0.5;
+  font-size: 1rem;
+  line-height: 1;
+
+  &:hover {
+    background: var(--klank-color-highlight);
+    opacity: 1;
+  }
+}
+
+.contextMenu {
+  position: absolute;
+  right: 0.25rem;
+  top: 100%;
+  z-index: 200;
+  background: var(--klank-color-background);
+  border: 1px solid var(--klank-color-border);
+  border-radius: 4px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  min-width: 9rem;
+  overflow: hidden;
+
+  button {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    cursor: pointer;
+    color: var(--klank-color-text);
+    font-size: 0.8125rem;
+    font-family: inherit;
+
+    &:hover {
+      background: var(--klank-color-highlight);
+    }
+  }
+
+  .dangerAction:hover {
+    background: var(--klank-color-fail);
+    color: #fff;
+  }
+}
+
+.songList {
+  display: flex;
+  flex-direction: column;
+  background: var(--klank-color-background);
+  padding-bottom: 0.25rem;
+}
+
+.songItem {
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    background: var(--klank-color-highlight);
+  }
+
+  &.activeSong {
+    background: var(--klank-color-selected);
+  }
+}
+
+.songButton {
+  flex: 1;
+  padding: 0.35rem 0.5rem 0.35rem 1.5rem;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+  color: var(--klank-color-text);
+  min-width: 0;
+}
+
+.removeButton {
+  flex-shrink: 0;
+  padding: 0.35rem 0.5rem;
+  cursor: pointer;
+  opacity: 0;
+  font-size: 0.875rem;
+  color: var(--klank-color-text);
+  transition: opacity 100ms;
+
+  .songItem:hover & {
+    opacity: 0.6;
+  }
+
+  &:hover {
+    opacity: 1 !important;
+    color: var(--klank-color-fail);
+  }
+}
+
+.addSongRow {
+  padding: 0.25rem 0.5rem 0.125rem 0.5rem;
+}
+
+.addSongButton {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  border-radius: 4px;
+  border: 1px dashed var(--klank-color-border);
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--klank-color-text);
+  opacity: 0.7;
+  font-family: inherit;
+
+  svg {
+    width: 0.625rem;
+    height: 0.625rem;
+    flex-shrink: 0;
+  }
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+    background: var(--klank-color-highlight);
+    border-style: solid;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.35;
+  }
+}
+
+.empty {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--klank-color-text);
+  opacity: 0.45;
+  font-style: italic;
+}

--- a/apps/klank/app/components/menu/playlistSection.module.css
+++ b/apps/klank/app/components/menu/playlistSection.module.css
@@ -130,11 +130,6 @@
   margin: 0.2rem 0.25rem;
 }
 
-.menuButtonWrapper {
-  position: relative;
-  flex-shrink: 0;
-}
-
 .menuButton {
   padding: 0.375rem 0.5rem;
   cursor: pointer;
@@ -150,10 +145,7 @@
 }
 
 .contextMenu {
-  position: absolute;
-  right: 0;
-  top: 100%;
-  z-index: 200;
+  z-index: 9999;
   background: var(--klank-color-background);
   border: 1px solid var(--klank-color-border);
   border-radius: 4px;

--- a/apps/klank/app/components/player/Player.tsx
+++ b/apps/klank/app/components/player/Player.tsx
@@ -16,10 +16,23 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
   const setTabIsScrolling = useKlankStore().setTabIsScrolling
   const tabPath = useKlankStore().tab.path
   const fileService = useKlankStore().fileService
+  const playlists = useKlankStore().playlists
+  const activePlaylistId = useKlankStore().activePlaylistId
+  const activePlaylistIndex = useKlankStore().activePlaylistIndex
+  const nextInPlaylist = useKlankStore().nextInPlaylist
+  const prevInPlaylist = useKlankStore().prevInPlaylist
   const mode = useKlankStore().mode
   const setMode = useKlankStore().setMode
   const [tabData, setTabData] = useState<string | undefined>()
   const [editedContent, setEditedContent] = useState<string>('')
+
+  const activePlaylist = playlists.find((p) => p.id === activePlaylistId)
+  const playlistNav = activePlaylist && activePlaylistIndex !== null ? {
+    current: activePlaylistIndex + 1,
+    total: activePlaylist.paths.length,
+    onPrev: prevInPlaylist,
+    onNext: nextInPlaylist,
+  } : undefined
 
   useEffect(() => {
     if (!fileService?.readTabFile) return
@@ -61,6 +74,7 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
         setTabScrollSpeed={setTabScrollSpeed}
         setTabIsScrolling={setTabIsScrolling}
         onEditToggle={handleEditToggle}
+        playlist={playlistNav}
       />
       {mode === 'Edit' ? (
         <textarea

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -1,5 +1,4 @@
 import styles from './settings.module.css'
-import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { createGitService, type GitChangedFile, type GitResult, type GitService } from '@klank/platform-api'

--- a/apps/klank/styles.css
+++ b/apps/klank/styles.css
@@ -98,9 +98,15 @@ meter {
 :where(dialog:modal) {
   all: revert;
 }
-html,
+html {
+  height: 100%;
+  width: 100%;
+  font-size: clamp(13px, 1.1vw, 18px);
+}
+
 body {
   height: 100%;
   width: 100%;
   font-family: 'Roboto Mono', monospace;
+  font-size: 1rem;
 }

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -10,6 +10,14 @@ export type Ui = {
   menuWidth: number
 }
 
+export type Playlist = {
+  id: string
+  name: string
+  /** Ordered list of full file-system paths to .tab.txt files. */
+  paths: string[]
+  createdAt: number
+}
+
 /**
  * Settings for a single open tab. Fields marked with `@persisted` are saved to
  * `klank-storage` in localStorage — never rename them.
@@ -60,6 +68,21 @@ type KlankState = {
   setTabDetails: (details: string) => void
   setTabLink: (link: string) => void
   setServerMode: (serverMode: boolean) => void
+  /** Named playlists — persisted to localStorage. */
+  playlists: Playlist[]
+  /** ID of the currently active playlist, or null when none is active. Persisted. */
+  activePlaylistId: string | null
+  /** Index of the currently playing song within the active playlist. Persisted. */
+  activePlaylistIndex: number | null
+  createPlaylist: (name: string) => void
+  deletePlaylist: (id: string) => void
+  renamePlaylist: (id: string, name: string) => void
+  addTabToPlaylist: (id: string, path: string) => void
+  removeTabFromPlaylist: (id: string, path: string) => void
+  reorderPlaylist: (id: string, paths: string[]) => void
+  setActivePlaylist: (id: string | null) => void
+  nextInPlaylist: () => void
+  prevInPlaylist: () => void
 }
 
 /** All valid scroll speed levels (0–9, displayed as 1–10). */
@@ -103,6 +126,9 @@ export const useKlankStore = create<KlankState>()(
         tabSettingByPath: {},
         mode: "Read",
         theme: "Light",
+        playlists: [],
+        activePlaylistId: null,
+        activePlaylistIndex: null,
         setBaseDirectory: (baseDirectory) => set((state) => ({...state, baseDirectory})),
         setFileService: (fileService) => set((state) => ({...state, fileService})),
         setMode: (mode) => set((state) => ({...state, mode})),
@@ -176,6 +202,112 @@ export const useKlankStore = create<KlankState>()(
         setTabDetails: (details) => set((state) => ({...state,tab: {...state.tab, details}})),
         setTabLink: (link) => set( state => ({...state, tab: {...state.tab, link}})),
         setServerMode: (serverMode) => set((state) => ({...state, serverMode})),
+        createPlaylist: (name) => set((state) => ({
+          ...state,
+          playlists: [
+            ...state.playlists,
+            { id: crypto.randomUUID(), name, paths: [], createdAt: Date.now() },
+          ],
+        })),
+        deletePlaylist: (id) => set((state) => ({
+          ...state,
+          playlists: state.playlists.filter((p) => p.id !== id),
+          activePlaylistId: state.activePlaylistId === id ? null : state.activePlaylistId,
+          activePlaylistIndex: state.activePlaylistId === id ? null : state.activePlaylistIndex,
+        })),
+        renamePlaylist: (id, name) => set((state) => ({
+          ...state,
+          playlists: state.playlists.map((p) => p.id === id ? { ...p, name } : p),
+        })),
+        addTabToPlaylist: (id, path) => set((state) => ({
+          ...state,
+          playlists: state.playlists.map((p) =>
+            p.id === id && !p.paths.includes(path)
+              ? { ...p, paths: [...p.paths, path] }
+              : p
+          ),
+        })),
+        removeTabFromPlaylist: (id, path) => set((state) => {
+          const playlist = state.playlists.find((p) => p.id === id)
+          const newPaths = playlist?.paths.filter((p) => p !== path) ?? []
+          const removedIndex = playlist?.paths.indexOf(path) ?? -1
+          let newIndex = state.activePlaylistIndex
+          if (state.activePlaylistId === id && newIndex !== null) {
+            if (removedIndex < newIndex) newIndex = newIndex - 1
+            if (newIndex >= newPaths.length) newIndex = Math.max(0, newPaths.length - 1)
+          }
+          return {
+            ...state,
+            playlists: state.playlists.map((p) => p.id === id ? { ...p, paths: newPaths } : p),
+            activePlaylistIndex: newIndex,
+          }
+        }),
+        reorderPlaylist: (id, paths) => set((state) => ({
+          ...state,
+          playlists: state.playlists.map((p) => p.id === id ? { ...p, paths } : p),
+        })),
+        setActivePlaylist: (id) => set((state) => {
+          if (id === null) return { ...state, activePlaylistId: null, activePlaylistIndex: null }
+          const playlist = state.playlists.find((p) => p.id === id)
+          if (!playlist || playlist.paths.length === 0) return { ...state, activePlaylistId: id, activePlaylistIndex: null }
+          const firstPath = playlist.paths[0]
+          const saved = state.tabSettingByPath[firstPath]
+          return {
+            ...state,
+            activePlaylistId: id,
+            activePlaylistIndex: 0,
+            tab: {
+              ...state.tab,
+              path: firstPath,
+              isScrolling: false,
+              fontSize: saved?.fontSize ?? state.tab.fontSize,
+              transpose: saved?.transpose ?? 0,
+              scrollSpeed: saved?.scrollSpeed ?? state.tab.scrollSpeed,
+            },
+          }
+        }),
+        nextInPlaylist: () => set((state) => {
+          const { activePlaylistId, activePlaylistIndex, playlists } = state
+          if (activePlaylistId === null || activePlaylistIndex === null) return state
+          const playlist = playlists.find((p) => p.id === activePlaylistId)
+          if (!playlist || playlist.paths.length === 0) return state
+          const nextIndex = (activePlaylistIndex + 1) % playlist.paths.length
+          const path = playlist.paths[nextIndex]
+          const saved = state.tabSettingByPath[path]
+          return {
+            ...state,
+            activePlaylistIndex: nextIndex,
+            tab: {
+              ...state.tab,
+              path,
+              isScrolling: false,
+              fontSize: saved?.fontSize ?? state.tab.fontSize,
+              transpose: saved?.transpose ?? 0,
+              scrollSpeed: saved?.scrollSpeed ?? state.tab.scrollSpeed,
+            },
+          }
+        }),
+        prevInPlaylist: () => set((state) => {
+          const { activePlaylistId, activePlaylistIndex, playlists } = state
+          if (activePlaylistId === null || activePlaylistIndex === null) return state
+          const playlist = playlists.find((p) => p.id === activePlaylistId)
+          if (!playlist || playlist.paths.length === 0) return state
+          const prevIndex = (activePlaylistIndex - 1 + playlist.paths.length) % playlist.paths.length
+          const path = playlist.paths[prevIndex]
+          const saved = state.tabSettingByPath[path]
+          return {
+            ...state,
+            activePlaylistIndex: prevIndex,
+            tab: {
+              ...state.tab,
+              path,
+              isScrolling: false,
+              fontSize: saved?.fontSize ?? state.tab.fontSize,
+              transpose: saved?.transpose ?? 0,
+              scrollSpeed: saved?.scrollSpeed ?? state.tab.scrollSpeed,
+            },
+          }
+        }),
       }),
       {
         name: 'klank-storage',
@@ -184,6 +316,9 @@ export const useKlankStore = create<KlankState>()(
           theme: state.theme,
           ui: state.ui,
           baseDirectory: state.baseDirectory,
+          playlists: state.playlists,
+          activePlaylistId: state.activePlaylistId,
+          activePlaylistIndex: state.activePlaylistIndex,
         }),
       }
     )

--- a/libs/ui/src/lib/fileTreeView/FileTreeView.tsx
+++ b/libs/ui/src/lib/fileTreeView/FileTreeView.tsx
@@ -11,7 +11,9 @@ const renderTreeStructure = (
   currentTabPath: string,
   setTabPath: (path: string) => void,
   collapsedArtists: string[],
-  setCollapsedArtists: React.Dispatch<React.SetStateAction<string[]>>
+  setCollapsedArtists: React.Dispatch<React.SetStateAction<string[]>>,
+  onAddToPlaylist?: (path: string) => void,
+  activePlaylistPaths?: string[]
 ) => {
   const currentTree = sortByArtist(files, searchFilter)
   const treeKeys = Object.keys(currentTree)
@@ -41,18 +43,31 @@ const renderTreeStructure = (
         </button>
         {!collapsedArtists.includes(artist) && (
           <ul className={styles.songList}>
-            {currentTree[artist].map((item, index) => (
-              <li
-                id={currentTabPath === item.path ? 'active' : ''}
-                className={currentTabPath === item.path ? styles.active : ''}
-                key={item.path}
-              >
-                <button onClick={() => setTabPath(item.path)}>
-                  <FileIcon />
-                  <span>{item.song ?? item.artist}</span>
-                </button>
-              </li>
-            ))}
+            {currentTree[artist].map((item) => {
+              const alreadyInPlaylist = activePlaylistPaths?.includes(item.path)
+              return (
+                <li
+                  id={currentTabPath === item.path ? 'active' : ''}
+                  className={currentTabPath === item.path ? styles.active : ''}
+                  key={item.path}
+                >
+                  <button onClick={() => setTabPath(item.path)}>
+                    <FileIcon />
+                    <span>{item.song ?? item.artist}</span>
+                  </button>
+                  {onAddToPlaylist && !alreadyInPlaylist && (
+                    <button
+                      className={styles.addToPlaylistButton}
+                      onClick={(e) => { e.stopPropagation(); onAddToPlaylist(item.path) }}
+                      title="Add to active playlist"
+                      aria-label="Add to active playlist"
+                    >
+                      +
+                    </button>
+                  )}
+                </li>
+              )
+            })}
           </ul>
         )}
       </li>
@@ -65,9 +80,11 @@ type FileTreeViewProps = {
   currentTabPath: string
   setTabPath: (path: string) => void
   searchFilter: string
+  onAddToPlaylist?: (path: string) => void
+  activePlaylistPaths?: string[]
 } & React.ComponentPropsWithRef<'ul'>
 
-export const FileTreeView: React.FC<FileTreeViewProps> = ({tree, currentTabPath, setTabPath, searchFilter, ...props }) => {
+export const FileTreeView: React.FC<FileTreeViewProps> = ({tree, currentTabPath, setTabPath, searchFilter, onAddToPlaylist, activePlaylistPaths, ...props }) => {
   const [collapsedArtists, setCollapsedArtists] = useState<string[]>([])
 
   useEffect(() => {
@@ -88,6 +105,6 @@ export const FileTreeView: React.FC<FileTreeViewProps> = ({tree, currentTabPath,
   }, [currentTabPath, tree, collapsedArtists])
 
   return <ul className={styles.container} {...props}>
-    {renderTreeStructure(tree, searchFilter, currentTabPath, setTabPath, collapsedArtists, setCollapsedArtists)}
+    {renderTreeStructure(tree, searchFilter, currentTabPath, setTabPath, collapsedArtists, setCollapsedArtists, onAddToPlaylist, activePlaylistPaths)}
   </ul>
 }

--- a/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
+++ b/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
@@ -78,7 +78,7 @@
   opacity: 0;
   transition: opacity 100ms;
 
-  li:hover & {
+  .songList li:hover & {
     opacity: 0.5;
   }
 

--- a/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
+++ b/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
@@ -55,10 +55,6 @@
       align-items: center;
       gap: 4px;
     }
-
-    &:hover .addToPlaylistButton {
-      opacity: 0.5;
-    }
   }
 }
 
@@ -76,6 +72,10 @@
   color: var(--klank-color-text);
   opacity: 0;
   transition: opacity 100ms;
+
+  li:hover & {
+    opacity: 0.5;
+  }
 
   &:hover {
     opacity: 1 !important;

--- a/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
+++ b/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
@@ -38,9 +38,8 @@
   background: var(--klank-color-background);
 
   li {
-    display: flex;
-    align-items: center;
-    padding: 0;
+    position: relative;
+    padding: 8px;
 
     &:hover {
       background: var(--klank-color-highlight);
@@ -51,33 +50,32 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.05);
     }
 
-    > button:first-child {
-      flex: 1;
-      min-width: 0;
+    button {
       display: flex;
       align-items: center;
       gap: 4px;
-      padding: 8px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+    }
+
+    &:hover .addToPlaylistButton {
+      opacity: 0.5;
     }
   }
 }
 
 .addToPlaylistButton {
-  flex-shrink: 0;
-  padding: 8px 10px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.875rem;
   line-height: 1;
   color: var(--klank-color-text);
   opacity: 0;
   transition: opacity 100ms;
-
-  li:hover & {
-    opacity: 0.5;
-  }
 
   &:hover {
     opacity: 1 !important;

--- a/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
+++ b/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
@@ -2,7 +2,7 @@
 
 }
 .menuItem {
-  background: #f8f8f8;
+  background: var(--klank-color-highlight);
 
   button {
     cursor: pointer;
@@ -22,12 +22,12 @@
   align-items: center;
   text-transform: capitalize;
   font-weight: 700;
-  padding: 4px 8px;
+  padding: 0.25rem 0.5rem;
   svg {
     margin-left: auto;
   }
   &:hover {
-    background: #eaeaea;
+    background: var(--klank-color-selected);
   }
 
 }
@@ -38,7 +38,9 @@
   background: var(--klank-color-background);
 
   li {
-    padding: 8px;
+    display: flex;
+    align-items: center;
+    padding: 0;
 
     &:hover {
       background: var(--klank-color-highlight);
@@ -49,11 +51,37 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.05);
     }
 
-    button {
+    > button:first-child {
+      flex: 1;
+      min-width: 0;
       display: flex;
       align-items: center;
       gap: 4px;
+      padding: 8px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
+  }
+}
+
+.addToPlaylistButton {
+  flex-shrink: 0;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--klank-color-text);
+  opacity: 0;
+  transition: opacity 100ms;
+
+  li:hover & {
+    opacity: 0.5;
+  }
+
+  &:hover {
+    opacity: 1 !important;
+    color: var(--klank-color-success);
   }
 }
 

--- a/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
+++ b/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
@@ -1,12 +1,10 @@
-.container {
+.container {}
 
-}
 .menuItem {
   background: var(--klank-color-highlight);
 
   button {
     cursor: pointer;
-    width: 100%;
   }
 }
 
@@ -22,10 +20,13 @@
   align-items: center;
   text-transform: capitalize;
   font-weight: 700;
+  width: 100%;
   padding: 0.25rem 0.5rem;
+
   svg {
     margin-left: auto;
   }
+
   &:hover {
     background: var(--klank-color-selected);
   }
@@ -49,23 +50,26 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.05);
     }
 
-    /* Song name button — flex: 1 pushes + to the right; width: auto overrides
-       the .menuItem button { width: 100% } rule above */
     > button:first-child {
       flex: 1;
       min-width: 0;
-      width: auto;
       display: flex;
       align-items: center;
       gap: 4px;
       padding: 8px;
+      overflow: hidden;
+
+      span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 }
 
 .addToPlaylistButton {
   flex-shrink: 0;
-  width: auto;
   padding: 8px 10px;
   cursor: pointer;
   font-size: 0.875rem;

--- a/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
+++ b/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
@@ -29,7 +29,6 @@
   &:hover {
     background: var(--klank-color-selected);
   }
-
 }
 
 .songList {
@@ -38,8 +37,8 @@
   background: var(--klank-color-background);
 
   li {
-    position: relative;
-    padding: 8px;
+    display: flex;
+    align-items: center;
 
     &:hover {
       background: var(--klank-color-highlight);
@@ -50,22 +49,24 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.05);
     }
 
-    button {
+    /* Song name button — flex: 1 pushes + to the right; width: auto overrides
+       the .menuItem button { width: 100% } rule above */
+    > button:first-child {
+      flex: 1;
+      min-width: 0;
+      width: auto;
       display: flex;
       align-items: center;
       gap: 4px;
+      padding: 8px;
     }
   }
 }
 
 .addToPlaylistButton {
-  position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  padding: 0 10px;
-  display: flex;
-  align-items: center;
+  flex-shrink: 0;
+  width: auto;
+  padding: 8px 10px;
   cursor: pointer;
   font-size: 0.875rem;
   line-height: 1;
@@ -87,6 +88,6 @@
   background: var(--klank-color-selected);
 }
 
-.rotated{
+.rotated {
   transform: rotate(180deg);
 }

--- a/libs/ui/src/lib/incrementButton/increment.module.css
+++ b/libs/ui/src/lib/incrementButton/increment.module.css
@@ -11,7 +11,7 @@
     display: flex;
     align-items: center;
 
-    background: #e3e3e3;
+    background: var(--klank-color-secondary-background);
     border-radius: 4px;
 
     button, span {

--- a/libs/ui/src/lib/searchbar/searchbar.module.css
+++ b/libs/ui/src/lib/searchbar/searchbar.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
+  align-items: center;
   padding: 8px;
-  height: 56px;
   gap: 8px;
   box-shadow: 0 -4px 15px rgba(0, 0, 0, 0.1);
   > div {
@@ -13,6 +13,7 @@
 
   button {
     margin-left: auto;
+    flex-shrink: 0;
     svg {
       transition: transform 100ms;
       transform: rotate(0deg);

--- a/libs/ui/src/lib/sheetToolbar/SheetToolbar.tsx
+++ b/libs/ui/src/lib/sheetToolbar/SheetToolbar.tsx
@@ -6,6 +6,14 @@ import { TransposeIcon } from '../icons/TransposeIcon'
 import { PlayIcon } from '../icons/PlayIcon'
 import { StopIcon } from '../icons/StopIcon'
 import { EditIcon } from '../icons/EditIcon'
+import { ChevronIcon } from '../icons/ChevronIcon'
+
+type PlaylistNav = {
+  current: number
+  total: number
+  onPrev: () => void
+  onNext: () => void
+}
 
 type SheetToolbarProps = {
   songName: string
@@ -19,6 +27,7 @@ type SheetToolbarProps = {
   setTabScrollSpeed: (speed: number) => void
   setTabIsScrolling: (isScrolling: boolean) => void
   onEditToggle: () => void
+  playlist?: PlaylistNav
 } & React.ComponentPropsWithRef<'div'>
 
 export const SheetToolbar: React.FC<SheetToolbarProps> = ({
@@ -33,6 +42,7 @@ export const SheetToolbar: React.FC<SheetToolbarProps> = ({
   setTabIsScrolling,
   mode,
   onEditToggle,
+  playlist,
   ...props
 }) => {
   React.useEffect(() => {
@@ -56,48 +66,68 @@ export const SheetToolbar: React.FC<SheetToolbarProps> = ({
       } else if (e.key === '-' || e.key === '_') {
         e.preventDefault()
         setTabScrollSpeed(Math.max(1, tabScrollSpeed - 1))
+      } else if (e.key === 'ArrowLeft' && playlist) {
+        e.preventDefault()
+        playlist.onPrev()
+      } else if (e.key === 'ArrowRight' && playlist) {
+        e.preventDefault()
+        playlist.onNext()
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isScrolling, setTabIsScrolling, tabScrollSpeed, setTabScrollSpeed])
+  }, [isScrolling, setTabIsScrolling, tabScrollSpeed, setTabScrollSpeed, playlist])
 
   return (
     <div className={styles.container} {...props}>
-      <span>{songName}</span>
-      <IncrementButton
-        value={fontSize}
-        setValue={setTabFontSize}
-        icon={<FontSizeIcon />}
-        min={8}
-      />
-      <IncrementButton
-        value={transpose}
-        setValue={setTabTranspose}
-        icon={<TransposeIcon />}
-      />
-      <IncrementButton
-        value={tabScrollSpeed}
-        setValue={setTabScrollSpeed}
-        icon={<SpeedIcon />}
-        min={1}
-        max={10}
-      />
-      <div className={styles.controlWrapper}>
-        <Button
-          label={isScrolling ? 'stop' : 'play'}
-          icon={isScrolling ? <StopIcon /> : <PlayIcon />}
-          onClick={() => setTabIsScrolling(!isScrolling)}
+      {playlist && (
+        <div className={styles.playlistNav}>
+          <button onClick={playlist.onPrev} aria-label="Previous song">
+            <ChevronIcon style={{ transform: 'rotate(90deg)' }} />
+          </button>
+          <span className={styles.playlistCounter}>{playlist.current}/{playlist.total}</span>
+          <button onClick={playlist.onNext} aria-label="Next song">
+            <ChevronIcon style={{ transform: 'rotate(-90deg)' }} />
+          </button>
+        </div>
+      )}
+
+      <span className={styles.songName}>{songName}</span>
+
+      <div className={styles.controls}>
+        <IncrementButton
+          value={fontSize}
+          setValue={setTabFontSize}
+          icon={<FontSizeIcon />}
+          min={8}
         />
-        <Button
-          label={mode === 'Edit' ? 'save' : 'edit'}
-          icon={<EditIcon />}
-          onClick={onEditToggle}
-          className={mode === 'Edit' ? styles.activeButton : undefined}
+        <IncrementButton
+          value={transpose}
+          setValue={setTabTranspose}
+          icon={<TransposeIcon />}
         />
+        <IncrementButton
+          value={tabScrollSpeed}
+          setValue={setTabScrollSpeed}
+          icon={<SpeedIcon />}
+          min={1}
+          max={10}
+        />
+        <div className={styles.actionButtons}>
+          <Button
+            label={isScrolling ? 'stop' : 'play'}
+            icon={isScrolling ? <StopIcon /> : <PlayIcon />}
+            onClick={() => setTabIsScrolling(!isScrolling)}
+          />
+          <Button
+            label={mode === 'Edit' ? 'save' : 'edit'}
+            icon={<EditIcon />}
+            onClick={onEditToggle}
+            className={mode === 'Edit' ? styles.activeButton : undefined}
+          />
+        </div>
       </div>
     </div>
   )
 }
-

--- a/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
+++ b/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
@@ -2,38 +2,90 @@
   background: var(--klank-color-background);
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 2px 16px;
+  gap: 0.625rem;
+  padding: 2px 0.75rem;
   border-bottom: 1px solid var(--klank-color-border);
-  span {
-    font-size: 14px;
-    font-weight: 700;
-  }
-  > div:first-of-type {
-    margin-left: auto;
-  }
+  min-width: 0;
 }
 
-.controlWrapper {
+/* Song title — grows to fill all spare space, truncates gracefully */
+.songName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+/* All controls stay in a fixed-width group on the right */
+.controls {
   display: flex;
-  gap: 14px;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* Play / Edit buttons */
+.actionButtons {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  border-left: 1px solid var(--klank-color-border);
+  padding-left: 0.5rem;
+
   button {
-    height: 24px;
-    line-height: 29px;
-    font-size: 12px;
+    height: 1.5rem;
+    line-height: 1.8rem;
+    font-size: 0.75rem;
     font-weight: 700;
     font-variant: all-small-caps;
-    padding: 0 8px;
+    padding: 0 0.5rem;
     svg {
-      height: 16px;
-      width: 16px;
-    }
-    &:first-of-type {
-      margin-left: 4px;
+      height: 1rem;
+      width: 1rem;
     }
   }
 }
 
 .activeButton {
   background: var(--klank-color-highlight);
+}
+
+/* Playlist prev/next strip — shown when a playlist is active */
+.playlistNav {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-right: 1px solid var(--klank-color-border);
+  padding-right: 0.625rem;
+  flex-shrink: 0;
+
+  button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem 0.3rem;
+    border-radius: 3px;
+    cursor: pointer;
+    color: var(--klank-color-text);
+    &:hover {
+      background: var(--klank-color-highlight);
+    }
+    svg {
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+  }
+
+  .playlistCounter {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    font-variant: all-small-caps;
+    min-width: 2rem;
+    text-align: center;
+    color: var(--klank-color-text);
+    opacity: 0.7;
+  }
 }

--- a/libs/ui/src/lib/toolTip/toolTip.module.css
+++ b/libs/ui/src/lib/toolTip/toolTip.module.css
@@ -11,6 +11,6 @@
   border-radius: 4px;
   font-size: 14px;
   font-weight: 400;
-  z-index: 2;
+  z-index: 1000;
   pointer-events: none;
 }

--- a/libs/ui/src/lib/toolbar/toolbar.module.css
+++ b/libs/ui/src/lib/toolbar/toolbar.module.css
@@ -1,11 +1,13 @@
 .container {
   display: flex;
   justify-content: space-between;
-  gap: 8px;
-  padding: 4px 16px;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 1rem;
+  height: 34px;
   border-bottom: 1px solid var(--klank-color-border);
   svg {
-    width: 20px;
+    width: 1.25rem;
   }
 }
 
@@ -35,8 +37,8 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  padding: 8px 4px;
-  gap: 6px;
+  padding: 0.5rem 0.25rem;
+  gap: 0.375rem;
   border-bottom: none;
 }
 


### PR DESCRIPTION
## Summary

- **Responsive scaling**: `html { font-size: clamp(13px, 1.1vw, 18px) }` makes all `rem`-based UI grow from narrow windows up to 4K; toolbar, searchbar, and sheetToolbar converted from `px` to `rem`
- **Narrow window**: `ResizeObserver` in `app.tsx` auto-collapses the menu below 600px; fixed a bug where returning from the Settings page collapsed the menu (ResizeObserver was firing with `width=0` on re-mount)
- **Flex-based tree height**: replaced hardcoded `calc(100vh - 130px)` with `height: 100dvh` + `flex: 1; min-height: 0` on `treeWrapper`; searchbar and playlist section now always visible
- **Playlist feature** (sidebar Option A): create/rename/delete named playlists; ●/○ activate toggle; expand to see ordered songs; prev/next controls in SheetToolbar; left/right arrow key navigation
- **+ button on file tree**: when a playlist is active, a `+` appears on hover next to each song not already in the playlist (absolutely positioned, no layout impact on song names)
- **Sticky playlist**: playlist section lives above the scrollable file tree so it stays visible as you scroll through songs
- **Dark mode fixes**: hardcoded `#f8f8f8`/`#eaeaea` in `FileTreeView` and `#e3e3e3` in `IncrementButton` replaced with CSS custom properties
- **Height alignment**: both the logo row and icon toolbar row are pinned to `height: 34px`

## Test plan

- [ ] Resize window to ~480px — menu should auto-collapse; player fills the screen
- [ ] Navigate to Settings and back — menu should remain open
- [ ] DevTools device pixel ratio 2.0 — icons and text scale up
- [ ] Create a playlist; add songs via `+` in file tree and "Add current song" in the playlist panel
- [ ] `+` appears on hover only for songs not already in the active playlist
- [ ] ◁/▷ controls and left/right arrow keys navigate playlist songs
- [ ] Clicking a song from the file tree clears the playlist nav controls
- [ ] Scroll the file tree while a playlist is expanded — playlist stays at the top
- [ ] Light/Dark theme toggle — file tree and increment buttons use correct colours
- [ ] Logo row and icon toolbar row are the same height

🤖 Generated with [Claude Code](https://claude.com/claude-code)