### PR TITLE
Add new-playlist modal, toolbar button, and pointer-based song reordering

### DIFF
--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -8,6 +8,7 @@ import {
   DownloadIcon,
   FileTreeView,
   LogoIcon,
+  NewPlaylistIcon,
   Searchbar,
   Toolbar,
 } from '@klank/ui'
@@ -31,17 +32,36 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
   const activePlaylistId = useKlankStore().activePlaylistId
   const playlists = useKlankStore().playlists
   const addTabToPlaylist = useKlankStore().addTabToPlaylist
+  const createPlaylist = useKlankStore().createPlaylist
   const [searchFilter, setSearchFilter] = useState<string>('')
   const [isEnteringUrl, setIsEnteringUrl] = useState(false)
   const [urlValue, setUrlValue] = useState('')
   const [isDownloading, setIsDownloading] = useState(false)
   const [downloadError, setDownloadError] = useState<string | null>(null)
+  const [isCreatingPlaylist, setIsCreatingPlaylist] = useState(false)
+  const [newPlaylistName, setNewPlaylistName] = useState('')
 
   const activePlaylist = playlists.find((p) => p.id === activePlaylistId) ?? null
 
   const handleSelectSong = (path: string) => {
     useKlankStore.setState((s) => ({ ...s, activePlaylistIndex: null }))
     setTabPath(path)
+  }
+
+  const handleRequestCreatePlaylist = () => {
+    setNewPlaylistName('')
+    setIsCreatingPlaylist(true)
+  }
+
+  const handleConfirmCreatePlaylist = () => {
+    const name = newPlaylistName.trim()
+    if (!name) return
+    createPlaylist(name)
+    setIsCreatingPlaylist(false)
+  }
+
+  const handleCancelCreatePlaylist = () => {
+    setIsCreatingPlaylist(false)
   }
 
   const handleRequestDownload = () => {
@@ -77,6 +97,40 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
       setIsDownloading(false)
     }
   }
+
+  const createPlaylistModal = isCreatingPlaylist && createPortal(
+    <div
+      className={styles.overlay}
+      onClick={(e) => { if (e.target === e.currentTarget) handleCancelCreatePlaylist() }}
+    >
+      <div className={styles.modal}>
+        <div className={styles.modalHeader}>
+          <NewPlaylistIcon />
+          <span className={styles.modalTitle}>New Playlist</span>
+        </div>
+        <div className={styles.modalBody}>
+          <input
+            className={styles.modalInput}
+            type="text"
+            placeholder="Playlist name"
+            value={newPlaylistName}
+            onChange={(e) => setNewPlaylistName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleConfirmCreatePlaylist()
+              if (e.key === 'Escape') handleCancelCreatePlaylist()
+            }}
+            autoFocus
+          />
+          <span className={styles.modalHint}>Enter a name for your new playlist</span>
+        </div>
+        <div className={styles.modalActions}>
+          <button className={styles.btnCancel} onClick={handleCancelCreatePlaylist}>Cancel</button>
+          <button className={styles.btnCreate} onClick={handleConfirmCreatePlaylist} disabled={!newPlaylistName.trim()}>Create</button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
 
   const downloadModal = isEnteringUrl && createPortal(
     <div
@@ -124,6 +178,7 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
           setBaseDirectory={setBaseDirectory}
           setTabPath={handleSelectSong}
           tree={tree}
+          onRequestCreatePlaylist={handleRequestCreatePlaylist}
           onRequestDownload={handleRequestDownload}
           isDownloading={isDownloading}
           downloadError={downloadError}
@@ -152,6 +207,7 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
           setSearchFilter={setSearchFilter}
         />
       </ul>
+      {createPlaylistModal}
       {downloadModal}
     </>
   )

--- a/apps/klank/app/components/menu/PlaylistSection.tsx
+++ b/apps/klank/app/components/menu/PlaylistSection.tsx
@@ -272,6 +272,17 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
                       )
                     })}
 
