### PR TITLE
Add automated version tracking and display in Settings

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,14 +1,43 @@
-name: Build Windows Release
+name: Release Windows
 
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
-  build-windows:
+  release-windows:
     runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        run: |
+          $ver = "2.0.${{ github.run_number }}"
+          Write-Output "VERSION=$ver" >> $env:GITHUB_OUTPUT
+          Write-Host "Building version: $ver"
+
+      - name: Patch tauri.conf.json
+        shell: pwsh
+        run: |
+          $ver = '${{ steps.version.outputs.VERSION }}'
+          $path = 'apps/klank/src-tauri/tauri.conf.json'
+          $json = Get-Content $path -Raw | ConvertFrom-Json
+          $json.version = $ver
+          $json | ConvertTo-Json -Depth 10 | Set-Content $path -Encoding UTF8
+
+      - name: Patch Cargo.toml
+        shell: pwsh
+        run: |
+          $ver = '${{ steps.version.outputs.VERSION }}'
+          $path = 'apps/klank/src-tauri/Cargo.toml'
+          $content = Get-Content $path -Raw
+          $patched = $content -replace '(?m)^version = "[\d.]+"', "version = `"$ver`""
+          Set-Content $path -Value $patched -Encoding UTF8 -NoNewline
 
       # Reads the pnpm version from packageManager in package.json
       - uses: pnpm/action-setup@v4
@@ -32,12 +61,22 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: klank-nsis
+          name: klank-nsis-${{ steps.version.outputs.VERSION }}
           path: apps/klank/src-tauri/target/release/bundle/nsis/*.exe
           if-no-files-found: error
 
       - uses: actions/upload-artifact@v4
         with:
-          name: klank-msi
+          name: klank-msi-${{ steps.version.outputs.VERSION }}
           path: apps/klank/src-tauri/target/release/bundle/msi/*.msi
           if-no-files-found: error
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $ver = '${{ steps.version.outputs.VERSION }}'
+          $nsis = Get-ChildItem apps/klank/src-tauri/target/release/bundle/nsis/*.exe | Select-Object -First 1
+          $msi  = Get-ChildItem apps/klank/src-tauri/target/release/bundle/msi/*.msi  | Select-Object -First 1
+          gh release create "v$ver" --title "klank v$ver" --notes "Windows installers for klank v$ver." $nsis.FullName $msi.FullName

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -1,7 +1,7 @@
 import styles from './settings.module.css'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
-import { createGitService, type GitChangedFile, type GitResult, type GitService } from '@klank/platform-api'
+import { createGitService, getAppVersion, type GitChangedFile, type GitResult, type GitService } from '@klank/platform-api'
 import { useKlankStore } from '@klank/store'
 
 type Status = { ok: boolean; message: string } | null
@@ -21,6 +21,7 @@ export default function Settings() {
   const [commitMessage, setCommitMessage] = useState('Update tabs')
   const [status, setStatus] = useState<Status>(null)
   const [busy, setBusy] = useState(false)
+  const [version, setVersion] = useState<string>('')
 
   const refreshGitState = async (dir: string, git: GitService) => {
     const [files, commits] = await Promise.all([
@@ -49,6 +50,10 @@ export default function Settings() {
     init()
     return () => { cancelled = true }
   }, [baseDirectory])
+
+  useEffect(() => {
+    getAppVersion().then(setVersion)
+  }, [])
 
   const handleChangeFolder = async () => {
     if (!fileService) return
@@ -114,6 +119,11 @@ export default function Settings() {
             <button className={styles.button} onClick={handleChangeFolder} disabled={!fileService}>
               Change
             </button>
+          </div>
+
+          <div className={styles.row}>
+            <span className={styles.label}>Version</span>
+            <span className={styles.dirPath}>{version || '…'}</span>
           </div>
 
           <div className={styles.row}>

--- a/apps/klank/src-tauri/Cargo.lock
+++ b/apps/klank/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "Klank"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "log",
  "serde",

--- a/apps/klank/src-tauri/Cargo.toml
+++ b/apps/klank/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Klank"
-version = "0.1.0"
+version = "2.0.0"
 description = "Sheet management"
 authors = ["you"]
 license = ""

--- a/apps/klank/src-tauri/tauri.conf.json
+++ b/apps/klank/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "klank",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "identifier": "io.github.hampterworks.klank",
   "build": {
     "frontendDist": "../build/client",

--- a/libs/platform-api/src/index.ts
+++ b/libs/platform-api/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/sort'
 export * from './lib/chords';
 export * from './lib/userAgent';
 export * from './lib/download';
+export * from './lib/app';

--- a/libs/platform-api/src/lib/app.ts
+++ b/libs/platform-api/src/lib/app.ts
@@ -1,0 +1,3 @@
+import { getVersion } from '@tauri-apps/api/app'
+
+export const getAppVersion = (): Promise<string> => getVersion()


### PR DESCRIPTION
## Summary

- Release pipeline now auto-generates version `2.0.<run_number>` (e.g. `2.0.42`) on each manual run — no git tags needed
- Before building, the pipeline patches `tauri.conf.json` and `Cargo.toml` with the generated version, then creates a GitHub Release with the NSIS and MSI installers attached
- Added `getAppVersion()` to `@klank/platform-api` wrapping `@tauri-apps/api/app`
- Settings page **General** section now shows the running app version
- Baseline version bumped to `2.0.0`

## Test plan

- [ ] Open Settings in dev — version row shows `2.0.0`
- [ ] Trigger the release workflow manually via GitHub Actions → confirm version in the built installer matches `2.0.<run_number>` and a GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)