+                    {/* Drop sentinel — allows placing dragged item at the last position */}
+                    {dragIndex !== null && (
+                      <li
+                        data-song-index={playlist.paths.length}
+                        className={[
+                          styles.dropSentinel,
+                          hoverIndex === playlist.paths.length ? styles.dragOver : '',
+                        ].join(' ')}
+                      />
+                    )}
+
                     {/* Add current song — inline, visible, with state feedback */}
                     {currentTabPath && (
                       <li className={styles.addSongRow}>

--- a/apps/klank/app/components/menu/PlaylistSection.tsx
+++ b/apps/klank/app/components/menu/PlaylistSection.tsx
@@ -2,7 +2,7 @@ import styles from './playlistSection.module.css'
 import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useKlankStore } from '@klank/store'
-import { ChevronIcon, PlusIcon } from '@klank/ui'
+import { ChevronIcon, GripIcon, PlusIcon } from '@klank/ui'
 import { FileEntry } from '@klank/platform-api'
 
 type PlaylistSectionProps = {
@@ -17,15 +17,22 @@ const getSongDisplayName = (path: string): string => {
   return dashIndex !== -1 ? withoutExt.slice(dashIndex + 3) : withoutExt
 }
 
+export const reorder = <T,>(arr: T[], from: number, to: number): T[] => {
+  const result = [...arr]
+  const [item] = result.splice(from, 1)
+  result.splice(to, 0, item)
+  return result
+}
+
 export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath }) => {
   const playlists = useKlankStore().playlists
   const activePlaylistId = useKlankStore().activePlaylistId
   const activePlaylistIndex = useKlankStore().activePlaylistIndex
-  const createPlaylist = useKlankStore().createPlaylist
   const deletePlaylist = useKlankStore().deletePlaylist
   const renamePlaylist = useKlankStore().renamePlaylist
   const addTabToPlaylist = useKlankStore().addTabToPlaylist
   const removeTabFromPlaylist = useKlankStore().removeTabFromPlaylist
+  const reorderPlaylist = useKlankStore().reorderPlaylist
   const setActivePlaylist = useKlankStore().setActivePlaylist
 
   const [isCollapsed, setIsCollapsed] = useState(false)
@@ -34,7 +41,10 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
   const [contextMenuPos, setContextMenuPos] = useState<{ top: number; right: number } | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editingName, setEditingName] = useState('')
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null)
   const editInputRef = useRef<HTMLInputElement>(null)
+  const prevLengthRef = useRef(playlists.length)
 
   useEffect(() => {
     if (editingId && editInputRef.current) {
@@ -50,20 +60,16 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
     return () => window.removeEventListener('click', close)
   }, [contextMenuId])
 
-  const handleCreate = () => {
-    createPlaylist('New Playlist')
-    setIsCollapsed(false)
-    setTimeout(() => {
-      const store = useKlankStore.getState()
-      const newest = [...store.playlists].sort((a, b) => b.createdAt - a.createdAt)[0]
+  useEffect(() => {
+    if (playlists.length > prevLengthRef.current) {
+      const newest = [...playlists].sort((a, b) => b.createdAt - a.createdAt)[0]
       if (newest) {
-        setEditingId(newest.id)
-        setEditingName(newest.name)
+        setIsCollapsed(false)
         setExpandedId(newest.id)
-        setActivePlaylist(newest.id)
       }
-    }, 0)
-  }
+    }
+    prevLengthRef.current = playlists.length
+  }, [playlists])
 
   const handleRenameCommit = (id: string) => {
     if (editingName.trim()) renamePlaylist(id, editingName.trim())
@@ -100,9 +106,60 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
     }))
   }
 
+  // Pointer-event based drag — avoids WebView2's broken HTML5 DnD intercept.
+  // The grip handle captures the pointer so we get all moves even outside the list,
+  // then elementFromPoint finds which song slot the cursor is over.
+  const handleGripPointerDown = (
+    e: React.PointerEvent<HTMLSpanElement>,
+    playlistId: string,
+    paths: string[],
+    fromIndex: number,
+  ) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const grip = e.currentTarget
+    grip.setPointerCapture(e.pointerId)
+    setDragIndex(fromIndex)
+    document.body.style.cursor = 'grabbing'
+
+    const onMove = (ev: PointerEvent) => {
+      const el = document.elementFromPoint(ev.clientX, ev.clientY)
+      const li = el?.closest<HTMLElement>('[data-song-index]')
+      if (li) setHoverIndex(Number(li.dataset.songIndex))
+    }
+
+    const cleanup = () => {
+      setDragIndex(null)
+      setHoverIndex(null)
+      document.body.style.cursor = ''
+      grip.removeEventListener('pointermove', onMove)
+      grip.removeEventListener('pointerup', onUp)
+      grip.removeEventListener('lostpointercapture', cleanup)
+    }
+
+    const onUp = (ev: PointerEvent) => {
+      const el = document.elementFromPoint(ev.clientX, ev.clientY)
+      const li = el?.closest<HTMLElement>('[data-song-index]')
+      if (li) {
+        const toIndex = Number(li.dataset.songIndex)
+        // When dragging downward, splice removes the item first so every
+        // subsequent index shifts up by one — subtract 1 to land before
+        // the hovered row as the visual indicator (border-top) implies.
+        const insertAt = fromIndex < toIndex ? toIndex - 1 : toIndex
+        if (!isNaN(toIndex) && insertAt !== fromIndex) {
+          reorderPlaylist(playlistId, reorder(paths, fromIndex, insertAt))
+        }
+      }
+      cleanup()
+    }
+
+    grip.addEventListener('pointermove', onMove)
+    grip.addEventListener('pointerup', onUp)
+    grip.addEventListener('lostpointercapture', cleanup)
+  }
+
   return (
     <div className={styles.section}>
-      {/* Header — two separate buttons, not nested */}
       <div className={styles.header}>
         <button
           className={styles.headerToggle}
@@ -110,14 +167,6 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
         >
           <ChevronIcon className={isCollapsed ? styles.rotated : ''} />
           <span>Playlists</span>
-        </button>
-        <button
-          className={styles.addButton}
-          onClick={handleCreate}
-          title="New playlist"
-          aria-label="New playlist"
-        >
-          <PlusIcon />
         </button>
       </div>
 
@@ -183,11 +232,28 @@ export const PlaylistSection: React.FC<PlaylistSectionProps> = ({ currentTabPath
                     )}
                     {playlist.paths.map((path, index) => {
                       const isCurrent = isActive && activePlaylistIndex === index
+                      const isDragging = dragIndex === index
+                      const isDropTarget = hoverIndex === index && dragIndex !== index
                       return (
                         <li
                           key={path}
-                          className={`${styles.songItem} ${isCurrent ? styles.activeSong : ''}`}
+                          data-song-index={index}
+                          className={[
+                            styles.songItem,
+                            isCurrent ? styles.activeSong : '',
+                            isDragging ? styles.dragging : '',
+                            isDropTarget ? styles.dragOver : '',
+                          ].join(' ')}
                         >
+                          <span
+                            className={styles.dragHandle}
+                            aria-hidden
+                            onPointerDown={(e) =>
+                              handleGripPointerDown(e, playlist.id, playlist.paths, index)
+                            }
+                          >
+                            <GripIcon />
+                          </span>
                           <button
                             className={styles.songButton}
                             onClick={() => handleSongClick(path, playlist.id, index)}

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -155,6 +155,29 @@
   cursor: not-allowed;
 }
 
+.btnCreate {
+  height: 30px;
+  padding: 0 16px;
+  font-size: 0.8rem;
+  font-family: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 4px;
+  border: none;
+  background: var(--klank-color-text);
+  color: var(--klank-color-background);
+  transition: opacity 0.15s;
+}
+
+.btnCreate:hover:not(:disabled) {
+  opacity: 0.8;
+}
+
+.btnCreate:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+
 .tabMenu {
   display: flex;
   gap: 8px;

--- a/apps/klank/app/components/menu/playlistSection.module.css
+++ b/apps/klank/app/components/menu/playlistSection.module.css
@@ -241,6 +241,15 @@
   }
 }
 
+.dropSentinel {
+  height: 8px;
+  list-style: none;
+
+  &.dragOver {
+    border-top: 2px solid var(--klank-color-text);
+  }
+}
+
 .addSongRow {
   padding: 0.25rem 0.5rem 0.125rem 0.5rem;
 }

--- a/apps/klank/app/components/menu/playlistSection.module.css
+++ b/apps/klank/app/components/menu/playlistSection.module.css
@@ -43,24 +43,6 @@
   transform: rotate(-90deg);
 }
 
-.addButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.3rem 0.5rem;
-  cursor: pointer;
-  color: var(--klank-color-text);
-  border-left: 1px solid var(--klank-color-border);
-
-  &:hover {
-    background: var(--klank-color-selected);
-  }
-
-  svg {
-    width: 0.75rem;
-    height: 0.75rem;
-  }
-}
 
 .list {
   display: flex;
@@ -191,6 +173,39 @@
 
   &.activeSong {
     background: var(--klank-color-selected);
+  }
+
+  &.dragging {
+    opacity: 0.4;
+  }
+
+  &.dragOver {
+    border-top: 2px solid var(--klank-color-text);
+  }
+}
+
+.dragHandle {
+  display: flex;
+  align-items: center;
+  padding: 0 0.25rem 0 0.5rem;
+  opacity: 0;
+  cursor: grab;
+  touch-action: none;
+  color: var(--klank-color-text);
+  flex-shrink: 0;
+  transition: opacity 100ms;
+
+  .songItem:hover & {
+    opacity: 0.4;
+  }
+
+  &:hover {
+    opacity: 0.8 !important;
+  }
+
+  svg {
+    width: 0.625rem;
+    height: 0.875rem;
   }
 }
 

--- a/apps/klank/tests/playlist-reorder.spec.ts
+++ b/apps/klank/tests/playlist-reorder.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import fc from 'fast-check'
+import { reorder } from '../app/components/menu/PlaylistSection'
+
+const nonEmptyArrayArb = <T>(arb: fc.Arbitrary<T>) =>
+  fc.array(arb, { minLength: 1, maxLength: 20 })
+
+const indexPairArb = (len: number) =>
+  fc.tuple(
+    fc.integer({ min: 0, max: len - 1 }),
+    fc.integer({ min: 0, max: len - 1 }),
+  )
+
+describe('reorder — property-based', () => {
+  it('result has the same length as input', () => {
+    fc.assert(fc.property(nonEmptyArrayArb(fc.string()), (arr) => {
+      const [from, to] = [0, arr.length - 1]
+      expect(reorder(arr, from, to)).toHaveLength(arr.length)
+    }))
+  })
+
+  it('result contains the same elements (is a permutation)', () => {
+    fc.assert(fc.property(nonEmptyArrayArb(fc.string()), (arr) => {
+      return fc.assert(fc.property(indexPairArb(arr.length), ([from, to]) => {
+        const result = reorder(arr, from, to)
+        expect([...result].sort()).toEqual([...arr].sort())
+      }))
+    }))
+  })
+
+  it('item at "from" lands at "to"', () => {
+    fc.assert(fc.property(nonEmptyArrayArb(fc.string()), (arr) => {
+      return fc.assert(fc.property(indexPairArb(arr.length), ([from, to]) => {
+        const item = arr[from]
+        const result = reorder(arr, from, to)
+        expect(result[to]).toBe(item)
+      }))
+    }))
+  })
+
+  it('does not mutate the original array', () => {
+    fc.assert(fc.property(nonEmptyArrayArb(fc.string()), (arr) => {
+      const copy = [...arr]
+      reorder(arr, 0, arr.length - 1)
+      expect(arr).toEqual(copy)
+    }))
+  })
+
+  it('from === to leaves the array unchanged', () => {
+    fc.assert(fc.property(nonEmptyArrayArb(fc.string()), (arr) => {
+      return fc.assert(fc.property(fc.integer({ min: 0, max: arr.length - 1 }), (idx) => {
+        expect(reorder(arr, idx, idx)).toEqual(arr)
+      }))
+    }))
+  })
+
+  it('dragging down: item lands before the hovered row (insertAt = hoverIndex - 1)', () => {
+    // Use arr = [0,1,2,...,len-1] so each value is unique and equals its original index.
+    // Mirrors the UI fix: when from < hoverIndex the caller passes hoverIndex-1 as insertAt.
+    fc.assert(fc.property(fc.integer({ min: 3, max: 20 }), (len) => {
+      const arr = Array.from({ length: len }, (_, i) => i)
+      return fc.assert(fc.property(
+        fc.integer({ min: 0, max: len - 2 }),
+        fc.integer({ min: 1, max: len - 1 }),
+        (from, hoverIndex) => {
+          fc.pre(from < hoverIndex)
+          const insertAt = hoverIndex - 1
+          const result = reorder(arr, from, insertAt)
+          // arr[i] === i, so result.indexOf(from) finds where the dragged item ended up
+          const draggedPos = result.indexOf(from)
+          const hoveredPos = result.indexOf(hoverIndex)
+          expect(draggedPos).toBeLessThan(hoveredPos)
+        }
+      ))
+    }))
+  })
+
+  it('dragging up: item lands before the hovered row (insertAt = hoverIndex)', () => {
+    fc.assert(fc.property(fc.integer({ min: 3, max: 20 }), (len) => {
+      const arr = Array.from({ length: len }, (_, i) => i)
+      return fc.assert(fc.property(
+        fc.integer({ min: 1, max: len - 1 }),
+        fc.integer({ min: 0, max: len - 2 }),
+        (from, hoverIndex) => {
+          fc.pre(from > hoverIndex)
+          const result = reorder(arr, from, hoverIndex)
+          const draggedPos = result.indexOf(from)
+          const hoveredPos = result.indexOf(hoverIndex)
+          expect(draggedPos).toBeLessThan(hoveredPos)
+        }
+      ))
+    }))
+  })
+})

--- a/libs/store/src/lib/store.spec.ts
+++ b/libs/store/src/lib/store.spec.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import fc from 'fast-check'
+
+// Stub localStorage before store import — persist middleware reads it on init.
+// setItem stores data so getItem can return it; this silences the "storage unavailable" warning.
+const localStorageData: Record<string, string> = {}
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn((key: string) => localStorageData[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { localStorageData[key] = value }),
+  removeItem: vi.fn((key: string) => { delete localStorageData[key] }),
+  clear: vi.fn(() => { Object.keys(localStorageData).forEach((k) => delete localStorageData[k]) }),
+  length: 0,
+  key: vi.fn(() => null),
+})
+
+import { useKlankStore, type Playlist } from './store.js'
+
+const makePlaylist = (overrides: Partial<Playlist> = {}): Playlist => ({
+  id: crypto.randomUUID(),
+  name: 'Test',
+  paths: [],
+  createdAt: Date.now(),
+  ...overrides,
+})
+
+const resetPlaylists = (playlists: Playlist[] = []) => {
+  useKlankStore.setState({ playlists, activePlaylistId: null, activePlaylistIndex: null })
+}
+
+// Arbitraries
+const playlistNameArb = fc.string({ minLength: 1, maxLength: 80 })
+const pathArb = fc.string({ minLength: 1, maxLength: 200 })
+const pathsArb = fc.array(pathArb, { minLength: 0, maxLength: 20 })
+
+describe('createPlaylist — property-based', () => {
+  beforeEach(() => resetPlaylists())
+
+  it('count always increases by 1', () => {
+    fc.assert(fc.property(playlistNameArb, fc.integer({ min: 0, max: 5 }), (name, seed) => {
+      const existing = Array.from({ length: seed }, () => makePlaylist())
+      resetPlaylists(existing)
+      useKlankStore.getState().createPlaylist(name)
+      expect(useKlankStore.getState().playlists).toHaveLength(seed + 1)
+    }))
+  })
+
+  it('new playlist always has the given name', () => {
+    fc.assert(fc.property(playlistNameArb, (name) => {
+      resetPlaylists()
+      useKlankStore.getState().createPlaylist(name)
+      const found = useKlankStore.getState().playlists.find((p) => p.name === name)
+      expect(found).toBeDefined()
+    }))
+  })
+
+  it('pre-existing playlists are not mutated', () => {
+    fc.assert(fc.property(playlistNameArb, fc.integer({ min: 1, max: 4 }), (name, seed) => {
+      const existing = Array.from({ length: seed }, () => makePlaylist())
+      resetPlaylists(existing)
+      useKlankStore.getState().createPlaylist(name)
+      const after = useKlankStore.getState().playlists
+      existing.forEach((ep) => {
+        expect(after.find((p) => p.id === ep.id)).toEqual(ep)
+      })
+    }))
+  })
+})
+
+describe('deletePlaylist — property-based', () => {
+  it('count decreases by 1 and target is gone', () => {
+    fc.assert(fc.property(fc.integer({ min: 1, max: 5 }), fc.integer({ min: 0, max: 4 }), (count, rawIdx) => {
+      const playlists = Array.from({ length: count }, () => makePlaylist())
+      resetPlaylists(playlists)
+      const idx = rawIdx % count
+      const target = playlists[idx]
+      useKlankStore.getState().deletePlaylist(target.id)
+      const after = useKlankStore.getState().playlists
+      expect(after).toHaveLength(count - 1)
+      expect(after.find((p) => p.id === target.id)).toBeUndefined()
+    }))
+  })
+
+  it('non-target playlists are unchanged', () => {
+    fc.assert(fc.property(fc.integer({ min: 2, max: 5 }), fc.integer({ min: 0, max: 4 }), (count, rawIdx) => {
+      const playlists = Array.from({ length: count }, () => makePlaylist())
+      resetPlaylists(playlists)
+      const idx = rawIdx % count
+      const target = playlists[idx]
+      useKlankStore.getState().deletePlaylist(target.id)
+      const after = useKlankStore.getState().playlists
+      playlists.filter((p) => p.id !== target.id).forEach((ep) => {
+        expect(after.find((p) => p.id === ep.id)).toEqual(ep)
+      })
+    }))
+  })
+})
+
+describe('renamePlaylist — property-based', () => {
+  it('only the target playlist name changes', () => {
+    fc.assert(fc.property(playlistNameArb, fc.integer({ min: 1, max: 5 }), fc.integer({ min: 0, max: 4 }), (newName, count, rawIdx) => {
+      const playlists = Array.from({ length: count }, () => makePlaylist())
+      resetPlaylists(playlists)
+      const idx = rawIdx % count
+      const target = playlists[idx]
+      useKlankStore.getState().renamePlaylist(target.id, newName)
+      const after = useKlankStore.getState().playlists
+      const renamed = after.find((p) => p.id === target.id)
+      expect(renamed?.name).toBe(newName)
+      playlists.filter((p) => p.id !== target.id).forEach((ep) => {
+        expect(after.find((p) => p.id === ep.id)).toEqual(ep)
+      })
+    }))
+  })
+})
+
+describe('reorderPlaylist — property-based', () => {
+  it('stores exactly the provided paths for the target playlist', () => {
+    fc.assert(fc.property(pathsArb, (paths) => {
+      const playlist = makePlaylist()
+      resetPlaylists([playlist])
+      useKlankStore.getState().reorderPlaylist(playlist.id, paths)
+      const after = useKlankStore.getState().playlists.find((p) => p.id === playlist.id)
+      expect(after?.paths).toEqual(paths)
+    }))
+  })
+
+  it('only the target playlist is affected', () => {
+    fc.assert(fc.property(pathsArb, (paths) => {
+      const target = makePlaylist()
+      const other = makePlaylist({ name: 'Other' })
+      resetPlaylists([target, other])
+      useKlankStore.getState().reorderPlaylist(target.id, paths)
+      const afterOther = useKlankStore.getState().playlists.find((p) => p.id === other.id)
+      expect(afterOther).toEqual(other)
+    }))
+  })
+})

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -31,4 +31,6 @@ export { StopIcon } from './lib/icons/StopIcon';
 export { EditIcon } from './lib/icons/EditIcon';
 export { CloseIcon } from './lib/icons/CloseIcon';
 export { SpeedIcon } from './lib/icons/SpeedIcon';
+export { GripIcon } from './lib/icons/GripIcon';
+export { NewPlaylistIcon } from './lib/icons/NewPlaylistIcon';
 

--- a/libs/ui/src/lib/icons/GripIcon.tsx
+++ b/libs/ui/src/lib/icons/GripIcon.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+export const GripIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="10"
+    height="14"
+    viewBox="0 0 10 14"
+    fill="currentColor"
+    {...props}
+  >
+    <circle cx="3" cy="2.5" r="1.2" />
+    <circle cx="7" cy="2.5" r="1.2" />
+    <circle cx="3" cy="7" r="1.2" />
+    <circle cx="7" cy="7" r="1.2" />
+    <circle cx="3" cy="11.5" r="1.2" />
+    <circle cx="7" cy="11.5" r="1.2" />
+  </svg>
+)

--- a/libs/ui/src/lib/icons/NewPlaylistIcon.tsx
+++ b/libs/ui/src/lib/icons/NewPlaylistIcon.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+
+export const NewPlaylistIcon: React.FC<React.ComponentPropsWithoutRef<'svg'>> = (props) => (
+  <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    {/* Document body */}
+    <path
+      d="M20 12V5.74853C20 5.5894 19.9368 5.43679 19.8243 5.32426L16.6757 2.17574C16.5632 2.06321 16.4106 2 16.2515 2H4.6C4.26863 2 4 2.26863 4 2.6V21.4C4 21.7314 4.26863 22 4.6 22H11"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    {/* Corner fold */}
+    <path
+      d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    {/* Plus — horizontal arm */}
+    <path
+      d="M15.5 18H20.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    {/* Plus — vertical arm */}
+    <path
+      d="M18 15.5V20.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+)

--- a/libs/ui/src/lib/toolbar/Toolbar.tsx
+++ b/libs/ui/src/lib/toolbar/Toolbar.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   DownloadIcon,
   FolderIcon,
+  NewPlaylistIcon,
   RefreshIcon,
   SettingsIcon,
   ShuffleIcon,
@@ -30,6 +31,7 @@ type ToolbarProps = {
   setBaseDirectory: (directory: string) => void
   setTabPath: (path: string) => void
   onRequestDownload?: () => void
+  onRequestCreatePlaylist?: () => void
   isDownloading?: boolean
   downloadError?: string | null
   onSettingsClick?: () => void
@@ -43,6 +45,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   setNeedsUpdate,
   setTabPath,
   onRequestDownload,
+  onRequestCreatePlaylist,
   isDownloading,
   downloadError,
   onSettingsClick,
@@ -92,6 +95,13 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           onClick={() => handleRandomPathUpdate()}
           iconButton={true}
           icon={<ShuffleIcon />}
+        />
+      </ToolTip>
+      <ToolTip message="New Playlist">
+        <Button
+          onClick={() => onRequestCreatePlaylist?.()}
+          iconButton={true}
+          icon={<NewPlaylistIcon />}
         />
       </ToolTip>
       {downloadError && (

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-jsx-a11y": "6.10.1",
     "eslint-plugin-react": "7.35.0",
     "eslint-plugin-react-hooks": "5.0.0",
+    "fast-check": "^4.8.0",
     "jiti": "2.4.2",
     "jsdom": "~22.1.0",
     "jsonc-eslint-parser": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: 5.0.0
         version: 5.0.0(eslint@9.39.4(jiti@2.4.2))
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       jiti:
         specifier: 2.4.2
         version: 2.4.2
@@ -3705,6 +3708,10 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4992,6 +4999,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -10237,6 +10247,10 @@ snapshots:
 
   extsprintf@1.3.0: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -11649,6 +11663,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   qs@6.14.2:
     dependencies:


### PR DESCRIPTION
## Summary

- **New Playlist button** moved from the Playlists section header into the toolbar (between Shuffle and Download), using a custom `NewPlaylistIcon` (document + plus SVG derived from the provided design)
- **Create Playlist modal** mirrors the existing Download Tab UX — name input with autoFocus, Create/Cancel buttons, Escape key and overlay click to dismiss; `PlaylistSection` auto-expands the newly created playlist via a `useEffect` length watch
- **Song reordering** implemented via pointer capture (`setPointerCapture` + `document.elementFromPoint`) rather than HTML5 drag-and-drop, which is intercepted at the OS level by WebView2 on Windows and never delivers `dragover` events to the web page
- **Off-by-one fix** in the drop calculation: when dragging downward, `splice` removes the source item first, shifting all later indices up by one — `insertAt = hoverIndex - 1` corrects this so the item lands before the visually indicated row (border-top indicator) rather than after it

## Test plan

- [x] `pnpm nx run-many -t test` — 69 tests pass across all projects
- [x] `pnpm nx run-many -t lint` — no warnings
- [x] `pnpm nx run-many -t typecheck` — clean
- [x] `pnpm nx run-many -t build` — clean
- [ ] Manual: click the toolbar `+` button → modal appears → type a name → Create → playlist appears expanded
- [ ] Manual: Cancel / Escape / overlay click closes modal without creating
- [ ] Manual: drag grip handle on a song → item follows cursor → release reorders correctly in both up and down directions

## New property-based tests (`fast-check`)

| File | What's tested |
|------|---------------|
| `libs/store/src/lib/store.spec.ts` | `createPlaylist`, `deletePlaylist`, `renamePlaylist`, `reorderPlaylist` store action invariants |
| `apps/klank/tests/playlist-reorder.spec.ts` | `reorder()` pure function: permutation, length, no mutation, no-op when from===to, correct landing direction for drag-up and drag-down |

🤖 Generated with [Claude Code](https://claude.com/claude-code)