### PR TITLE
Sanitize chord diagram data: regenerate from theory, add slash chords and a strict validator

### DIFF
--- a/apps/klank/public/chords-bass.json
+++ b/apps/klank/public/chords-bass.json
@@ -1,374 +1,782 @@
 {
   "A": [
-    { "frets": [0, 0, 2, 2], "fingers": [0, 0, 1, 2], "baseFret": 1, "barres": [] },
-    { "frets": [0, 0, 2, 2], "fingers": [0, 0, 1, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 2, "toString": 3 }] }
+    { "frets": [5, 4, 2, 2], "fingers": [4, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 7, 6], "fingers": [1, 3, 4, 2], "baseFret": 5, "barres": [] }
   ],
   "A#": [
-    { "frets": [1, 1, 3, 3], "fingers": [1, 1, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [6, 5, 3, 3], "fingers": [4, 3, 1, 2], "baseFret": 3, "barres": [] },
+    { "frets": [6, 8, 8, 7], "fingers": [1, 3, 4, 2], "baseFret": 6, "barres": [] }
   ],
   "B": [
-    { "frets": [2, 2, 4, 4], "fingers": [1, 1, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [7, 6, 4, 4], "fingers": [4, 3, 1, 2], "baseFret": 4, "barres": [] },
+    { "frets": [7, 9, 9, 8], "fingers": [1, 3, 4, 2], "baseFret": 7, "barres": [] }
   ],
   "C": [
-    { "frets": [3, 3, 5, 5], "fingers": [1, 1, 3, 4], "baseFret": 1, "barres": [] },
-    { "frets": [3, 3, 2, 0], "fingers": [4, 3, 2, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 3, 2, 0], "fingers": [0, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 5, 5], "fingers": [4, 3, 1, 2], "baseFret": 5, "barres": [] }
   ],
   "C#": [
-    { "frets": [4, 4, 6, 6], "fingers": [1, 1, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 4, 3, 1], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 6, 6], "fingers": [4, 3, 1, 2], "baseFret": 6, "barres": [] }
   ],
   "D": [
-    { "frets": [2, 0, 0, 2], "fingers": [2, 0, 0, 1], "baseFret": 1, "barres": [] },
-    { "frets": [5, 5, 7, 7], "fingers": [1, 1, 3, 4], "baseFret": 5, "barres": [] }
+    { "frets": [-1, 5, 4, 2], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [10, 9, 7, 7], "fingers": [4, 3, 1, 2], "baseFret": 7, "barres": [] }
   ],
   "D#": [
-    { "frets": [3, 1, 5, 3], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 6, 5, 3], "fingers": [0, 3, 2, 1], "baseFret": 3, "barres": [] },
+    { "frets": [11, 10, 8, 8], "fingers": [4, 3, 1, 2], "baseFret": 8, "barres": [] }
   ],
   "E": [
     { "frets": [0, 2, 2, 1], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
-    { "frets": [0, 2, 2, 1], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 7, 6, 4], "fingers": [0, 3, 2, 1], "baseFret": 4, "barres": [] }
   ],
   "F": [
-    { "frets": [1, 3, 3, 2], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] }
+    { "frets": [1, 3, 3, 2], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 5], "fingers": [0, 3, 2, 1], "baseFret": 5, "barres": [] }
   ],
   "F#": [
-    { "frets": [2, 4, 4, 3], "fingers": [1, 3, 4, 2], "baseFret": 2, "barres": [] }
+    { "frets": [2, 4, 4, 3], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 6], "fingers": [0, 3, 2, 1], "baseFret": 6, "barres": [] }
   ],
   "G": [
-    { "frets": [3, 5, 5, 4], "fingers": [1, 3, 4, 2], "baseFret": 3, "barres": [] },
-    { "frets": [3, 2, 0, 0], "fingers": [2, 1, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [3, 2, 0, 0], "fingers": [2, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 9, 7], "fingers": [0, 3, 2, 1], "baseFret": 7, "barres": [] }
   ],
   "G#": [
+    { "frets": [4, 3, 1, 1], "fingers": [4, 3, 1, 2], "baseFret": 1, "barres": [] },
     { "frets": [4, 6, 6, 5], "fingers": [1, 3, 4, 2], "baseFret": 4, "barres": [] }
   ],
   "Am": [
-    { "frets": [0, 0, 2, 2], "fingers": [0, 0, 1, 2], "baseFret": 1, "barres": [] },
-    { "frets": [5, 7, 7, 5], "fingers": [1, 3, 4, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 3 }] }
+    { "frets": [5, 3, 2, 2], "fingers": [4, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 7, 5], "fingers": [1, 3, 4, 2], "baseFret": 5, "barres": [] }
   ],
   "A#m": [
-    { "frets": [1, 4, 3, 3], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] }
+    { "frets": [6, 4, 3, 3], "fingers": [4, 3, 1, 2], "baseFret": 3, "barres": [] },
+    { "frets": [6, 8, 8, 6], "fingers": [1, 3, 4, 2], "baseFret": 6, "barres": [] }
   ],
   "Bm": [
-    { "frets": [2, 2, 4, 4], "fingers": [1, 1, 3, 4], "baseFret": 1, "barres": [] },
-    { "frets": [2, 2, 4, 7], "fingers": [1, 1, 2, 4], "baseFret": 2, "barres": [] }
+    { "frets": [7, 5, 4, 4], "fingers": [4, 3, 1, 2], "baseFret": 4, "barres": [] },
+    { "frets": [7, 9, 9, 7], "fingers": [1, 3, 4, 2], "baseFret": 7, "barres": [] }
   ],
   "Cm": [
-    { "frets": [3, 6, 5, 5], "fingers": [1, 4, 2, 3], "baseFret": 3, "barres": [] }
+    { "frets": [-1, 3, 1, 0], "fingers": [0, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 6, 5, 5], "fingers": [4, 3, 1, 2], "baseFret": 5, "barres": [] }
   ],
   "C#m": [
-    { "frets": [4, 7, 6, 6], "fingers": [1, 4, 2, 3], "baseFret": 4, "barres": [] }
+    { "frets": [-1, 4, 2, 1], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [9, 7, 6, 6], "fingers": [4, 3, 1, 2], "baseFret": 6, "barres": [] }
   ],
   "Dm": [
-    { "frets": [1, 0, 3, 2], "fingers": [1, 0, 4, 2], "baseFret": 1, "barres": [] },
-    { "frets": [5, 5, 7, 7], "fingers": [1, 1, 3, 4], "baseFret": 5, "barres": [] }
+    { "frets": [-1, 5, 3, 2], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [10, 8, 7, 7], "fingers": [4, 3, 1, 2], "baseFret": 7, "barres": [] }
   ],
   "D#m": [
-    { "frets": [2, 1, 4, 3], "fingers": [2, 1, 4, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 6, 4, 3], "fingers": [0, 3, 2, 1], "baseFret": 3, "barres": [] },
+    { "frets": [11, 9, 8, 8], "fingers": [4, 3, 1, 2], "baseFret": 8, "barres": [] }
   ],
   "Em": [
-    { "frets": [0, 2, 2, 0], "fingers": [0, 2, 3, 0], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 2, 0], "fingers": [0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 5, 4], "fingers": [0, 3, 2, 1], "baseFret": 4, "barres": [] }
   ],
   "Fm": [
-    { "frets": [1, 3, 3, 1], "fingers": [1, 3, 4, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 3 }] }
+    { "frets": [1, 3, 3, 1], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 6, 5], "fingers": [0, 3, 2, 1], "baseFret": 5, "barres": [] }
   ],
   "F#m": [
-    { "frets": [2, 4, 4, 2], "fingers": [1, 3, 4, 1], "baseFret": 2, "barres": [{ "fret": 2, "fromString": 0, "toString": 3 }] }
+    { "frets": [2, 4, 4, 2], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 7, 6], "fingers": [0, 3, 2, 1], "baseFret": 6, "barres": [] }
   ],
   "Gm": [
-    { "frets": [3, 5, 5, 3], "fingers": [1, 3, 4, 1], "baseFret": 3, "barres": [{ "fret": 3, "fromString": 0, "toString": 3 }] }
+    { "frets": [3, 1, 0, 0], "fingers": [2, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 5, 5, 3], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] }
   ],
   "G#m": [
-    { "frets": [4, 6, 6, 4], "fingers": [1, 3, 4, 1], "baseFret": 4, "barres": [{ "fret": 4, "fromString": 0, "toString": 3 }] }
+    { "frets": [4, 2, 1, 1], "fingers": [4, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 6, 4], "fingers": [1, 3, 4, 2], "baseFret": 4, "barres": [] }
   ],
   "A7": [
-    { "frets": [0, 0, 2, 0], "fingers": [0, 0, 2, 0], "baseFret": 1, "barres": [] }
+    { "frets": [5, 4, 5, 2], "fingers": [3, 2, 4, 1], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 5, 6], "fingers": [1, 4, 2, 3], "baseFret": 5, "barres": [] }
   ],
   "A#7": [
-    { "frets": [1, 1, 0, 3], "fingers": [1, 1, 0, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 1, 0, 1], "fingers": [0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [6, 8, 6, 7], "fingers": [1, 4, 2, 3], "baseFret": 6, "barres": [] }
   ],
   "B7": [
-    { "frets": [2, 2, 1, 4], "fingers": [2, 2, 1, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 1, 2], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 9, 7, 8], "fingers": [1, 4, 2, 3], "baseFret": 7, "barres": [] }
   ],
   "C7": [
-    { "frets": [3, 3, 2, 5], "fingers": [2, 2, 1, 4], "baseFret": 2, "barres": [] }
+    { "frets": [-1, 3, 2, 3], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [8, 10, 8, 9], "fingers": [1, 4, 2, 3], "baseFret": 8, "barres": [] }
   ],
   "C#7": [
-    { "frets": [4, 4, 3, 6], "fingers": [2, 2, 1, 4], "baseFret": 3, "barres": [] }
+    { "frets": [-1, 4, 3, 4], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [9, 11, 9, 10], "fingers": [1, 4, 2, 3], "baseFret": 9, "barres": [] }
   ],
   "D7": [
-    { "frets": [2, 0, 0, 2], "fingers": [2, 0, 0, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 5, 4, 5], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [10, 12, 10, 11], "fingers": [1, 4, 2, 3], "baseFret": 10, "barres": [] }
   ],
   "D#7": [
-    { "frets": [3, 1, 1, 3], "fingers": [3, 1, 1, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 6, 5, 6], "fingers": [0, 2, 1, 3], "baseFret": 5, "barres": [] },
+    { "frets": [11, 13, 11, 12], "fingers": [1, 4, 2, 3], "baseFret": 11, "barres": [] }
   ],
   "E7": [
-    { "frets": [0, 2, 0, 1], "fingers": [0, 2, 0, 1], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 0, 1], "fingers": [0, 2, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 7], "fingers": [0, 2, 1, 3], "baseFret": 6, "barres": [] }
   ],
   "F7": [
-    { "frets": [1, 3, 1, 2], "fingers": [1, 4, 1, 2], "baseFret": 1, "barres": [] }
+    { "frets": [1, 3, 1, 2], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 8], "fingers": [0, 2, 1, 3], "baseFret": 7, "barres": [] }
   ],
   "F#7": [
-    { "frets": [2, 4, 2, 3], "fingers": [1, 4, 1, 2], "baseFret": 2, "barres": [] }
+    { "frets": [2, 1, 2, 3], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 9], "fingers": [0, 2, 1, 3], "baseFret": 8, "barres": [] }
   ],
   "G7": [
-    { "frets": [3, 5, 3, 4], "fingers": [1, 4, 1, 2], "baseFret": 3, "barres": [] },
-    { "frets": [3, 2, 0, 0], "fingers": [3, 2, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [3, 2, 3, 0], "fingers": [2, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 9, 10], "fingers": [0, 2, 1, 3], "baseFret": 9, "barres": [] }
   ],
   "G#7": [
-    { "frets": [4, 6, 4, 5], "fingers": [1, 4, 1, 2], "baseFret": 4, "barres": [] }
+    { "frets": [4, 3, 4, 1], "fingers": [3, 2, 4, 1], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 4, 5], "fingers": [1, 4, 2, 3], "baseFret": 4, "barres": [] }
   ],
   "Am7": [
-    { "frets": [0, 0, 2, 0], "fingers": [0, 0, 2, 0], "baseFret": 1, "barres": [] }
+    { "frets": [5, 3, 5, 5], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 5, 5], "fingers": [1, 4, 2, 3], "baseFret": 5, "barres": [] }
   ],
   "A#m7": [
-    { "frets": [1, 1, 3, 1], "fingers": [1, 1, 4, 1], "baseFret": 1, "barres": [] }
+    { "frets": [6, 4, 6, 6], "fingers": [2, 1, 3, 4], "baseFret": 4, "barres": [] },
+    { "frets": [6, 8, 6, 6], "fingers": [1, 4, 2, 3], "baseFret": 6, "barres": [] }
   ],
   "Bm7": [
-    { "frets": [2, 2, 0, 2], "fingers": [2, 2, 0, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 0, 2], "fingers": [0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [7, 9, 7, 7], "fingers": [1, 4, 2, 3], "baseFret": 7, "barres": [] }
   ],
   "Cm7": [
-    { "frets": [3, 3, 1, 3], "fingers": [3, 3, 1, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 3, 1, 3], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [8, 10, 8, 8], "fingers": [1, 4, 2, 3], "baseFret": 8, "barres": [] }
   ],
   "C#m7": [
-    { "frets": [4, 4, 2, 4], "fingers": [3, 3, 1, 3], "baseFret": 2, "barres": [] }
+    { "frets": [-1, 4, 2, 4], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [9, 11, 9, 9], "fingers": [1, 4, 2, 3], "baseFret": 9, "barres": [] }
   ],
   "Dm7": [
-    { "frets": [1, 0, 0, 2], "fingers": [1, 0, 0, 2], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 5, 3, 5], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [10, 12, 10, 10], "fingers": [1, 4, 2, 3], "baseFret": 10, "barres": [] }
   ],
   "D#m7": [
-    { "frets": [2, 1, 1, 3], "fingers": [2, 1, 1, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 6, 4, 6], "fingers": [0, 2, 1, 3], "baseFret": 4, "barres": [] },
+    { "frets": [11, 13, 11, 11], "fingers": [1, 4, 2, 3], "baseFret": 11, "barres": [] }
   ],
   "Em7": [
-    { "frets": [0, 2, 0, 0], "fingers": [0, 2, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 0, 0], "fingers": [0, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 5, 7], "fingers": [0, 2, 1, 3], "baseFret": 5, "barres": [] }
   ],
   "Fm7": [
-    { "frets": [1, 3, 1, 1], "fingers": [1, 4, 1, 1], "baseFret": 1, "barres": [] }
+    { "frets": [1, 3, 1, 1], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 6, 8], "fingers": [0, 2, 1, 3], "baseFret": 6, "barres": [] }
   ],
   "F#m7": [
-    { "frets": [2, 4, 2, 2], "fingers": [1, 4, 1, 1], "baseFret": 2, "barres": [] }
+    { "frets": [2, 0, 2, 2], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 7, 9], "fingers": [0, 2, 1, 3], "baseFret": 7, "barres": [] }
   ],
   "Gm7": [
-    { "frets": [3, 5, 3, 3], "fingers": [1, 4, 1, 1], "baseFret": 3, "barres": [] }
+    { "frets": [3, 1, 3, 0], "fingers": [2, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 5, 3, 3], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] }
   ],
   "G#m7": [
-    { "frets": [4, 6, 4, 4], "fingers": [1, 4, 1, 1], "baseFret": 4, "barres": [] }
+    { "frets": [4, 2, 4, 4], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 4, 4], "fingers": [1, 4, 2, 3], "baseFret": 4, "barres": [] }
   ],
   "Amaj7": [
-    { "frets": [0, 0, 2, 1], "fingers": [0, 0, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [5, 4, 6, 6], "fingers": [2, 1, 3, 4], "baseFret": 4, "barres": [] },
+    { "frets": [5, 7, 6, 6], "fingers": [1, 4, 2, 3], "baseFret": 5, "barres": [] }
   ],
   "A#maj7": [
-    { "frets": [1, 1, 3, 2], "fingers": [1, 1, 3, 2], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 1, 0, 2], "fingers": [0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [6, 8, 7, 7], "fingers": [1, 4, 2, 3], "baseFret": 6, "barres": [] }
   ],
   "Bmaj7": [
-    { "frets": [2, 2, 4, 3], "fingers": [1, 1, 3, 2], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 1, 3], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 9, 8, 8], "fingers": [1, 4, 2, 3], "baseFret": 7, "barres": [] }
   ],
   "Cmaj7": [
-    { "frets": [3, 3, 5, 4], "fingers": [2, 2, 4, 3], "baseFret": 3, "barres": [] },
-    { "frets": [3, 3, 2, 0], "fingers": [4, 3, 2, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 3, 2, 4], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [8, 10, 9, 9], "fingers": [1, 4, 2, 3], "baseFret": 8, "barres": [] }
   ],
   "C#maj7": [
-    { "frets": [4, 4, 6, 5], "fingers": [2, 2, 4, 3], "baseFret": 4, "barres": [] }
+    { "frets": [-1, 4, 3, 5], "fingers": [0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [9, 11, 10, 10], "fingers": [1, 4, 2, 3], "baseFret": 9, "barres": [] }
   ],
   "Dmaj7": [
-    { "frets": [2, 0, 4, 2], "fingers": [2, 0, 4, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 5, 4, 6], "fingers": [0, 2, 1, 3], "baseFret": 4, "barres": [] },
+    { "frets": [10, 12, 11, 11], "fingers": [1, 4, 2, 3], "baseFret": 10, "barres": [] }
   ],
   "D#maj7": [
-    { "frets": [3, 1, 5, 3], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 6, 5, 7], "fingers": [0, 2, 1, 3], "baseFret": 5, "barres": [] },
+    { "frets": [11, 13, 12, 12], "fingers": [1, 4, 2, 3], "baseFret": 11, "barres": [] }
   ],
   "Emaj7": [
-    { "frets": [0, 2, 2, 1], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 1, 1], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 8], "fingers": [0, 2, 1, 3], "baseFret": 6, "barres": [] }
   ],
   "Fmaj7": [
-    { "frets": [1, 3, 3, 2], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] }
+    { "frets": [1, 3, 2, 2], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 9], "fingers": [0, 2, 1, 3], "baseFret": 7, "barres": [] }
   ],
   "F#maj7": [
-    { "frets": [2, 4, 4, 3], "fingers": [1, 3, 4, 2], "baseFret": 2, "barres": [] }
+    { "frets": [2, 1, 3, 3], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 10], "fingers": [0, 2, 1, 3], "baseFret": 8, "barres": [] }
   ],
   "Gmaj7": [
-    { "frets": [3, 5, 5, 4], "fingers": [1, 3, 4, 2], "baseFret": 3, "barres": [] },
-    { "frets": [3, 2, 0, 0], "fingers": [3, 2, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [3, 5, 4, 4], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 9, 11], "fingers": [0, 2, 1, 3], "baseFret": 9, "barres": [] }
   ],
   "G#maj7": [
-    { "frets": [4, 6, 6, 5], "fingers": [1, 3, 4, 2], "baseFret": 4, "barres": [] }
+    { "frets": [4, 3, 1, 0], "fingers": [3, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 5, 5], "fingers": [1, 4, 2, 3], "baseFret": 4, "barres": [] }
   ],
   "Asus2": [
-    { "frets": [0, 2, 2, 2], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] }
+    { "frets": [5, 2, 2, 2], "fingers": [4, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 7, 4], "fingers": [2, 3, 4, 1], "baseFret": 4, "barres": [] }
   ],
   "A#sus2": [
-    { "frets": [1, 3, 3, 3], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [6, 3, 3, 3], "fingers": [4, 1, 2, 3], "baseFret": 3, "barres": [] },
+    { "frets": [6, 8, 8, 5], "fingers": [2, 3, 4, 1], "baseFret": 5, "barres": [] }
   ],
   "Bsus2": [
-    { "frets": [2, 4, 4, 4], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [7, 4, 4, 4], "fingers": [4, 1, 2, 3], "baseFret": 4, "barres": [] },
+    { "frets": [7, 9, 9, 6], "fingers": [2, 3, 4, 1], "baseFret": 6, "barres": [] }
   ],
   "Csus2": [
-    { "frets": [3, 5, 5, 5], "fingers": [1, 2, 3, 4], "baseFret": 3, "barres": [] }
+    { "frets": [-1, 3, 0, 0], "fingers": [0, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 5, 5, 5], "fingers": [4, 1, 2, 3], "baseFret": 5, "barres": [] }
   ],
   "C#sus2": [
-    { "frets": [4, 6, 6, 6], "fingers": [1, 2, 3, 4], "baseFret": 4, "barres": [] }
+    { "frets": [-1, 4, 1, 1], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [9, 6, 6, 6], "fingers": [4, 1, 2, 3], "baseFret": 6, "barres": [] }
   ],
   "Dsus2": [
-    { "frets": [0, 0, 0, 2], "fingers": [0, 0, 0, 2], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 5, 2, 2], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [10, 7, 7, 7], "fingers": [4, 1, 2, 3], "baseFret": 7, "barres": [] }
   ],
   "D#sus2": [
-    { "frets": [1, 1, 3, 3], "fingers": [1, 1, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 6, 3, 3], "fingers": [0, 3, 1, 2], "baseFret": 3, "barres": [] },
+    { "frets": [11, 8, 8, 8], "fingers": [4, 1, 2, 3], "baseFret": 8, "barres": [] }
   ],
   "Esus2": [
-    { "frets": [0, 2, 4, 4], "fingers": [0, 1, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 4, 4], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 4, 4], "fingers": [0, 3, 1, 2], "baseFret": 4, "barres": [] }
   ],
   "Fsus2": [
-    { "frets": [1, 3, 5, 0], "fingers": [1, 2, 4, 0], "baseFret": 1, "barres": [] }
+    { "frets": [1, 3, 3, 0], "fingers": [1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 5, 5], "fingers": [0, 3, 1, 2], "baseFret": 5, "barres": [] }
   ],
   "F#sus2": [
-    { "frets": [2, 4, 6, 1], "fingers": [1, 2, 4, 1], "baseFret": 1, "barres": [] }
+    { "frets": [2, 4, 4, 1], "fingers": [2, 3, 4, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 6, 6], "fingers": [0, 3, 1, 2], "baseFret": 6, "barres": [] }
   ],
   "Gsus2": [
-    { "frets": [3, 0, 0, 0], "fingers": [1, 0, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [3, 0, 0, 0], "fingers": [1, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 7, 7], "fingers": [0, 3, 1, 2], "baseFret": 7, "barres": [] }
   ],
   "G#sus2": [
-    { "frets": [4, 6, 8, 3], "fingers": [1, 2, 4, 1], "baseFret": 3, "barres": [] }
+    { "frets": [4, 1, 1, 1], "fingers": [4, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 6, 3], "fingers": [2, 3, 4, 1], "baseFret": 3, "barres": [] }
   ],
   "Asus4": [
-    { "frets": [0, 0, 2, 2], "fingers": [0, 0, 1, 2], "baseFret": 1, "barres": [] }
+    { "frets": [5, 5, 2, 2], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 7, 7], "fingers": [1, 2, 3, 4], "baseFret": 5, "barres": [] }
   ],
   "A#sus4": [
-    { "frets": [1, 1, 3, 3], "fingers": [1, 1, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [6, 6, 3, 3], "fingers": [3, 4, 1, 2], "baseFret": 3, "barres": [] },
+    { "frets": [6, 8, 8, 8], "fingers": [1, 2, 3, 4], "baseFret": 6, "barres": [] }
   ],
   "Bsus4": [
-    { "frets": [2, 2, 4, 4], "fingers": [1, 1, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [7, 7, 4, 4], "fingers": [3, 4, 1, 2], "baseFret": 4, "barres": [] },
+    { "frets": [7, 9, 9, 9], "fingers": [1, 2, 3, 4], "baseFret": 7, "barres": [] }
   ],
   "Csus4": [
-    { "frets": [3, 3, 5, 5], "fingers": [1, 1, 3, 4], "baseFret": 3, "barres": [] }
+    { "frets": [-1, 3, 3, 0], "fingers": [0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 8, 5, 5], "fingers": [3, 4, 1, 2], "baseFret": 5, "barres": [] }
   ],
   "C#sus4": [
-    { "frets": [4, 4, 6, 6], "fingers": [1, 1, 3, 4], "baseFret": 4, "barres": [] }
+    { "frets": [-1, 4, 4, 1], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [9, 9, 6, 6], "fingers": [3, 4, 1, 2], "baseFret": 6, "barres": [] }
   ],
   "Dsus4": [
-    { "frets": [3, 0, 5, 2], "fingers": [2, 0, 4, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 5, 5, 2], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [10, 10, 7, 7], "fingers": [3, 4, 1, 2], "baseFret": 7, "barres": [] }
   ],
   "D#sus4": [
-    { "frets": [4, 1, 6, 1], "fingers": [4, 1, 4, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 6, 6, 3], "fingers": [0, 2, 3, 1], "baseFret": 3, "barres": [] },
+    { "frets": [11, 11, 8, 8], "fingers": [3, 4, 1, 2], "baseFret": 8, "barres": [] }
   ],
   "Esus4": [
-    { "frets": [0, 2, 2, 2], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 2, 2], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 4], "fingers": [0, 2, 3, 1], "baseFret": 4, "barres": [] }
   ],
   "Fsus4": [
-    { "frets": [1, 3, 3, 3], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [1, 3, 3, 3], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 8, 5], "fingers": [0, 2, 3, 1], "baseFret": 5, "barres": [] }
   ],
   "F#sus4": [
-    { "frets": [2, 4, 4, 4], "fingers": [1, 2, 3, 4], "baseFret": 2, "barres": [] }
+    { "frets": [2, 4, 4, 4], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 9, 6], "fingers": [0, 2, 3, 1], "baseFret": 6, "barres": [] }
   ],
   "Gsus4": [
-    { "frets": [3, 5, 5, 5], "fingers": [1, 2, 3, 4], "baseFret": 3, "barres": [] }
+    { "frets": [3, 3, 0, 0], "fingers": [1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 10, 7], "fingers": [0, 2, 3, 1], "baseFret": 7, "barres": [] }
   ],
   "G#sus4": [
+    { "frets": [4, 4, 1, 1], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] },
     { "frets": [4, 6, 6, 6], "fingers": [1, 2, 3, 4], "baseFret": 4, "barres": [] }
   ],
   "Adim": [
-    { "frets": [-1, 0, 1, 2], "fingers": [0, 0, 1, 2], "baseFret": 1, "barres": [] }
+    { "frets": [5, 6, 7, 5], "fingers": [1, 3, 4, 2], "baseFret": 5, "barres": [] }
   ],
   "A#dim": [
-    { "frets": [0, 1, 2, 3], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] }
+    { "frets": [6, 7, 8, 6], "fingers": [1, 3, 4, 2], "baseFret": 6, "barres": [] }
   ],
   "Bdim": [
-    { "frets": [1, 2, 3, 4], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [7, 8, 9, 7], "fingers": [1, 3, 4, 2], "baseFret": 7, "barres": [] }
   ],
   "Cdim": [
-    { "frets": [2, 3, 4, 5], "fingers": [1, 2, 3, 4], "baseFret": 2, "barres": [] }
+    { "frets": [8, 9, 10, 8], "fingers": [1, 3, 4, 2], "baseFret": 8, "barres": [] }
   ],
   "C#dim": [
-    { "frets": [3, 4, 5, 6], "fingers": [1, 2, 3, 4], "baseFret": 3, "barres": [] }
+    { "frets": [-1, 4, 2, 0], "fingers": [0, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 10, 11, 9], "fingers": [1, 3, 4, 2], "baseFret": 9, "barres": [] }
   ],
   "Ddim": [
-    { "frets": [1, 5, 3, 1], "fingers": [1, 4, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [10, 11, 12, 10], "fingers": [1, 3, 4, 2], "baseFret": 10, "barres": [] }
   ],
   "D#dim": [
-    { "frets": [2, 0, 1, 2], "fingers": [2, 0, 1, 3], "baseFret": 1, "barres": [] }
+    { "frets": [11, 12, 13, 11], "fingers": [1, 3, 4, 2], "baseFret": 11, "barres": [] }
   ],
   "Edim": [
     { "frets": [0, 1, 2, 0], "fingers": [0, 1, 2, 0], "baseFret": 1, "barres": [] }
   ],
   "Fdim": [
-    { "frets": [1, 2, 3, 1], "fingers": [1, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [1, 2, 3, 1], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] }
   ],
   "F#dim": [
-    { "frets": [2, 3, 4, 2], "fingers": [1, 2, 3, 1], "baseFret": 2, "barres": [] }
+    { "frets": [2, 3, 4, 2], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] }
   ],
   "Gdim": [
-    { "frets": [3, 4, 5, 3], "fingers": [1, 2, 3, 1], "baseFret": 3, "barres": [] }
+    { "frets": [3, 4, 5, 3], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] }
   ],
   "G#dim": [
-    { "frets": [4, 5, 6, 4], "fingers": [1, 2, 3, 1], "baseFret": 4, "barres": [] }
+    { "frets": [4, 2, 0, 4], "fingers": [2, 1, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [4, 5, 6, 4], "fingers": [1, 3, 4, 2], "baseFret": 4, "barres": [] }
   ],
   "Aaug": [
-    { "frets": [1, 4, 3, 2], "fingers": [1, 4, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [5, 4, 3, -1], "fingers": [3, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 8, 7, 6], "fingers": [1, 4, 3, 2], "baseFret": 5, "barres": [] }
   ],
   "A#aug": [
-    { "frets": [2, 5, 4, 3], "fingers": [1, 4, 3, 2], "baseFret": 2, "barres": [] }
+    { "frets": [6, 5, 4, -1], "fingers": [3, 2, 1, 0], "baseFret": 4, "barres": [] },
+    { "frets": [6, 9, 8, 7], "fingers": [1, 4, 3, 2], "baseFret": 6, "barres": [] }
   ],
   "Baug": [
-    { "frets": [3, 6, 5, 4], "fingers": [1, 4, 3, 2], "baseFret": 3, "barres": [] }
+    { "frets": [-1, 2, 1, 0], "fingers": [0, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 6, 5, -1], "fingers": [3, 2, 1, 0], "baseFret": 5, "barres": [] }
   ],
   "Caug": [
-    { "frets": [4, 3, 2, 1], "fingers": [4, 3, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 3, 2, 1], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 6, -1], "fingers": [3, 2, 1, 0], "baseFret": 6, "barres": [] }
   ],
   "C#aug": [
-    { "frets": [1, 0, 3, 2], "fingers": [1, 0, 4, 2], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 4, 3, 2], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 7, -1], "fingers": [3, 2, 1, 0], "baseFret": 7, "barres": [] }
   ],
   "Daug": [
-    { "frets": [2, 1, 4, 3], "fingers": [2, 1, 4, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 5, 4, 3], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [10, 9, 8, -1], "fingers": [3, 2, 1, 0], "baseFret": 8, "barres": [] }
   ],
   "D#aug": [
-    { "frets": [3, 2, 5, 4], "fingers": [2, 1, 4, 3], "baseFret": 2, "barres": [] }
+    { "frets": [-1, 6, 5, 4], "fingers": [0, 3, 2, 1], "baseFret": 4, "barres": [] },
+    { "frets": [11, 10, 9, -1], "fingers": [3, 2, 1, 0], "baseFret": 9, "barres": [] }
   ],
   "Eaug": [
-    { "frets": [0, 3, 2, 1], "fingers": [0, 4, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [0, 3, 2, 1], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 5], "fingers": [0, 3, 2, 1], "baseFret": 5, "barres": [] }
   ],
   "Faug": [
-    { "frets": [1, 4, 3, 2], "fingers": [1, 4, 3, 2], "baseFret": 1, "barres": [] }
+    { "frets": [1, 4, 3, 2], "fingers": [1, 4, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 6], "fingers": [0, 3, 2, 1], "baseFret": 6, "barres": [] }
   ],
   "F#aug": [
-    { "frets": [2, 5, 4, 3], "fingers": [1, 4, 3, 2], "baseFret": 2, "barres": [] }
+    { "frets": [2, 1, 0, 3], "fingers": [2, 1, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 7], "fingers": [0, 3, 2, 1], "baseFret": 7, "barres": [] }
   ],
   "Gaug": [
-    { "frets": [3, 2, 1, 0], "fingers": [4, 3, 1, 0], "baseFret": 1, "barres": [] }
+    { "frets": [3, 2, 1, 0], "fingers": [3, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 6, 5, 4], "fingers": [1, 4, 3, 2], "baseFret": 3, "barres": [] }
   ],
   "G#aug": [
-    { "frets": [4, 3, 2, 1], "fingers": [4, 3, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [4, 3, 2, -1], "fingers": [3, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [4, 7, 6, 5], "fingers": [1, 4, 3, 2], "baseFret": 4, "barres": [] }
   ],
   "A5": [
-    { "frets": [0, 0, -1, -1], "fingers": [0, 0, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 0, 2, 2], "fingers": [0, 0, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 7, -1], "fingers": [1, 2, 3, 0], "baseFret": 5, "barres": [] }
   ],
   "A#5": [
-    { "frets": [1, 1, -1, -1], "fingers": [1, 1, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 1, 3, 3], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 8, 8, -1], "fingers": [1, 2, 3, 0], "baseFret": 6, "barres": [] }
   ],
   "B5": [
-    { "frets": [2, 2, -1, -1], "fingers": [1, 2, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 4, 4], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 9, 9, -1], "fingers": [1, 2, 3, 0], "baseFret": 7, "barres": [] }
   ],
   "C5": [
-    { "frets": [3, 3, -1, -1], "fingers": [1, 2, 0, 0], "baseFret": 3, "barres": [] }
+    { "frets": [-1, 3, 5, 5], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [8, 10, 10, -1], "fingers": [1, 2, 3, 0], "baseFret": 8, "barres": [] }
   ],
   "C#5": [
-    { "frets": [4, 4, -1, -1], "fingers": [1, 2, 0, 0], "baseFret": 4, "barres": [] }
+    { "frets": [-1, 4, 6, 6], "fingers": [0, 1, 2, 3], "baseFret": 4, "barres": [] },
+    { "frets": [9, 11, 11, -1], "fingers": [1, 2, 3, 0], "baseFret": 9, "barres": [] }
   ],
   "D5": [
-    { "frets": [-1, 0, 0, -1], "fingers": [0, 0, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 5, 7, 7], "fingers": [0, 1, 2, 3], "baseFret": 5, "barres": [] },
+    { "frets": [10, 12, 12, -1], "fingers": [1, 2, 3, 0], "baseFret": 10, "barres": [] }
   ],
   "D#5": [
-    { "frets": [-1, 1, 1, -1], "fingers": [0, 1, 1, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 6, 8, 8], "fingers": [0, 1, 2, 3], "baseFret": 6, "barres": [] }
   ],
   "E5": [
-    { "frets": [0, 2, 2, -1], "fingers": [0, 1, 2, 0], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 2, -1], "fingers": [0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 9, 9], "fingers": [0, 1, 2, 3], "baseFret": 7, "barres": [] }
   ],
   "F5": [
-    { "frets": [1, 3, 3, -1], "fingers": [1, 3, 4, 0], "baseFret": 1, "barres": [] }
+    { "frets": [1, 3, 3, -1], "fingers": [1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 10, 10], "fingers": [0, 1, 2, 3], "baseFret": 8, "barres": [] }
   ],
   "F#5": [
-    { "frets": [2, 4, 4, -1], "fingers": [1, 3, 4, 0], "baseFret": 2, "barres": [] }
+    { "frets": [2, 4, 4, -1], "fingers": [1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 11, 11], "fingers": [0, 1, 2, 3], "baseFret": 9, "barres": [] }
   ],
   "G5": [
-    { "frets": [3, 5, 5, -1], "fingers": [1, 3, 4, 0], "baseFret": 3, "barres": [] },
-    { "frets": [3, 5, 0, -1], "fingers": [1, 3, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [3, 5, 5, -1], "fingers": [1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 12, 12], "fingers": [0, 1, 2, 3], "baseFret": 10, "barres": [] }
   ],
   "G#5": [
-    { "frets": [4, 6, 6, -1], "fingers": [1, 3, 4, 0], "baseFret": 4, "barres": [] }
+    { "frets": [4, 6, 6, -1], "fingers": [1, 2, 3, 0], "baseFret": 4, "barres": [] }
+  ],
+  "A/C#": [
+    { "frets": [-1, 4, 2, 2], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [9, 7, 7, 9], "fingers": [3, 1, 2, 4], "baseFret": 7, "barres": [] }
+  ],
+  "A/E": [
+    { "frets": [0, 4, 2, 2], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 6], "fingers": [0, 2, 3, 1], "baseFret": 6, "barres": [] }
+  ],
+  "A/G#": [
+    { "frets": [4, 4, 2, 2], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [4, 7, 7, 6], "fingers": [1, 3, 4, 2], "baseFret": 4, "barres": [] }
+  ],
+  "A/G": [
+    { "frets": [3, 4, 2, 2], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] }
+  ],
+  "Am/C": [
+    { "frets": [-1, 3, 2, 2], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 7, 5], "fingers": [4, 2, 3, 1], "baseFret": 5, "barres": [] }
+  ],
+  "Am/E": [
+    { "frets": [0, 3, 2, 2], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 5], "fingers": [0, 2, 3, 1], "baseFret": 5, "barres": [] }
+  ],
+  "Am/G": [
+    { "frets": [3, 3, 2, 2], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] }
+  ],
+  "A#/D": [
+    { "frets": [-1, 5, 3, 3], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [10, 8, 8, 10], "fingers": [3, 1, 2, 4], "baseFret": 8, "barres": [] }
+  ],
+  "A#/F": [
+    { "frets": [1, 1, 0, 3], "fingers": [1, 2, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 8, 7], "fingers": [0, 2, 3, 1], "baseFret": 7, "barres": [] }
+  ],
+  "A#/A": [
+    { "frets": [5, 5, 3, 3], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [5, 8, 8, 7], "fingers": [1, 3, 4, 2], "baseFret": 5, "barres": [] }
+  ],
+  "A#/G#": [
+    { "frets": [4, 5, 3, 3], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] }
+  ],
+  "A#m/C#": [
+    { "frets": [-1, 4, 3, 3], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 8, 6], "fingers": [4, 2, 3, 1], "baseFret": 6, "barres": [] }
+  ],
+  "A#m/F": [
+    { "frets": [1, 4, 3, 3], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 8, 6], "fingers": [0, 2, 3, 1], "baseFret": 6, "barres": [] }
+  ],
+  "A#m/G#": [
+    { "frets": [4, 4, 3, 3], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] }
+  ],
+  "B/D#": [
+    { "frets": [-1, 6, 4, 4], "fingers": [0, 3, 1, 2], "baseFret": 4, "barres": [] },
+    { "frets": [11, 9, 9, 11], "fingers": [3, 1, 2, 4], "baseFret": 9, "barres": [] }
+  ],
+  "B/F#": [
+    { "frets": [2, 2, 1, -1], "fingers": [2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 9, 8], "fingers": [0, 2, 3, 1], "baseFret": 8, "barres": [] }
+  ],
+  "B/A#": [
+    { "frets": [6, 6, 4, 4], "fingers": [3, 4, 1, 2], "baseFret": 4, "barres": [] },
+    { "frets": [6, 9, 9, 8], "fingers": [1, 3, 4, 2], "baseFret": 6, "barres": [] }
+  ],
+  "B/A": [
+    { "frets": [5, 6, 4, 4], "fingers": [3, 4, 1, 2], "baseFret": 4, "barres": [] }
+  ],
+  "Bm/D": [
+    { "frets": [-1, 5, 4, 4], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [10, 9, 9, 7], "fingers": [4, 2, 3, 1], "baseFret": 7, "barres": [] }
+  ],
+  "Bm/F#": [
+    { "frets": [2, 2, 0, -1], "fingers": [1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 9, 7], "fingers": [0, 2, 3, 1], "baseFret": 7, "barres": [] }
+  ],
+  "Bm/A": [
+    { "frets": [5, 5, 4, 4], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] }
+  ],
+  "C/E": [
+    { "frets": [0, 3, 2, 0], "fingers": [0, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 5, 5], "fingers": [0, 3, 1, 2], "baseFret": 5, "barres": [] }
+  ],
+  "C/G": [
+    { "frets": [3, 3, 2, 0], "fingers": [2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 10, 9], "fingers": [0, 2, 3, 1], "baseFret": 9, "barres": [] }
+  ],
+  "C/B": [
+    { "frets": [7, 7, 5, 5], "fingers": [3, 4, 1, 2], "baseFret": 5, "barres": [] },
+    { "frets": [7, 10, 10, 9], "fingers": [1, 3, 4, 2], "baseFret": 7, "barres": [] }
+  ],
+  "C/A#": [
+    { "frets": [6, 7, 5, 5], "fingers": [3, 4, 1, 2], "baseFret": 5, "barres": [] }
+  ],
+  "Cm/D#": [
+    { "frets": [-1, 6, 5, 5], "fingers": [0, 3, 1, 2], "baseFret": 5, "barres": [] },
+    { "frets": [11, 10, 10, 8], "fingers": [4, 2, 3, 1], "baseFret": 8, "barres": [] }
+  ],
+  "Cm/G": [
+    { "frets": [3, 3, 1, 0], "fingers": [2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 6, 5, 5], "fingers": [1, 4, 2, 3], "baseFret": 3, "barres": [] }
+  ],
+  "Cm/A#": [
+    { "frets": [6, 6, 5, 5], "fingers": [3, 4, 1, 2], "baseFret": 5, "barres": [] }
+  ],
+  "C#/F": [
+    { "frets": [1, 4, 3, 1], "fingers": [1, 4, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 6, 6], "fingers": [0, 3, 1, 2], "baseFret": 6, "barres": [] }
+  ],
+  "C#/G#": [
+    { "frets": [4, 4, 3, 1], "fingers": [3, 4, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [4, 4, 3, -1], "fingers": [2, 3, 1, 0], "baseFret": 1, "barres": [] }
+  ],
+  "C#/C": [
+    { "frets": [8, 8, 6, 6], "fingers": [3, 4, 1, 2], "baseFret": 6, "barres": [] },
+    { "frets": [8, 11, 11, 10], "fingers": [1, 3, 4, 2], "baseFret": 8, "barres": [] }
+  ],
+  "C#/B": [
+    { "frets": [7, 8, 6, 6], "fingers": [3, 4, 1, 2], "baseFret": 6, "barres": [] }
+  ],
+  "C#m/E": [
+    { "frets": [0, 4, 2, 1], "fingers": [0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 6], "fingers": [0, 3, 1, 2], "baseFret": 6, "barres": [] }
+  ],
+  "C#m/G#": [
+    { "frets": [4, 4, 2, -1], "fingers": [2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [4, 7, 6, 6], "fingers": [1, 4, 2, 3], "baseFret": 4, "barres": [] }
+  ],
+  "C#m/B": [
+    { "frets": [7, 7, 6, 6], "fingers": [3, 4, 1, 2], "baseFret": 6, "barres": [] }
+  ],
+  "D/F#": [
+    { "frets": [2, 0, 0, 2], "fingers": [1, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 7, 7], "fingers": [0, 3, 1, 2], "baseFret": 7, "barres": [] }
+  ],
+  "D/A": [
+    { "frets": [5, 5, 4, 2], "fingers": [3, 4, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [5, 5, 4, -1], "fingers": [2, 3, 1, 0], "baseFret": 1, "barres": [] }
+  ],
+  "D/C#": [
+    { "frets": [9, 9, 7, 7], "fingers": [3, 4, 1, 2], "baseFret": 7, "barres": [] },
+    { "frets": [9, 12, 12, 11], "fingers": [1, 3, 4, 2], "baseFret": 9, "barres": [] }
+  ],
+  "D/C": [
+    { "frets": [8, 9, 7, 7], "fingers": [3, 4, 1, 2], "baseFret": 7, "barres": [] }
+  ],
+  "Dm/F": [
+    { "frets": [1, 0, 0, 2], "fingers": [1, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 7], "fingers": [0, 3, 1, 2], "baseFret": 7, "barres": [] }
+  ],
+  "Dm/A": [
+    { "frets": [5, 5, 3, -1], "fingers": [2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 8, 7, 7], "fingers": [1, 4, 2, 3], "baseFret": 5, "barres": [] }
+  ],
+  "Dm/C": [
+    { "frets": [8, 8, 7, 7], "fingers": [3, 4, 1, 2], "baseFret": 7, "barres": [] }
+  ],
+  "D#/G": [
+    { "frets": [3, 1, 1, 0], "fingers": [3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 6, 5, 3], "fingers": [1, 4, 3, 2], "baseFret": 3, "barres": [] }
+  ],
+  "D#/A#": [
+    { "frets": [-1, 1, 1, 0], "fingers": [0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 6, 5, 3], "fingers": [3, 4, 2, 1], "baseFret": 3, "barres": [] }
+  ],
+  "D#/D": [
+    { "frets": [10, 10, 8, 8], "fingers": [3, 4, 1, 2], "baseFret": 8, "barres": [] }
+  ],
+  "D#/C#": [
+    { "frets": [9, 10, 8, 8], "fingers": [3, 4, 1, 2], "baseFret": 8, "barres": [] }
+  ],
+  "D#m/F#": [
+    { "frets": [2, 1, 1, 3], "fingers": [3, 1, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 8], "fingers": [0, 3, 1, 2], "baseFret": 8, "barres": [] }
+  ],
+  "D#m/A#": [
+    { "frets": [6, 6, 4, -1], "fingers": [2, 3, 1, 0], "baseFret": 4, "barres": [] },
+    { "frets": [6, 9, 8, 8], "fingers": [1, 4, 2, 3], "baseFret": 6, "barres": [] }
+  ],
+  "D#m/C#": [
+    { "frets": [9, 9, 8, 8], "fingers": [3, 4, 1, 2], "baseFret": 8, "barres": [] }
+  ],
+  "E/G#": [
+    { "frets": [4, 2, 2, 4], "fingers": [3, 1, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [4, 7, 6, 4], "fingers": [1, 4, 3, 2], "baseFret": 4, "barres": [] }
+  ],
+  "E/B": [
+    { "frets": [-1, 2, 2, 1], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [7, 7, 6, 4], "fingers": [3, 4, 2, 1], "baseFret": 4, "barres": [] }
+  ],
+  "E/D#": [
+    { "frets": [11, 11, 9, 9], "fingers": [3, 4, 1, 2], "baseFret": 9, "barres": [] }
+  ],
+  "E/D": [
+    { "frets": [10, 11, 9, 9], "fingers": [3, 4, 1, 2], "baseFret": 9, "barres": [] }
+  ],
+  "Em/G": [
+    { "frets": [3, 2, 2, 0], "fingers": [3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 9, 9], "fingers": [0, 3, 1, 2], "baseFret": 9, "barres": [] }
+  ],
+  "Em/B": [
+    { "frets": [-1, 2, 2, 0], "fingers": [0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 7, 5, -1], "fingers": [2, 3, 1, 0], "baseFret": 5, "barres": [] }
+  ],
+  "Em/D": [
+    { "frets": [10, 10, 9, 9], "fingers": [3, 4, 1, 2], "baseFret": 9, "barres": [] }
+  ],
+  "F/A": [
+    { "frets": [5, 3, 3, 5], "fingers": [3, 1, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [5, 8, 7, 5], "fingers": [1, 4, 3, 2], "baseFret": 5, "barres": [] }
+  ],
+  "F/C": [
+    { "frets": [-1, 3, 3, 2], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [8, 8, 7, 5], "fingers": [3, 4, 2, 1], "baseFret": 5, "barres": [] }
+  ],
+  "F/E": [
+    { "frets": [0, 3, 3, 2], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [12, 12, 10, 10], "fingers": [3, 4, 1, 2], "baseFret": 10, "barres": [] }
+  ],
+  "F/D#": [
+    { "frets": [11, 12, 10, 10], "fingers": [3, 4, 1, 2], "baseFret": 10, "barres": [] }
+  ],
+  "Fm/G#": [
+    { "frets": [4, 3, 3, 1], "fingers": [4, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [4, 3, 3, 5], "fingers": [3, 1, 2, 4], "baseFret": 1, "barres": [] }
+  ],
+  "Fm/C": [
+    { "frets": [-1, 3, 3, 1], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [8, 8, 6, -1], "fingers": [2, 3, 1, 0], "baseFret": 6, "barres": [] }
+  ],
+  "Fm/D#": [
+    { "frets": [11, 11, 10, 10], "fingers": [3, 4, 1, 2], "baseFret": 10, "barres": [] }
+  ],
+  "F#/A#": [
+    { "frets": [6, 4, 4, 6], "fingers": [3, 1, 2, 4], "baseFret": 4, "barres": [] },
+    { "frets": [6, 9, 8, 6], "fingers": [1, 4, 3, 2], "baseFret": 6, "barres": [] }
+  ],
+  "F#/C#": [
+    { "frets": [-1, 4, 4, 3], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [9, 9, 8, 6], "fingers": [3, 4, 2, 1], "baseFret": 6, "barres": [] }
+  ],
+  "F#/F": [
+    { "frets": [1, 4, 4, 3], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [13, 13, 11, 11], "fingers": [3, 4, 1, 2], "baseFret": 11, "barres": [] }
+  ],
+  "F#/E": [
+    { "frets": [0, 4, 4, 3], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [12, 13, 11, 11], "fingers": [3, 4, 1, 2], "baseFret": 11, "barres": [] }
+  ],
+  "F#m/A": [
+    { "frets": [5, 4, 4, 2], "fingers": [4, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [5, 4, 4, 6], "fingers": [3, 1, 2, 4], "baseFret": 4, "barres": [] }
+  ],
+  "F#m/C#": [
+    { "frets": [-1, 4, 4, 2], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [9, 9, 7, -1], "fingers": [2, 3, 1, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F#m/E": [
+    { "frets": [0, 4, 4, 2], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [12, 12, 11, 11], "fingers": [3, 4, 1, 2], "baseFret": 11, "barres": [] }
+  ],
+  "G/B": [
+    { "frets": [-1, 2, 0, 0], "fingers": [0, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 5, 7], "fingers": [3, 1, 2, 4], "baseFret": 5, "barres": [] }
+  ],
+  "G/D": [
+    { "frets": [-1, 5, 5, 4], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [10, 10, 9, 7], "fingers": [3, 4, 2, 1], "baseFret": 7, "barres": [] }
+  ],
+  "G/F#": [
+    { "frets": [2, 2, 0, 0], "fingers": [1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [2, 5, 5, 4], "fingers": [1, 3, 4, 2], "baseFret": 1, "barres": [] }
+  ],
+  "G/F": [
+    { "frets": [1, 2, 0, 0], "fingers": [1, 2, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "Gm/A#": [
+    { "frets": [-1, 1, 0, 0], "fingers": [0, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 5, 5, 3], "fingers": [4, 2, 3, 1], "baseFret": 3, "barres": [] }
+  ],
+  "Gm/D": [
+    { "frets": [-1, 5, 5, 3], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [10, 10, 8, -1], "fingers": [2, 3, 1, 0], "baseFret": 8, "barres": [] }
+  ],
+  "Gm/F": [
+    { "frets": [1, 1, 0, 0], "fingers": [1, 2, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "G#/C": [
+    { "frets": [-1, 3, 1, 1], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [8, 6, 6, 8], "fingers": [3, 1, 2, 4], "baseFret": 6, "barres": [] }
+  ],
+  "G#/D#": [
+    { "frets": [-1, 6, 6, 5], "fingers": [0, 2, 3, 1], "baseFret": 5, "barres": [] },
+    { "frets": [11, 11, 10, 8], "fingers": [3, 4, 2, 1], "baseFret": 8, "barres": [] }
+  ],
+  "G#/G": [
+    { "frets": [3, 3, 1, 1], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [3, 6, 6, 5], "fingers": [1, 3, 4, 2], "baseFret": 3, "barres": [] }
+  ],
+  "G#/F#": [
+    { "frets": [2, 3, 1, 1], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] }
+  ],
+  "G#m/B": [
+    { "frets": [-1, 2, 1, 1], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [7, 6, 6, 4], "fingers": [4, 2, 3, 1], "baseFret": 4, "barres": [] }
+  ],
+  "G#m/D#": [
+    { "frets": [-1, 6, 6, 4], "fingers": [0, 2, 3, 1], "baseFret": 4, "barres": [] },
+    { "frets": [11, 11, 9, -1], "fingers": [2, 3, 1, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G#m/F#": [
+    { "frets": [2, 2, 1, 1], "fingers": [3, 4, 1, 2], "baseFret": 1, "barres": [] }
   ]
 }

--- a/apps/klank/public/chords-guitar.json
+++ b/apps/klank/public/chords-guitar.json
@@ -1,400 +1,938 @@
 {
   "A": [
     { "frets": [-1, 0, 2, 2, 2, 0], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
-    { "frets": [-1, 0, 2, 2, 2, 0], "fingers": [0, 0, 1, 1, 1, 0], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
-    { "frets": [-1, -1, 2, 2, 2, 0], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 7, 6, 5, 5], "fingers": [0, 0, 4, 3, 1, 2], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 9, 10, 9], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 7, "barres": [] }
   ],
   "A#": [
-    { "frets": [-1, 1, 3, 3, 3, 1], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] },
-    { "frets": [-1, -1, 3, 3, 3, 1], "fingers": [0, 0, 1, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 1, 0, 3, 3, 1], "fingers": [0, 1, 0, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [6, 5, 3, 3, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, -1, 8, 7, 6, 6], "fingers": [0, 0, 4, 3, 1, 2], "baseFret": 6, "barres": [] }
   ],
   "B": [
-    { "frets": [-1, 2, 4, 4, 4, 2], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 0, "toString": 5 }] },
-    { "frets": [-1, -1, 4, 4, 4, 2], "fingers": [0, 0, 1, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 4, 4, 4, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 6, 4, 4, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 9, 8, 7, 7], "fingers": [0, 0, 4, 3, 1, 2], "baseFret": 7, "barres": [] }
   ],
   "C": [
     { "frets": [-1, 3, 2, 0, 1, 0], "fingers": [0, 3, 2, 0, 1, 0], "baseFret": 1, "barres": [] },
-    { "frets": [3, 3, 5, 5, 5, 3], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 3, 5, 5, 5, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 5, 5, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 5, "barres": [] }
   ],
   "C#": [
-    { "frets": [-1, 4, 3, 1, 2, 1], "fingers": [0, 4, 3, 1, 2, 1], "baseFret": 1, "barres": [] },
-    { "frets": [4, 4, 6, 6, 6, 4], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 4, 3, 1, 2, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 6, 6, 6, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 4, "barres": [] },
+    { "frets": [9, 8, 6, 6, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "D": [
     { "frets": [-1, -1, 0, 2, 3, 2], "fingers": [0, 0, 0, 1, 3, 2], "baseFret": 1, "barres": [] },
-    { "frets": [5, 5, 7, 7, 7, 5], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 5, 7, 7, 7, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [10, 9, 7, 7, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "D#": [
     { "frets": [-1, -1, 1, 3, 4, 3], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 1, "barres": [] },
-    { "frets": [6, 6, 8, 8, 8, 6], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 6, 5, 3, 4, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 6, 8, 8, 8, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 6, "barres": [] }
   ],
   "E": [
     { "frets": [0, 2, 2, 1, 0, 0], "fingers": [0, 2, 3, 1, 0, 0], "baseFret": 1, "barres": [] },
-    { "frets": [0, 2, 2, 1, 0, 0], "fingers": [0, 2, 3, 1, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 7, 6, 4, 5, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 7, 9, 9, 9, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 7, "barres": [] }
   ],
   "F": [
     { "frets": [1, 3, 3, 2, 1, 1], "fingers": [1, 3, 4, 2, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] },
-    { "frets": [-1, -1, 3, 2, 1, 1], "fingers": [0, 0, 4, 3, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 1 }] }
+    { "frets": [-1, -1, 3, 5, 6, 5], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 8, 7, 5, 6, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 5, "barres": [] }
   ],
   "F#": [
-    { "frets": [2, 4, 4, 3, 2, 2], "fingers": [1, 3, 4, 2, 1, 1], "baseFret": 2, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] },
-    { "frets": [-1, -1, 4, 3, 2, 2], "fingers": [0, 0, 4, 3, 1, 1], "baseFret": 2, "barres": [{ "fret": 2, "fromString": 0, "toString": 1 }] }
+    { "frets": [-1, -1, 4, 3, 2, 2], "fingers": [0, 0, 4, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 7, 6], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 8, 6, 7, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 6, "barres": [] }
   ],
   "G": [
     { "frets": [3, 2, 0, 0, 0, 3], "fingers": [2, 1, 0, 0, 0, 3], "baseFret": 1, "barres": [] },
-    { "frets": [3, 2, 0, 0, 3, 3], "fingers": [2, 1, 0, 0, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 5, 7, 8, 7], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 10, 9, 7, 8, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 7, "barres": [] }
   ],
   "G#": [
-    { "frets": [4, 3, 1, 1, 1, 4], "fingers": [4, 3, 1, 1, 1, 4], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] },
-    { "frets": [4, 6, 6, 5, 4, 4], "fingers": [1, 3, 4, 2, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [4, 3, 1, 1, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 5, 4, 4], "fingers": [0, 0, 4, 3, 1, 2], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 9, 8], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 6, "barres": [] }
   ],
   "Am": [
     { "frets": [-1, 0, 2, 2, 1, 0], "fingers": [0, 0, 2, 3, 1, 0], "baseFret": 1, "barres": [] },
-    { "frets": [5, 7, 7, 5, 5, 5], "fingers": [1, 3, 4, 1, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, -1, 7, 5, 5, 5], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 9, 10, 8], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 7, "barres": [] }
   ],
   "A#m": [
-    { "frets": [-1, 1, 3, 3, 2, 1], "fingers": [0, 1, 3, 4, 2, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 1, 3, 3, 2, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 4, 3, 3, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, -1, 8, 6, 6, 6], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 6, "barres": [] }
   ],
   "Bm": [
-    { "frets": [-1, 2, 4, 4, 3, 2], "fingers": [1, 1, 3, 4, 2, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 0, "toString": 5 }] },
-    { "frets": [-1, -1, 4, 4, 3, 2], "fingers": [0, 0, 3, 4, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 4, 4, 3, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 4, 4, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 9, 7, 7, 7], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 7, "barres": [] }
   ],
   "Cm": [
-    { "frets": [-1, 3, 5, 5, 4, 3], "fingers": [1, 1, 3, 4, 2, 1], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 0, "toString": 5 }] },
-    { "frets": [-1, 3, 1, 0, 1, 3], "fingers": [0, 4, 1, 0, 2, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 3, 1, 0, 1, 3], "fingers": [0, 3, 1, 0, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 5, 5, 4, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 6, 5, 5, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 5, "barres": [] }
   ],
   "C#m": [
-    { "frets": [-1, 4, 6, 6, 5, 4], "fingers": [1, 1, 3, 4, 2, 1], "baseFret": 1, "barres": [{ "fret": 4, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 4, 2, 1, 2, -1], "fingers": [0, 4, 2, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 6, 6, 5, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 4, "barres": [] },
+    { "frets": [9, 7, 6, 6, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "Dm": [
     { "frets": [-1, -1, 0, 2, 3, 1], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] },
-    { "frets": [5, 5, 7, 7, 6, 5], "fingers": [1, 1, 3, 4, 2, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 5, 7, 7, 6, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 5, "barres": [] },
+    { "frets": [10, 8, 7, 7, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "D#m": [
     { "frets": [-1, -1, 1, 3, 4, 2], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 1, "barres": [] },
-    { "frets": [6, 6, 8, 8, 7, 6], "fingers": [1, 1, 3, 4, 2, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 6, 4, 3, 4, -1], "fingers": [0, 4, 2, 1, 3, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 6, 8, 8, 7, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 6, "barres": [] }
   ],
   "Em": [
     { "frets": [0, 2, 2, 0, 0, 0], "fingers": [0, 2, 3, 0, 0, 0], "baseFret": 1, "barres": [] },
-    { "frets": [0, 2, 2, 0, 0, 0], "fingers": [0, 1, 2, 0, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 7, 5, 4, 5, -1], "fingers": [0, 4, 2, 1, 3, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 7, 9, 9, 8, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 7, "barres": [] }
   ],
   "Fm": [
-    { "frets": [1, 3, 3, 1, 1, 1], "fingers": [1, 3, 4, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, -1, 3, 1, 1, 1], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 6, 4], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 8, 6, 5, 6, -1], "fingers": [0, 4, 2, 1, 3, 0], "baseFret": 5, "barres": [] }
   ],
   "F#m": [
-    { "frets": [2, 4, 4, 2, 2, 2], "fingers": [1, 3, 4, 1, 1, 1], "baseFret": 2, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, -1, 4, 2, 2, 2], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 7, 5], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 7, 6, 7, -1], "fingers": [0, 4, 2, 1, 3, 0], "baseFret": 6, "barres": [] }
   ],
   "Gm": [
-    { "frets": [3, 5, 5, 3, 3, 3], "fingers": [1, 3, 4, 1, 1, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] },
-    { "frets": [3, 5, 5, 3, 3, 3], "fingers": [1, 3, 4, 1, 1, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [3, 1, 0, 0, 3, 3], "fingers": [2, 1, 0, 0, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 3, 3, 3], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 7, 8, 6], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 5, "barres": [] }
   ],
   "G#m": [
-    { "frets": [4, 6, 6, 4, 4, 4], "fingers": [1, 3, 4, 1, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [4, 2, 1, 1, -1, -1], "fingers": [4, 3, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 4, 4, 4], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 9, 7], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 6, "barres": [] }
   ],
   "A7": [
     { "frets": [-1, 0, 2, 0, 2, 0], "fingers": [0, 0, 2, 0, 3, 0], "baseFret": 1, "barres": [] },
-    { "frets": [5, 7, 5, 6, 5, 5], "fingers": [1, 3, 1, 2, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [5, 7, 5, 6, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 9, 8, 9], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 7, "barres": [] }
   ],
   "A#7": [
-    { "frets": [-1, 1, 3, 1, 3, 1], "fingers": [1, 1, 3, 1, 4, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 1, 0, 1, 3, 1], "fingers": [0, 1, 0, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 5, 3, 3, 3, 4], "fingers": [4, 3, 1, 1, 1, 2], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [6, 8, 6, 7, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "B7": [
     { "frets": [-1, 2, 1, 2, 0, 2], "fingers": [0, 2, 1, 3, 0, 4], "baseFret": 1, "barres": [] },
-    { "frets": [7, 6, 7, 8, 7, 7], "fingers": [2, 1, 3, 4, 2, 2], "baseFret": 7, "barres": [] }
+    { "frets": [7, 6, 4, 4, 4, 5], "fingers": [4, 3, 1, 1, 1, 2], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [7, 9, 7, 8, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "C7": [
     { "frets": [-1, 3, 2, 3, 1, 0], "fingers": [0, 3, 2, 4, 1, 0], "baseFret": 1, "barres": [] },
-    { "frets": [8, 10, 8, 9, 8, 8], "fingers": [1, 3, 1, 2, 1, 1], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 3, 5, 3, 5, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 5, 5, 5, 6], "fingers": [4, 3, 1, 1, 1, 2], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
   ],
   "C#7": [
-    { "frets": [-1, 4, 3, 4, 2, 1], "fingers": [0, 4, 3, 4, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 4, 3, 1, 0, 1], "fingers": [0, 4, 3, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 3, 4, 0, 4], "fingers": [0, 2, 1, 3, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 6, 6, 6, 7], "fingers": [4, 3, 1, 1, 1, 2], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
   ],
   "D7": [
     { "frets": [-1, -1, 0, 2, 1, 2], "fingers": [0, 0, 0, 2, 1, 3], "baseFret": 1, "barres": [] },
-    { "frets": [-1, 5, 4, 5, 3, 5], "fingers": [0, 2, 1, 3, 1, 4], "baseFret": 5, "barres": [] }
+    { "frets": [-1, 5, 4, 5, 3, -1], "fingers": [0, 3, 2, 4, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 7, 5, 7, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 5, "barres": [] }
   ],
   "D#7": [
-    { "frets": [-1, -1, 1, 3, 2, 3], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 1, 3, 2, 3], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 5, 6, 4, -1], "fingers": [0, 3, 2, 4, 1, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 6, 8, 6, 8, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 6, "barres": [] }
   ],
   "E7": [
     { "frets": [0, 2, 0, 1, 0, 0], "fingers": [0, 2, 0, 1, 0, 0], "baseFret": 1, "barres": [] },
-    { "frets": [0, 2, 2, 1, 3, 0], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 7, 6, 7, 5, -1], "fingers": [0, 3, 2, 4, 1, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 7, 9, 7, 9, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 7, "barres": [] }
   ],
   "F7": [
-    { "frets": [1, 3, 1, 2, 1, 1], "fingers": [1, 3, 1, 2, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [1, 0, 1, 2, 1, -1], "fingers": [1, 0, 2, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 4, 5], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 10, 8, 10, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 8, "barres": [] }
   ],
   "F#7": [
-    { "frets": [2, 4, 2, 3, 2, 2], "fingers": [1, 3, 1, 2, 1, 1], "baseFret": 2, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [2, 1, 2, 3, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 5, 6], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 11, 9, 11, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 9, "barres": [] }
   ],
   "G7": [
     { "frets": [3, 2, 0, 0, 0, 1], "fingers": [3, 2, 0, 0, 0, 1], "baseFret": 1, "barres": [] },
-    { "frets": [3, 2, 0, 0, 3, 1], "fingers": [3, 2, 0, 0, 4, 1], "baseFret": 1, "barres": [] }
+    { "frets": [3, 5, 3, 4, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 7, 6, 7], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 5, "barres": [] }
   ],
   "G#7": [
-    { "frets": [4, 3, 1, 1, 1, 2], "fingers": [4, 3, 1, 1, 1, 2], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] }
+    { "frets": [-1, -1, -1, 1, 1, 2], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 4, 5, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 7, 8], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 6, "barres": [] }
   ],
   "Am7": [
     { "frets": [-1, 0, 2, 0, 1, 0], "fingers": [0, 0, 2, 0, 1, 0], "baseFret": 1, "barres": [] },
-    { "frets": [5, 7, 5, 5, 5, 5], "fingers": [1, 3, 1, 1, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [5, 3, 5, 5, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 5, 5, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 5, "barres": [] }
   ],
   "A#m7": [
-    { "frets": [-1, 1, 3, 1, 2, 1], "fingers": [1, 1, 3, 1, 2, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 1, 3, 1, 2, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 4, 6, 6, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [6, 8, 6, 6, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "Bm7": [
-    { "frets": [-1, 2, 4, 2, 3, 2], "fingers": [1, 1, 3, 1, 2, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 0, "toString": 5 }] },
-    { "frets": [-1, 2, 0, 2, 0, 2], "fingers": [0, 1, 0, 2, 0, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 0, 2, 0, 2], "fingers": [0, 1, 0, 2, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 7, 7, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [7, 9, 7, 7, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "Cm7": [
-    { "frets": [-1, 3, 5, 3, 4, 3], "fingers": [1, 1, 3, 1, 2, 1], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 3, 1, 3, 1, 3], "fingers": [0, 2, 1, 3, 1, 4], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [-1, 3, 5, 3, 4, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 10, 8, 8, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 8, "barres": [] }
   ],
   "C#m7": [
-    { "frets": [-1, 4, 6, 4, 5, 4], "fingers": [1, 1, 3, 1, 2, 1], "baseFret": 1, "barres": [{ "fret": 4, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 4, 2, 4, 0, 4], "fingers": [0, 2, 1, 3, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 6, 4, 5, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 4, "barres": [] },
+    { "frets": [9, 11, 9, 9, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 9, "barres": [] }
   ],
   "Dm7": [
-    { "frets": [-1, -1, 0, 2, 1, 1], "fingers": [0, 0, 0, 3, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 1 }] },
-    { "frets": [5, 5, 7, 7, 6, 5], "fingers": [1, 1, 3, 4, 2, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, -1, 0, 2, 1, 1], "fingers": [0, 0, 0, 2, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 4, "toString": 5 }] },
+    { "frets": [-1, 5, 3, 5, 3, 5], "fingers": [0, 2, 1, 3, 1, 4], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 2, "toString": 4 }] },
+    { "frets": [-1, 5, 7, 5, 6, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 5, "barres": [] }
   ],
   "D#m7": [
-    { "frets": [-1, -1, 1, 3, 2, 2], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 1, 3, 2, 2], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 4, 6, 4, 6], "fingers": [0, 2, 1, 3, 1, 4], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [-1, 6, 8, 6, 7, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 6, "barres": [] }
   ],
   "Em7": [
     { "frets": [0, 2, 0, 0, 0, 0], "fingers": [0, 2, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
-    { "frets": [0, 2, 2, 0, 3, 0], "fingers": [0, 2, 3, 0, 4, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 7, 5, 7, 5, 7], "fingers": [0, 2, 1, 3, 1, 4], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [-1, 7, 9, 7, 8, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 7, "barres": [] }
   ],
   "Fm7": [
-    { "frets": [1, 3, 1, 1, 1, 1], "fingers": [1, 3, 1, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [1, 3, 1, 1, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 4, 4], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 6, 8, 6, 8], "fingers": [0, 2, 1, 3, 1, 4], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
   ],
   "F#m7": [
-    { "frets": [2, 4, 2, 2, 2, 2], "fingers": [1, 3, 1, 1, 1, 1], "baseFret": 2, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [2, 0, 2, 2, 2, 0], "fingers": [1, 0, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 5, 5], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 7, 9, 7, 9], "fingers": [0, 2, 1, 3, 1, 4], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
   ],
   "Gm7": [
-    { "frets": [3, 5, 3, 3, 3, 3], "fingers": [1, 3, 1, 1, 1, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [3, 1, 0, 0, 3, 1], "fingers": [3, 1, 0, 0, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [3, 5, 3, 3, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 7, 6, 6], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 5, "barres": [] }
   ],
   "G#m7": [
-    { "frets": [4, 6, 4, 4, 4, 4], "fingers": [1, 3, 1, 1, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, -1, -1, 1, 0, 2], "fingers": [0, 0, 0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 4, 4, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 7, 7], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 6, "barres": [] }
   ],
   "Amaj7": [
     { "frets": [-1, 0, 2, 1, 2, 0], "fingers": [0, 0, 2, 1, 3, 0], "baseFret": 1, "barres": [] },
-    { "frets": [-1, 0, 2, 2, 2, 4], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [5, 7, 6, 6, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 9, 9, 9], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 7, "barres": [] }
   ],
   "A#maj7": [
-    { "frets": [-1, 1, 3, 2, 3, 1], "fingers": [1, 1, 3, 2, 4, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 1, 0, 2, 3, 1], "fingers": [0, 1, 0, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [6, 5, 3, 3, 3, 5], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [6, 8, 7, 7, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "Bmaj7": [
-    { "frets": [-1, 2, 4, 3, 4, 2], "fingers": [1, 1, 3, 2, 4, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 2, 1, 3, 0, 2], "fingers": [0, 2, 1, 4, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 6, 4, 4, 4, 6], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [7, 9, 8, 8, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "Cmaj7": [
     { "frets": [-1, 3, 2, 0, 0, 0], "fingers": [0, 3, 2, 0, 0, 0], "baseFret": 1, "barres": [] },
-    { "frets": [-1, 3, 5, 4, 5, 3], "fingers": [1, 1, 3, 2, 4, 1], "baseFret": 3, "barres": [{ "fret": 3, "fromString": 0, "toString": 5 }] }
+    { "frets": [8, 7, 5, 5, 5, 7], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [8, 10, 9, 9, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 8, "barres": [] }
   ],
   "C#maj7": [
-    { "frets": [-1, 4, 3, 1, 1, 1], "fingers": [0, 4, 3, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 3 }] }
+    { "frets": [-1, 4, 3, 1, 1, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 6, 5, 6, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 4, "barres": [] },
+    { "frets": [9, 8, 6, 6, 6, 8], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
   ],
   "Dmaj7": [
     { "frets": [-1, -1, 0, 2, 2, 2], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
-    { "frets": [-1, -1, 0, 2, 2, 2], "fingers": [0, 0, 0, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 1, "toString": 3 }] }
+    { "frets": [-1, 5, 7, 6, 7, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [10, 9, 7, 7, 7, 9], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
   ],
   "D#maj7": [
-    { "frets": [-1, -1, 1, 3, 3, 3], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 1, 3, 3, 3], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 5, 3, 3, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 6, 8, 7, 8, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 6, "barres": [] }
   ],
   "Emaj7": [
     { "frets": [0, 2, 1, 1, 0, 0], "fingers": [0, 3, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
-    { "frets": [0, 2, 2, 1, 4, 0], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 7, 6, 4, 4, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 7, 9, 8, 9, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 7, "barres": [] }
   ],
   "Fmaj7": [
-    { "frets": [-1, -1, 3, 2, 1, 0], "fingers": [0, 0, 3, 2, 1, 0], "baseFret": 1, "barres": [] },
-    { "frets": [1, 0, 2, 2, 1, 0], "fingers": [1, 0, 2, 3, 1, 0], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] }
+    { "frets": [1, 0, 2, 2, 1, 0], "fingers": [1, 0, 3, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 5, 5], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 5, 5, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 5, "barres": [] }
   ],
   "F#maj7": [
-    { "frets": [2, 1, 3, 3, 2, 1], "fingers": [2, 1, 3, 4, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [2, 1, 3, 3, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 6, 6], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 8, 6, 6, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 6, "barres": [] }
   ],
   "Gmaj7": [
-    { "frets": [3, 2, 0, 0, 0, 2], "fingers": [3, 2, 0, 0, 0, 1], "baseFret": 1, "barres": [] },
-    { "frets": [3, 2, 4, 4, 3, 2], "fingers": [2, 1, 4, 4, 3, 1], "baseFret": 2, "barres": [] }
+    { "frets": [3, 2, 0, 0, 0, 2], "fingers": [3, 1, 0, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 7, 7, 7], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 10, 9, 7, 7, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 7, "barres": [] }
   ],
   "G#maj7": [
-    { "frets": [4, 3, 1, 1, 1, 3], "fingers": [4, 3, 1, 1, 1, 2], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] }
+    { "frets": [-1, -1, -1, 1, 1, 3], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 5, 5, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 8, 8], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 6, "barres": [] }
   ],
   "Asus2": [
-    { "frets": [-1, 0, 2, 2, 0, 0], "fingers": [0, 0, 1, 2, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 0, 2, 2, 0, 0], "fingers": [0, 0, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 4, 5, 5], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 7, 9, 10, 7], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 7, "barres": [] }
   ],
   "A#sus2": [
-    { "frets": [-1, 1, 3, 3, 1, 1], "fingers": [1, 1, 3, 4, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 1, 3, 3, 1, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 3, 3, 3, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, -1, 8, 5, 6, 6], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 5, "barres": [] }
   ],
   "Bsus2": [
-    { "frets": [-1, 2, 4, 4, 2, 2], "fingers": [1, 1, 3, 4, 1, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 2, 4, 4, 2, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 4, 4, 4, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 9, 6, 7, 7], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 6, "barres": [] }
   ],
   "Csus2": [
-    { "frets": [-1, 3, 0, 0, 1, 3], "fingers": [0, 3, 0, 0, 1, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 3, 0, 0, 1, 3], "fingers": [0, 2, 0, 0, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 0, 0, 3, 3], "fingers": [0, 1, 0, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [8, 5, 5, 5, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 5, "barres": [] }
   ],
   "C#sus2": [
-    { "frets": [-1, 4, 1, 1, 2, 4], "fingers": [0, 4, 1, 1, 2, 4], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 3 }] }
+    { "frets": [-1, 4, 1, 1, 2, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 6, 6, 4, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 4, "barres": [] },
+    { "frets": [9, 6, 6, 6, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "Dsus2": [
-    { "frets": [-1, -1, 0, 2, 3, 0], "fingers": [0, 0, 0, 1, 3, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 0, 2, 3, 0], "fingers": [0, 0, 0, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 7, 7, 5, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 5, "barres": [] },
+    { "frets": [10, 7, 7, 7, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "D#sus2": [
-    { "frets": [-1, -1, 1, 3, 4, 1], "fingers": [0, 0, 1, 3, 4, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 1, 3, 4, 1], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 3, 3, 4, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 6, 8, 8, 6, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 6, "barres": [] }
   ],
   "Esus2": [
-    { "frets": [0, 2, 4, 4, 0, 0], "fingers": [0, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 2, 4, 0, 2], "fingers": [0, 0, 1, 3, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 4, 4, 5, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 7, 9, 9, 7, -1], "fingers": [0, 1, 3, 4, 2, 0], "baseFret": 7, "barres": [] }
   ],
   "Fsus2": [
-    { "frets": [1, 3, 3, 0, 1, 1], "fingers": [1, 3, 4, 0, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [1, 3, 3, 0, 1, -1], "fingers": [1, 3, 4, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 6, 3], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 8, 5, 5, 6, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 5, "barres": [] }
   ],
   "F#sus2": [
-    { "frets": [2, 4, 4, 1, 2, 2], "fingers": [1, 3, 4, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, -1, 4, 1, 2, 2], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 7, 4], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 6, 6, 7, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 6, "barres": [] }
   ],
   "Gsus2": [
-    { "frets": [3, 0, 0, 0, 3, 3], "fingers": [1, 0, 0, 0, 2, 3], "baseFret": 1, "barres": [] }
+    { "frets": [3, 0, 0, 0, 3, 3], "fingers": [1, 0, 0, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 7, 8, 5], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 10, 7, 7, 8, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 7, "barres": [] }
   ],
   "G#sus2": [
-    { "frets": [4, 6, 6, 1, 4, 4], "fingers": [1, 3, 4, 1, 1, 1], "baseFret": 4, "barres": [{ "fret": 4, "fromString": 0, "toString": 5 }] }
+    { "frets": [4, 1, 1, 1, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 3, 4, 4], "fingers": [0, 0, 4, 1, 2, 3], "baseFret": 3, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 9, 6], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 6, "barres": [] }
   ],
   "Asus4": [
-    { "frets": [-1, 0, 2, 2, 3, 0], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 0, 2, 2, 3, 0], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 7, 5, 5], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 9, 10, 10], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 7, "barres": [] }
   ],
   "A#sus4": [
-    { "frets": [-1, 1, 3, 3, 4, 1], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 1, 3, 3, 4, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 6, 3, 3, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, -1, 8, 8, 6, 6], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 6, "barres": [] }
   ],
   "Bsus4": [
-    { "frets": [-1, 2, 4, 4, 5, 2], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 2, 2, 4, 0, 2], "fingers": [0, 1, 2, 4, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 7, 4, 4, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 9, 9, 7, 7], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 7, "barres": [] }
   ],
   "Csus4": [
-    { "frets": [-1, 3, 5, 5, 6, 3], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 3, "barres": [{ "fret": 3, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, 3, 3, 0, 1, 1], "fingers": [0, 3, 4, 0, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 3, 0, -1, -1], "fingers": [0, 1, 2, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 8, 5, 5, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 5, "barres": [] }
   ],
   "C#sus4": [
-    { "frets": [-1, 4, 6, 6, 7, 4], "fingers": [1, 1, 2, 3, 4, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 4, 4, 1, 2, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 6, 6, 7, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 4, "barres": [] },
+    { "frets": [9, 9, 6, 6, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "Dsus4": [
-    { "frets": [-1, -1, 0, 2, 3, 3], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 0, 2, 3, 3], "fingers": [0, 0, 0, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 7, 7, 8, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [10, 10, 7, 7, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "D#sus4": [
-    { "frets": [-1, -1, 1, 3, 4, 4], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 1, 3, 4, 4], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 6, 3, 4, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 6, 8, 8, 9, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 6, "barres": [] }
   ],
   "Esus4": [
-    { "frets": [0, 2, 2, 2, 0, 0], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 2, 2, 0, 0], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 4, 5, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 7, 9, 9, 10, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 7, "barres": [] }
   ],
   "Fsus4": [
-    { "frets": [1, 1, 3, 3, 1, 1], "fingers": [1, 1, 3, 4, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, -1, 3, 3, 1, 1], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 6, 6], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 8, 8, 5, 6, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 5, "barres": [] }
   ],
   "F#sus4": [
-    { "frets": [2, 2, 4, 4, 2, 2], "fingers": [1, 1, 3, 4, 1, 1], "baseFret": 2, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [-1, -1, 4, 4, 2, 2], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 7, 7], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 9, 6, 7, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 6, "barres": [] }
   ],
   "Gsus4": [
-    { "frets": [3, 3, 0, 0, 1, 3], "fingers": [3, 4, 0, 0, 1, 2], "baseFret": 1, "barres": [] },
-    { "frets": [3, 3, 5, 5, 3, 3], "fingers": [1, 1, 3, 4, 1, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+    { "frets": [3, 3, 0, 0, 1, 3], "fingers": [2, 3, 0, 0, 1, 4], "baseFret": 1, "barres": [] },
+    { "frets": [3, 3, 0, 0, 3, 3], "fingers": [1, 2, 0, 0, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 7, 8, 8], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 5, "barres": [] }
   ],
   "G#sus4": [
-    { "frets": [4, 4, 1, 1, 2, 4], "fingers": [3, 4, 1, 1, 2, 4], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 3 }] }
+    { "frets": [4, 4, 1, 1, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 6, 4, 4], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 9, 9], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 6, "barres": [] }
   ],
   "Adim": [
-    { "frets": [-1, 0, 1, 2, 1, 5], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 0, 1, 2, 1, -1], "fingers": [0, 0, 1, 3, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 6, 7, 5, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 8, 10, 8], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 7, "barres": [] }
   ],
   "A#dim": [
-    { "frets": [-1, 1, 2, 3, 2, 0], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 1, 2, 3, 2, 0], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 7, 8, 6, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, -1, 8, 9, 11, 9], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 8, "barres": [] }
   ],
   "Bdim": [
-    { "frets": [-1, 2, 3, 4, 3, 1], "fingers": [0, 2, 3, 4, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 3, 4, 3, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 8, 9, 7, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 7, "barres": [] },
+    { "frets": [-1, -1, 9, 10, 12, 10], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 9, "barres": [] }
   ],
   "Cdim": [
-    { "frets": [-1, 3, 4, 5, 4, 2], "fingers": [0, 2, 3, 4, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, -1, 5, 4, 2], "fingers": [0, 0, 0, 3, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 4, 5, 4, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 9, 10, 8, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 8, "barres": [] }
   ],
   "C#dim": [
-    { "frets": [-1, 4, 5, 6, 5, 3], "fingers": [0, 2, 3, 4, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 4, 2, 0, 2, 3], "fingers": [0, 4, 1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 5, 6, 5, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 4, "barres": [] },
+    { "frets": [9, 10, 11, 9, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 9, "barres": [] }
   ],
   "Ddim": [
-    { "frets": [-1, -1, 0, 1, 3, 1], "fingers": [0, 0, 0, 1, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 0, 1, 3, 1], "fingers": [0, 0, 0, 1, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 6, 7, 6, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 5, "barres": [] },
+    { "frets": [10, 11, 12, 10, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 10, "barres": [] }
   ],
   "D#dim": [
-    { "frets": [-1, -1, 1, 2, 4, 2], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 1, 2, 4, 2], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 7, 8, 7, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 6, "barres": [] },
+    { "frets": [11, 12, 13, 11, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 11, "barres": [] }
   ],
   "Edim": [
-    { "frets": [0, 1, 2, 0, 5, 3], "fingers": [0, 1, 2, 0, 4, 3], "baseFret": 1, "barres": [] }
+    { "frets": [0, 1, 2, 0, -1, -1], "fingers": [0, 1, 2, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 2, 3, 5, 3], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 8, 9, 8, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 7, "barres": [] }
   ],
   "Fdim": [
-    { "frets": [1, 2, 3, 1, 0, 4], "fingers": [1, 2, 3, 1, 0, 4], "baseFret": 1, "barres": [] }
+    { "frets": [1, 2, 3, 1, 0, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 4, 0, 4], "fingers": [0, 0, 1, 2, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 9, 10, 9, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 8, "barres": [] }
   ],
   "F#dim": [
-    { "frets": [2, 3, 4, 2, 1, 5], "fingers": [2, 3, 4, 2, 1, 4], "baseFret": 1, "barres": [] }
+    { "frets": [2, 3, 4, 2, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 5, 7, 5], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 10, 11, 10, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 9, "barres": [] }
   ],
   "Gdim": [
-    { "frets": [3, 4, 5, 3, 2, 6], "fingers": [2, 3, 4, 2, 1, 4], "baseFret": 2, "barres": [] }
+    { "frets": [3, 4, 5, 3, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 6, 8, 6], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 10, 11, 12, 11, -1], "fingers": [0, 1, 2, 4, 3, 0], "baseFret": 10, "barres": [] }
   ],
   "G#dim": [
-    { "frets": [4, 5, 6, 4, 0, 7], "fingers": [2, 3, 4, 2, 0, 4], "baseFret": 4, "barres": [] }
+    { "frets": [4, 2, 0, 4, 3, -1], "fingers": [3, 1, 0, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [4, 5, 6, 4, -1, -1], "fingers": [1, 3, 4, 2, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 7, 9, 7], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 6, "barres": [] }
   ],
   "Aaug": [
-    { "frets": [-1, 0, 3, 2, 2, 1], "fingers": [0, 0, 4, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 0, 3, 2, 2, 1], "fingers": [0, 0, 4, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [5, 4, 3, -1, -1, -1], "fingers": [3, 2, 1, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 6, 6, 5], "fingers": [0, 0, 4, 2, 3, 1], "baseFret": 5, "barres": [] }
   ],
   "A#aug": [
-    { "frets": [-1, 1, 4, 3, 3, 2], "fingers": [0, 1, 4, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 1, 0, 3, 3, 2], "fingers": [0, 1, 0, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [6, 5, 4, -1, -1, -1], "fingers": [3, 2, 1, 0, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 8, 7, 7, 6], "fingers": [0, 0, 4, 2, 3, 1], "baseFret": 6, "barres": [] }
   ],
   "Baug": [
-    { "frets": [-1, 2, 5, 4, 4, 3], "fingers": [0, 1, 4, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 1, 0, 0, 3], "fingers": [0, 2, 1, 0, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 4, 4, 3], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [7, 6, 5, -1, -1, -1], "fingers": [3, 2, 1, 0, 0, 0], "baseFret": 5, "barres": [] }
   ],
   "Caug": [
-    { "frets": [-1, 3, 2, 1, 1, 0], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 3, 2, 1, 1, 0], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 5, 5, 4], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 6, -1, -1, -1], "fingers": [3, 2, 1, 0, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "C#aug": [
-    { "frets": [-1, 4, 3, 2, 2, 1], "fingers": [0, 4, 3, 1, 2, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 4, 3, 2, 2, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 6, 6, 5], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 5, "barres": [] },
+    { "frets": [9, 8, 7, -1, -1, -1], "fingers": [3, 2, 1, 0, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "Daug": [
-    { "frets": [-1, -1, 0, 3, 3, 2], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 0, 3, 3, 2], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 7, 7, 6], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 6, "barres": [] },
+    { "frets": [10, 9, 8, -1, -1, -1], "fingers": [3, 2, 1, 0, 0, 0], "baseFret": 8, "barres": [] }
   ],
   "D#aug": [
-    { "frets": [-1, -1, 1, 0, 0, 3], "fingers": [0, 0, 1, 0, 0, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 1, 0, 0, 3], "fingers": [0, 0, 1, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 5, 4, 4, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, -1, 8, 8, 7], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 7, "barres": [] }
   ],
   "Eaug": [
-    { "frets": [0, 3, 2, 1, 1, 0], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 1, "barres": [] }
+    { "frets": [0, 3, 2, 1, 1, 0], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 5, 5, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, -1, 9, 9, 8], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 8, "barres": [] }
   ],
   "Faug": [
-    { "frets": [-1, 0, 3, 2, 2, 1], "fingers": [0, 0, 4, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [1, 0, 3, 2, 2, -1], "fingers": [1, 0, 4, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 6, 6, 5], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 8, 7, 6, 6, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 6, "barres": [] }
   ],
   "F#aug": [
-    { "frets": [-1, 1, 4, 3, 3, 2], "fingers": [0, 1, 4, 2, 3, 1], "baseFret": 1, "barres": [] }
+    { "frets": [2, 1, 0, 3, 3, -1], "fingers": [2, 1, 0, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 3, 3, -1], "fingers": [0, 0, 3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 7, 7, -1], "fingers": [0, 4, 3, 1, 2, 0], "baseFret": 7, "barres": [] }
   ],
   "Gaug": [
-    { "frets": [3, 2, 1, 0, 0, 3], "fingers": [4, 3, 2, 0, 0, 1], "baseFret": 1, "barres": [] }
+    { "frets": [3, 2, 1, 0, 0, 3], "fingers": [3, 2, 1, 0, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 4, 4, 3], "fingers": [0, 0, 4, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 8, 8, 7], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 5, "barres": [] }
   ],
   "G#aug": [
-    { "frets": [4, 3, 2, 1, 1, 4], "fingers": [4, 3, 2, 1, 1, 4], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, -1, 1, 1, 0], "fingers": [0, 0, 0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 5, 5, 4], "fingers": [0, 0, 4, 2, 3, 1], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 9, 9, 8], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 6, "barres": [] }
   ],
   "A5": [
-    { "frets": [-1, 0, 2, 2, -1, -1], "fingers": [0, 0, 1, 2, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 0, 2, 2, -1, -1], "fingers": [0, 0, 1, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 7, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 9, 10, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 7, "barres": [] }
   ],
   "A#5": [
-    { "frets": [-1, 1, 3, 3, -1, -1], "fingers": [0, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 1, 3, 3, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 3, 6, 6], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 3, "barres": [] },
+    { "frets": [6, 8, 8, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 6, "barres": [] }
   ],
   "B5": [
-    { "frets": [-1, 2, 4, 4, -1, -1], "fingers": [0, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 2, 4, 4, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 4, 7, 7], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 4, "barres": [] },
+    { "frets": [7, 9, 9, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "C5": [
-    { "frets": [-1, 3, 5, 5, -1, -1], "fingers": [0, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 3, 5, 5, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 5, 8, 8], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 5, "barres": [] },
+    { "frets": [8, 10, 10, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 8, "barres": [] }
   ],
   "C#5": [
-    { "frets": [-1, 4, 6, 6, -1, -1], "fingers": [0, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, 4, 6, 6, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, -1, 6, 9, 9], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 6, "barres": [] },
+    { "frets": [9, 11, 11, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 9, "barres": [] }
   ],
   "D5": [
-    { "frets": [-1, -1, 0, 2, 3, -1], "fingers": [0, 0, 0, 1, 2, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 0, 2, 3, -1], "fingers": [0, 0, 0, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 7, 7, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, -1, 7, 10, 10], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 7, "barres": [] }
   ],
   "D#5": [
-    { "frets": [-1, -1, 1, 3, 4, -1], "fingers": [0, 0, 1, 3, 4, 0], "baseFret": 1, "barres": [] }
+    { "frets": [-1, -1, 1, 3, 4, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 8, 8, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, -1, -1, 8, 11, 11], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 8, "barres": [] }
   ],
   "E5": [
-    { "frets": [0, 2, 2, -1, -1, -1], "fingers": [0, 1, 2, 0, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [0, 2, 2, -1, -1, -1], "fingers": [0, 1, 3, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [0, 2, 2, 4, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 9, 9, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 7, "barres": [] }
   ],
   "F5": [
-    { "frets": [1, 3, 3, -1, -1, -1], "fingers": [1, 3, 4, 0, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [1, 3, 3, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 6, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 8, 10, 10, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 8, "barres": [] }
   ],
   "F#5": [
-    { "frets": [2, 4, 4, -1, -1, -1], "fingers": [1, 3, 4, 0, 0, 0], "baseFret": 2, "barres": [] }
+    { "frets": [2, 4, 4, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 7, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 11, 11, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 9, "barres": [] }
   ],
   "G5": [
-    { "frets": [3, 5, 5, -1, -1, -1], "fingers": [1, 3, 4, 0, 0, 0], "baseFret": 3, "barres": [] },
-    { "frets": [3, -1, 0, -1, -1, -1], "fingers": [1, 0, 0, 0, 0, 0], "baseFret": 1, "barres": [] }
+    { "frets": [3, 5, 5, -1, -1, -1], "fingers": [1, 3, 4, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 7, 8, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 10, 12, 12, -1, -1], "fingers": [0, 1, 2, 3, 0, 0], "baseFret": 10, "barres": [] }
   ],
   "G#5": [
-    { "frets": [4, 6, 6, -1, -1, -1], "fingers": [1, 3, 4, 0, 0, 0], "baseFret": 4, "barres": [] }
+    { "frets": [-1, -1, -1, 1, 4, 4], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 6, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 9, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 6, "barres": [] }
+  ],
+  "A/C#": [
+    { "frets": [-1, 4, 2, 2, 2, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 6, 5, 5], "fingers": [0, 0, 0, 3, 1, 2], "baseFret": 5, "barres": [] }
+  ],
+  "A/E": [
+    { "frets": [0, 0, 2, 2, 2, 0], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 6, 5, -1], "fingers": [0, 3, 4, 2, 1, 0], "baseFret": 5, "barres": [] }
+  ],
+  "A/G#": [
+    { "frets": [4, 4, 2, 2, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 6, 5, 5], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 5, "barres": [] }
+  ],
+  "A/G": [
+    { "frets": [3, 0, 2, 0, 2, 0], "fingers": [3, 0, 1, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 6, 5, 5], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 5, "barres": [] }
+  ],
+  "Am/C": [
+    { "frets": [-1, 3, 2, 2, 1, 0], "fingers": [0, 4, 2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 5, 5, 5], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Am/E": [
+    { "frets": [0, 0, 2, 2, 1, 0], "fingers": [0, 0, 2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 5, 5, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 5, "barres": [] }
+  ],
+  "Am/G": [
+    { "frets": [3, 0, 2, 2, 1, 0], "fingers": [4, 0, 2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 5, 5, 5], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] }
+  ],
+  "A#/D": [
+    { "frets": [-1, -1, 0, 3, 3, 1], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 3, 3, 3, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 1, "barres": [] }
+  ],
+  "A#/F": [
+    { "frets": [1, 1, 0, 3, 3, -1], "fingers": [1, 2, 0, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 3, 3, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] }
+  ],
+  "A#/A": [
+    { "frets": [-1, 0, 0, 3, 3, 1], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 0, 3, 3, 3, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] }
+  ],
+  "A#/G#": [
+    { "frets": [4, 1, 3, 1, 3, 1], "fingers": [4, 1, 2, 1, 3, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [4, 5, 3, 3, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "A#m/C#": [
+    { "frets": [-1, 4, 3, 3, 2, -1], "fingers": [0, 4, 2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 6, 6, 6], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 6, "barres": [] }
+  ],
+  "A#m/F": [
+    { "frets": [-1, -1, 3, 3, 2, 1], "fingers": [0, 0, 3, 4, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 6, 6, 6], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 3, "barres": [] }
+  ],
+  "A#m/G#": [
+    { "frets": [4, 1, 3, 1, 2, 1], "fingers": [4, 1, 3, 1, 2, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [4, 4, 3, 3, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "B/D#": [
+    { "frets": [-1, -1, 1, 4, 4, 2], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 4, 4, 4, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 4, "barres": [] }
+  ],
+  "B/F#": [
+    { "frets": [2, 2, 1, -1, -1, -1], "fingers": [2, 3, 1, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 4, 4, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] }
+  ],
+  "B/A#": [
+    { "frets": [-1, 1, 1, 3, 0, 2], "fingers": [0, 1, 2, 4, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 6, 4, 4, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 4, "barres": [] }
+  ],
+  "B/A": [
+    { "frets": [-1, 0, 1, 2, 0, 2], "fingers": [0, 0, 1, 2, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 6, 4, 4, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 4, "barres": [] }
+  ],
+  "Bm/D": [
+    { "frets": [-1, 5, 4, 4, 3, -1], "fingers": [0, 4, 2, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 7, 7, 7], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 7, "barres": [] }
+  ],
+  "Bm/F#": [
+    { "frets": [2, 2, 0, -1, -1, -1], "fingers": [1, 2, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 7, 7, 7], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 4, "barres": [] }
+  ],
+  "Bm/A": [
+    { "frets": [-1, 0, 0, 2, 0, 2], "fingers": [0, 0, 0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [5, 5, 4, 4, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "C/E": [
+    { "frets": [0, 3, 2, 0, 1, 0], "fingers": [0, 3, 2, 0, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 5, 5, 5, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 5, "barres": [] }
+  ],
+  "C/G": [
+    { "frets": [3, 3, 2, 0, 1, 0], "fingers": [3, 4, 2, 0, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 5, 5, 3], "fingers": [0, 0, 2, 3, 4, 1], "baseFret": 1, "barres": [] }
+  ],
+  "C/B": [
+    { "frets": [-1, 2, 2, 0, 1, 0], "fingers": [0, 2, 3, 0, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 7, 5, 5, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "C/A#": [
+    { "frets": [-1, 1, 2, 0, 1, 0], "fingers": [0, 1, 3, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 7, 5, 5, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "Cm/D#": [
+    { "frets": [-1, -1, 1, 0, 1, 3], "fingers": [0, 0, 1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 5, 5, 4, -1], "fingers": [0, 4, 2, 3, 1, 0], "baseFret": 4, "barres": [] }
+  ],
+  "Cm/G": [
+    { "frets": [3, 3, 1, 0, 1, -1], "fingers": [3, 4, 1, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 5, 4, 3], "fingers": [0, 0, 3, 4, 2, 1], "baseFret": 1, "barres": [] }
+  ],
+  "Cm/A#": [
+    { "frets": [-1, 1, 1, 0, 1, 3], "fingers": [0, 1, 2, 0, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [6, 6, 5, 5, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "C#/F": [
+    { "frets": [-1, -1, 3, 1, 2, 1], "fingers": [0, 0, 4, 1, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 6, 6, 4], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 3, "barres": [] }
+  ],
+  "C#/G#": [
+    { "frets": [-1, -1, -1, 1, 2, 1], "fingers": [0, 0, 0, 1, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 6, 6, 4], "fingers": [0, 0, 2, 3, 4, 1], "baseFret": 4, "barres": [] }
+  ],
+  "C#/C": [
+    { "frets": [-1, 3, 3, 1, 2, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 6, 6, 6, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 3, "barres": [] }
+  ],
+  "C#/B": [
+    { "frets": [-1, 2, 3, 1, 2, -1], "fingers": [0, 2, 4, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 8, 6, 6, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "C#m/E": [
+    { "frets": [-1, -1, 2, 1, 2, 0], "fingers": [0, 0, 2, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 6, 5, -1], "fingers": [0, 4, 2, 3, 1, 0], "baseFret": 5, "barres": [] }
+  ],
+  "C#m/G#": [
+    { "frets": [-1, -1, -1, 1, 2, 0], "fingers": [0, 0, 0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 6, 5, 4], "fingers": [0, 0, 3, 4, 2, 1], "baseFret": 4, "barres": [] }
+  ],
+  "C#m/B": [
+    { "frets": [-1, 2, 2, 1, 2, 0], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 7, 6, 6, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "D/F#": [
+    { "frets": [2, 0, 0, 2, 3, 2], "fingers": [1, 0, 0, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 7, 7, 5], "fingers": [0, 0, 1, 3, 4, 2], "baseFret": 4, "barres": [] }
+  ],
+  "D/A": [
+    { "frets": [-1, 0, 0, 2, 3, 2], "fingers": [0, 0, 0, 1, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 7, 7, 5], "fingers": [0, 0, 2, 3, 4, 1], "baseFret": 5, "barres": [] }
+  ],
+  "D/C#": [
+    { "frets": [-1, 4, 4, 2, 3, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 7, 7, 7, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 4, "barres": [] }
+  ],
+  "D/C": [
+    { "frets": [-1, 3, 0, 2, 1, 2], "fingers": [0, 4, 0, 2, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 4, 5, 3, 5], "fingers": [0, 1, 2, 3, 1, 4], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 1, "toString": 4 }] }
+  ],
+  "Dm/F": [
+    { "frets": [1, 0, 0, 2, 3, 1], "fingers": [1, 0, 0, 3, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 7, 6, -1], "fingers": [0, 4, 2, 3, 1, 0], "baseFret": 6, "barres": [] }
+  ],
+  "Dm/A": [
+    { "frets": [-1, 0, 0, 2, 3, 1], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [5, 5, 3, -1, -1, -1], "fingers": [2, 3, 1, 0, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "Dm/C": [
+    { "frets": [-1, 3, 0, 2, 1, 1], "fingers": [0, 4, 0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 3, 5, 3, 5], "fingers": [0, 1, 1, 2, 1, 3], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 1, "toString": 4 }] }
+  ],
+  "D#/G": [
+    { "frets": [3, 1, 1, 0, -1, -1], "fingers": [3, 1, 2, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 3, 4, 3], "fingers": [0, 0, 4, 1, 3, 2], "baseFret": 1, "barres": [] }
+  ],
+  "D#/A#": [
+    { "frets": [-1, 1, 1, 0, -1, -1], "fingers": [0, 1, 2, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 3, 4, 3], "fingers": [0, 0, 0, 1, 3, 2], "baseFret": 1, "barres": [] }
+  ],
+  "D#/D": [
+    { "frets": [-1, 5, 5, 3, 4, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 8, 8, 8, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 5, "barres": [] }
+  ],
+  "D#/C#": [
+    { "frets": [-1, 4, 5, 3, 4, -1], "fingers": [0, 2, 4, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 10, 8, 8, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "D#m/F#": [
+    { "frets": [2, 1, 1, 3, -1, -1], "fingers": [3, 1, 2, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 3, 4, -1], "fingers": [0, 0, 2, 1, 3, 0], "baseFret": 1, "barres": [] }
+  ],
+  "D#m/A#": [
+    { "frets": [-1, -1, -1, 3, 4, 2], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [6, 6, 4, -1, -1, -1], "fingers": [2, 3, 1, 0, 0, 0], "baseFret": 4, "barres": [] }
+  ],
+  "D#m/C#": [
+    { "frets": [-1, 4, 4, 3, 4, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 9, 8, 8, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "E/G#": [
+    { "frets": [-1, -1, -1, 1, 0, 0], "fingers": [0, 0, 0, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 4, 5, 4], "fingers": [0, 0, 4, 1, 3, 2], "baseFret": 4, "barres": [] }
+  ],
+  "E/B": [
+    { "frets": [-1, 2, 2, 1, 0, 0], "fingers": [0, 2, 3, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 4, 5, 4], "fingers": [0, 0, 0, 1, 3, 2], "baseFret": 1, "barres": [] }
+  ],
+  "E/D#": [
+    { "frets": [-1, -1, 1, 1, 0, 0], "fingers": [0, 0, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 6, 4, 5, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 4, "barres": [] }
+  ],
+  "E/D": [
+    { "frets": [-1, -1, 0, 1, 0, 0], "fingers": [0, 0, 0, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 6, 4, 5, -1], "fingers": [0, 2, 4, 1, 3, 0], "baseFret": 4, "barres": [] }
+  ],
+  "Em/G": [
+    { "frets": [-1, -1, -1, 0, 0, 0], "fingers": [0, 0, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 2, 2, 0, 0, 0], "fingers": [3, 1, 2, 0, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "Em/B": [
+    { "frets": [-1, 2, 2, 0, 0, 0], "fingers": [0, 1, 2, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 7, 5, -1, -1, -1], "fingers": [2, 3, 1, 0, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "Em/D": [
+    { "frets": [-1, -1, 0, 0, 0, 0], "fingers": [0, 0, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 5, 4, 5, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 1, "barres": [] }
+  ],
+  "F/A": [
+    { "frets": [-1, 0, 3, 2, 1, 1], "fingers": [0, 0, 4, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [5, 3, 3, 5, -1, -1], "fingers": [3, 1, 2, 4, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "F/C": [
+    { "frets": [-1, 3, 3, 2, 1, -1], "fingers": [0, 3, 4, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 5, 6, 5], "fingers": [0, 0, 0, 1, 3, 2], "baseFret": 5, "barres": [] }
+  ],
+  "F/E": [
+    { "frets": [0, 0, 3, 2, 1, 0], "fingers": [0, 0, 3, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 5, 6, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 5, "barres": [] }
+  ],
+  "F/D#": [
+    { "frets": [-1, -1, 1, 2, 1, 1], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 7, 5, 6, -1], "fingers": [0, 2, 4, 1, 3, 0], "baseFret": 5, "barres": [] }
+  ],
+  "Fm/G#": [
+    { "frets": [-1, -1, -1, 1, 1, 1], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [4, 3, 3, 5, -1, -1], "fingers": [3, 1, 2, 4, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "Fm/C": [
+    { "frets": [-1, 3, 3, 1, 1, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 5, 6, 4], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 4, "barres": [] }
+  ],
+  "Fm/D#": [
+    { "frets": [-1, -1, 1, 1, 1, 1], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 6, 5, 6, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 5, "barres": [] }
+  ],
+  "F#/A#": [
+    { "frets": [-1, -1, -1, 3, 2, 2], "fingers": [0, 0, 0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [6, 4, 4, 6, -1, -1], "fingers": [3, 1, 2, 4, 0, 0], "baseFret": 4, "barres": [] }
+  ],
+  "F#/C#": [
+    { "frets": [-1, 4, 4, 3, 2, -1], "fingers": [0, 3, 4, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 6, 7, 6], "fingers": [0, 0, 0, 1, 3, 2], "baseFret": 6, "barres": [] }
+  ],
+  "F#/F": [
+    { "frets": [-1, -1, 3, 3, 2, 2], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 8, 6, 7, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 6, "barres": [] }
+  ],
+  "F#/E": [
+    { "frets": [-1, -1, 2, 3, 2, 2], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 8, 6, 7, -1], "fingers": [0, 2, 4, 1, 3, 0], "baseFret": 6, "barres": [] }
+  ],
+  "F#m/A": [
+    { "frets": [-1, -1, -1, 2, 2, 2], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 4, 4, 6, -1, -1], "fingers": [3, 1, 2, 4, 0, 0], "baseFret": 4, "barres": [] }
+  ],
+  "F#m/C#": [
+    { "frets": [-1, 4, 4, 2, 2, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 6, 7, 5], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 5, "barres": [] }
+  ],
+  "F#m/E": [
+    { "frets": [0, 0, 2, 2, 2, 2], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 6, 7, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 6, "barres": [] }
+  ],
+  "G/B": [
+    { "frets": [-1, 2, 0, 0, 3, 3], "fingers": [0, 1, 0, 0, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 5, 7, -1, -1], "fingers": [3, 1, 2, 4, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "G/D": [
+    { "frets": [-1, -1, 0, 0, 0, -1], "fingers": [0, 0, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 0, 0, 0, 3], "fingers": [0, 0, 0, 0, 0, 1], "baseFret": 1, "barres": [] }
+  ],
+  "G/F#": [
+    { "frets": [2, 2, 0, 0, 0, 2], "fingers": [1, 2, 0, 0, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 9, 7, 8, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 7, "barres": [] }
+  ],
+  "G/F": [
+    { "frets": [1, 2, 0, 0, 0, 1], "fingers": [1, 3, 0, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 4, 3, 3], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Gm/A#": [
+    { "frets": [-1, 1, 0, 0, 3, 3], "fingers": [0, 1, 0, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 3, 3, 3], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Gm/D": [
+    { "frets": [-1, -1, 0, 3, 3, 3], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 7, 8, 6], "fingers": [0, 0, 0, 2, 3, 1], "baseFret": 6, "barres": [] }
+  ],
+  "Gm/F": [
+    { "frets": [1, 1, 0, 0, 3, 1], "fingers": [1, 2, 0, 0, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 3, 3, 3], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] }
+  ],
+  "G#/C": [
+    { "frets": [-1, 3, 1, 1, 1, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 5, 4, 4], "fingers": [0, 0, 0, 3, 1, 2], "baseFret": 1, "barres": [] }
+  ],
+  "G#/D#": [
+    { "frets": [-1, -1, 1, 1, 1, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 6, 5, 4, -1], "fingers": [0, 3, 4, 2, 1, 0], "baseFret": 4, "barres": [] }
+  ],
+  "G#/G": [
+    { "frets": [3, 3, 1, 1, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 5, 4, 4], "fingers": [0, 0, 3, 4, 1, 2], "baseFret": 1, "barres": [] }
+  ],
+  "G#/F#": [
+    { "frets": [2, 3, 1, 1, -1, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 5, 4, 4], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#m/B": [
+    { "frets": [-1, 2, 1, 1, 0, -1], "fingers": [0, 3, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 4, 4, 4], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#m/D#": [
+    { "frets": [-1, -1, 1, 1, 0, -1], "fingers": [0, 0, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 6, 4, 4, -1], "fingers": [0, 3, 4, 1, 2, 0], "baseFret": 4, "barres": [] }
+  ],
+  "G#m/F#": [
+    { "frets": [2, 2, 1, 1, 0, -1], "fingers": [3, 4, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 4, 4, 4], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] }
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,14 @@ export default [
     },
   },
   {
+    // tools/ scripts run under plain `node` with type stripping, which cannot
+    // resolve @klank/* workspace aliases — they import lib sources relatively
+    files: ['tools/**/*.ts'],
+    rules: {
+      '@nx/enforce-module-boundaries': 'off',
+    },
+  },
+  {
     files: [
       '**/*.ts',
       '**/*.tsx',

--- a/libs/platform-api/src/lib/chord-correctness.spec.ts
+++ b/libs/platform-api/src/lib/chord-correctness.spec.ts
@@ -2,52 +2,97 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { getInvalidNotes, parseChordKey, GUITAR_TUNING, BASS_TUNING } from './chord-theory.js'
-import type { ChordDiagramMap } from './chord-diagrams.js'
+import {
+  CHORD_INTERVALS,
+  expectedChordKeys,
+  findDuplicateVariants,
+  getInvalidNotes,
+  getRequiredPitches,
+  getVariantNotes,
+  parseChordKey,
+  pitchName,
+  validateChordVariant,
+  GUITAR_TUNING,
+  BASS_TUNING,
+} from './chord-theory.js'
+import type { ChordDiagramMap, Instrument } from './chord-diagrams.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const GUITAR_PATH = resolve(__dirname, '../../../../apps/klank/public/chords-guitar.json')
-const BASS_PATH   = resolve(__dirname, '../../../../apps/klank/public/chords-bass.json')
+const DATA: Record<Instrument, { path: string; tuning: readonly number[] }> = {
+  guitar: {
+    path: resolve(__dirname, '../../../../apps/klank/public/chords-guitar.json'),
+    tuning: GUITAR_TUNING,
+  },
+  bass: {
+    path: resolve(__dirname, '../../../../apps/klank/public/chords-bass.json'),
+    tuning: BASS_TUNING,
+  },
+}
+const INSTRUMENTS = Object.keys(DATA) as Instrument[]
 
-function loadMap(path: string): ChordDiagramMap {
-  return JSON.parse(readFileSync(path, 'utf-8')) as ChordDiagramMap
+function loadMap(instrument: Instrument): ChordDiagramMap {
+  return JSON.parse(readFileSync(DATA[instrument].path, 'utf-8')) as ChordDiagramMap
 }
 
-function auditMap(map: ChordDiagramMap, tuning: readonly number[]): string[] {
-  const failures: string[] = []
-  for (const [key, variants] of Object.entries(map)) {
-    if (!parseChordKey(key)) continue  // skip unrecognised quality — separate guard
-    for (const [i, variant] of variants.entries()) {
-      const errors = getInvalidNotes(key, variant, tuning)
-      if (errors.length > 0) {
-        failures.push(
-          `${key}[${i}] frets=${JSON.stringify(variant.frets)}: ` +
-          `non-chord note(s) ${errors.map((e) => e.name).join(', ')}`,
-        )
+describe.each(INSTRUMENTS)('%s chord data', (instrument) => {
+  const map = loadMap(instrument)
+
+  it('defines exactly the expected chord keys, in order', () => {
+    expect(Object.keys(map)).toEqual(expectedChordKeys())
+  })
+
+  it('has 1 to 4 variants per key with no duplicates', () => {
+    for (const [key, variants] of Object.entries(map)) {
+      expect(variants.length, `${key} variant count`).toBeGreaterThanOrEqual(1)
+      expect(variants.length, `${key} variant count`).toBeLessThanOrEqual(4)
+      expect(findDuplicateVariants(variants), `${key} duplicates`).toEqual([])
+    }
+  })
+
+  it('uses only notes belonging to each chord', () => {
+    const failures: string[] = []
+    for (const [key, variants] of Object.entries(map)) {
+      for (const [i, variant] of variants.entries()) {
+        const errors = getInvalidNotes(key, variant, DATA[instrument].tuning)
+        if (errors.length > 0) {
+          failures.push(
+            `${key}[${i}] frets=${JSON.stringify(variant.frets)}: ` +
+              `non-chord note(s) ${errors.map((e) => e.name).join(', ')}`,
+          )
+        }
       }
     }
-  }
-  return failures
-}
-
-describe('chord data correctness', () => {
-  it('all guitar chord variants use only notes belonging to the chord', () => {
-    const failures = auditMap(loadMap(GUITAR_PATH), GUITAR_TUNING)
     expect(failures, failures.join('\n')).toHaveLength(0)
   })
 
-  it('all bass chord variants use only notes belonging to the chord', () => {
-    const failures = auditMap(loadMap(BASS_PATH), BASS_TUNING)
+  it('every triad variant is complete — all chord tones present', () => {
+    const failures: string[] = []
+    for (const [key, variants] of Object.entries(map)) {
+      const parsed = parseChordKey(key)
+      if (!parsed || CHORD_INTERVALS[parsed.quality].length === 4) continue
+      for (const [i, variant] of variants.entries()) {
+        const sounded = getVariantNotes(variant, DATA[instrument].tuning)
+        const missing = [...getRequiredPitches(parsed)].filter((p) => !sounded.has(p))
+        if (missing.length > 0) {
+          failures.push(
+            `${key}[${i}] frets=${JSON.stringify(variant.frets)}: ` +
+              `missing tone(s) ${missing.map(pitchName).join(', ')}`,
+          )
+        }
+      }
+    }
     expect(failures, failures.join('\n')).toHaveLength(0)
   })
 
-  it('every chord key is a known root + quality combination', () => {
-    const unknown: string[] = []
-    for (const path of [GUITAR_PATH, BASS_PATH]) {
-      for (const key of Object.keys(loadMap(path))) {
-        if (!parseChordKey(key)) unknown.push(key)
+  it('every variant passes the full validator', () => {
+    const failures: string[] = []
+    for (const [key, variants] of Object.entries(map)) {
+      for (const [i, variant] of variants.entries()) {
+        for (const { rule, message } of validateChordVariant(key, variant, instrument)) {
+          failures.push(`${key}[${i}] frets=${JSON.stringify(variant.frets)} ${rule}: ${message}`)
+        }
       }
     }
-    expect(unknown, `Unknown chord keys: ${unknown.join(', ')}`).toHaveLength(0)
+    expect(failures, failures.join('\n')).toHaveLength(0)
   })
 })

--- a/libs/platform-api/src/lib/chord-diagrams.spec.ts
+++ b/libs/platform-api/src/lib/chord-diagrams.spec.ts
@@ -42,14 +42,13 @@ describe('normalizeChordKey', () => {
     )
   })
 
-  it('strips slash-bass note for any chord/bass combination', () => {
+  it('preserves the slash-bass note for any chord/bass combination', () => {
     fc.assert(
       fc.property(
         chordNameArb,
         fc.constantFrom('G', 'B', 'D', 'F', 'A', 'C#'),
         (chord, bass) => {
-          const result = normalizeChordKey(`${chord}/${bass}`)
-          expect(result).not.toContain('/')
+          expect(normalizeChordKey(`${chord}/${bass}`)).toBe(`${chord}/${bass}`)
         },
       ),
     )
@@ -60,6 +59,13 @@ describe('normalizeChordKey', () => {
       expect(normalizeChordKey(flat)).toBe(sharp)
       expect(normalizeChordKey(`${flat}m`)).toBe(`${sharp}m`)
       expect(normalizeChordKey(`${flat}maj7`)).toBe(`${sharp}maj7`)
+    }
+  })
+
+  it('maps flat bass notes to their sharp equivalents', () => {
+    for (const [flat, sharp] of FLAT_PAIRS) {
+      expect(normalizeChordKey(`C/${flat}`)).toBe(`C/${sharp}`)
+      expect(normalizeChordKey(`${flat}m/${flat}`)).toBe(`${sharp}m/${sharp}`)
     }
   })
 
@@ -92,7 +98,8 @@ describe('lookupChordDiagram', () => {
     const map: ChordDiagramMap = { Am: [makeVariant()] }
     fc.assert(
       fc.property(
-        fc.string({ maxLength: 30 }).filter((s) => !['Am', 'A#m'].includes(s)),
+        // exclude anything that legitimately resolves to "Am", incl. slash fallback
+        fc.string({ maxLength: 30 }).filter((s) => normalizeChordKey(s).split('/')[0] !== 'Am'),
         (name) => {
           expect(lookupChordDiagram(map, name)).toHaveLength(0)
         },
@@ -107,11 +114,13 @@ describe('lookupChordDiagram', () => {
     expect(lookupChordDiagram(map, 'A#')).toEqual([variant])
   })
 
-  it('ignores slash bass notes', () => {
-    const variant = makeVariant()
-    const map: ChordDiagramMap = { Am: [variant] }
-    expect(lookupChordDiagram(map, 'Am/C')).toEqual([variant])
-    expect(lookupChordDiagram(map, 'Am/G')).toEqual([variant])
+  it('prefers the exact slash key and falls back to the plain root chord', () => {
+    const plain = makeVariant()
+    const slash = makeVariant()
+    const map: ChordDiagramMap = { Am: [plain], 'Am/G': [slash] }
+    expect(lookupChordDiagram(map, 'Am/G')).toEqual([slash])
+    expect(lookupChordDiagram(map, 'Am/C')).toEqual([plain])
+    expect(lookupChordDiagram(map, 'Am/Gb')).toEqual([plain])
   })
 
   it('returns the exact array stored in the map without copying', () => {

--- a/libs/platform-api/src/lib/chord-diagrams.spec.ts
+++ b/libs/platform-api/src/lib/chord-diagrams.spec.ts
@@ -54,19 +54,14 @@ describe('normalizeChordKey', () => {
     )
   })
 
-  it('maps all flat roots to their sharp equivalents', () => {
-    for (const [flat, sharp] of FLAT_PAIRS) {
-      expect(normalizeChordKey(flat)).toBe(sharp)
-      expect(normalizeChordKey(`${flat}m`)).toBe(`${sharp}m`)
-      expect(normalizeChordKey(`${flat}maj7`)).toBe(`${sharp}maj7`)
-    }
-  })
-
-  it('maps flat bass notes to their sharp equivalents', () => {
-    for (const [flat, sharp] of FLAT_PAIRS) {
-      expect(normalizeChordKey(`C/${flat}`)).toBe(`C/${sharp}`)
-      expect(normalizeChordKey(`${flat}m/${flat}`)).toBe(`${sharp}m/${sharp}`)
-    }
+  it('maps flat roots and flat bass notes to their sharp equivalents, for any suffix', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...FLAT_PAIRS), suffixArb, fc.constantFrom(...FLAT_PAIRS), ([flatRoot, sharpRoot], suffix, [flatBass, sharpBass]) => {
+        expect(normalizeChordKey(`${flatRoot}${suffix}`)).toBe(`${sharpRoot}${suffix}`)
+        expect(normalizeChordKey(`${flatRoot}${suffix}/${flatBass}`)).toBe(`${sharpRoot}${suffix}/${sharpBass}`)
+        expect(normalizeChordKey(`${flatRoot}${suffix}/${sharpBass}`)).toBe(`${sharpRoot}${suffix}/${sharpBass}`)
+      }),
+    )
   })
 
   it('leaves sharp roots unchanged', () => {
@@ -115,12 +110,16 @@ describe('lookupChordDiagram', () => {
   })
 
   it('prefers the exact slash key and falls back to the plain root chord', () => {
-    const plain = makeVariant()
-    const slash = makeVariant()
-    const map: ChordDiagramMap = { Am: [plain], 'Am/G': [slash] }
-    expect(lookupChordDiagram(map, 'Am/G')).toEqual([slash])
-    expect(lookupChordDiagram(map, 'Am/C')).toEqual([plain])
-    expect(lookupChordDiagram(map, 'Am/Gb')).toEqual([plain])
+    const plain = [makeVariant()]
+    const slash = [makeVariant()]
+    const map: ChordDiagramMap = { Am: plain, 'Am/G': slash }
+    expect(lookupChordDiagram(map, 'Am/G')).toBe(slash)
+    fc.assert(
+      fc.property(noteArb.filter((n) => n !== 'G'), (bass) => {
+        expect(lookupChordDiagram(map, `Am/${bass}`)).toBe(plain)
+      }),
+    )
+    expect(lookupChordDiagram(map, 'Am/Gb')).toBe(plain) // flat bass normalizes to F#
   })
 
   it('returns the exact array stored in the map without copying', () => {

--- a/libs/platform-api/src/lib/chord-diagrams.ts
+++ b/libs/platform-api/src/lib/chord-diagrams.ts
@@ -23,19 +23,19 @@ const FLAT_TO_SHARP: Record<string, string> = {
   Ab: 'G#',
 }
 
+/** Map a flat-spelled note prefix to its sharp equivalent ("Bb..." → "A#..."). */
+function sharpen(note: string): string {
+  const twoChar = note.slice(0, 2)
+  return FLAT_TO_SHARP[twoChar] ? FLAT_TO_SHARP[twoChar] + note.slice(2) : note
+}
+
 /** Normalize a chord name to the sharps-based key used in the JSON data.
- *  Strips slash-bass notes and maps flat roots to their sharp equivalents. */
+ *  Keeps slash-bass notes and maps flat roots and bass notes to sharps
+ *  (e.g. "Dm/Gb" → "Dm/F#"). */
 export function normalizeChordKey(chordName: string): string {
   const slashIdx = chordName.indexOf('/')
-  const base = slashIdx !== -1 ? chordName.slice(0, slashIdx) : chordName
-
-  // Try two-char root first (e.g. "Bb", "C#"), then single char
-  const twoChar = base.slice(0, 2)
-  if (FLAT_TO_SHARP[twoChar]) {
-    return FLAT_TO_SHARP[twoChar] + base.slice(2)
-  }
-
-  return base
+  if (slashIdx === -1) return sharpen(chordName)
+  return `${sharpen(chordName.slice(0, slashIdx))}/${sharpen(chordName.slice(slashIdx + 1))}`
 }
 
 const cache = new Map<Instrument, ChordDiagramMap>()
@@ -65,9 +65,16 @@ export async function loadChordDiagrams(instrument: Instrument): Promise<ChordDi
 }
 
 /** Look up chord variants from a pre-loaded map.
- *  Normalizes the chord name and returns an empty array when not found.
- *  Uses hasOwnProperty to guard against prototype property names (e.g. "valueOf"). */
+ *  Normalizes the chord name; slash chords missing from the map fall back to
+ *  the plain root chord (e.g. "Am/B" → "Am"). Returns an empty array when not
+ *  found. Uses hasOwnProperty to guard against prototype property names. */
 export function lookupChordDiagram(map: ChordDiagramMap, chordName: string): ChordVariant[] {
   const key = normalizeChordKey(chordName)
-  return Object.prototype.hasOwnProperty.call(map, key) ? map[key] : []
+  if (Object.prototype.hasOwnProperty.call(map, key)) return map[key]
+  const slashIdx = key.indexOf('/')
+  if (slashIdx !== -1) {
+    const plain = key.slice(0, slashIdx)
+    if (Object.prototype.hasOwnProperty.call(map, plain)) return map[plain]
+  }
+  return []
 }

--- a/libs/platform-api/src/lib/chord-theory.spec.ts
+++ b/libs/platform-api/src/lib/chord-theory.spec.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import type { ChordVariant } from './chord-diagrams.js'
+import {
+  CHORD_ROOTS,
+  DIAGRAM_ROWS,
+  MAX_FRET,
+  expectedChordKeys,
+  findDuplicateVariants,
+  getAllowedPitches,
+  getRequiredPitches,
+  parseChordKey,
+  pitchName,
+  validateChordVariant,
+} from './chord-theory.js'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const variant = (partial: Partial<ChordVariant>): ChordVariant => ({
+  frets: [0, 0, 0, 0, 0, 0],
+  fingers: [0, 0, 0, 0, 0, 0],
+  baseFret: 1,
+  barres: [],
+  ...partial,
+})
+
+/** Open C major — canonical, fully valid. */
+const C_OPEN = variant({ frets: [-1, 3, 2, 0, 1, 0], fingers: [0, 3, 2, 0, 1, 0] })
+
+/** F major barre — canonical, fully valid. */
+const F_BARRE = variant({
+  frets: [1, 3, 3, 2, 1, 1],
+  fingers: [1, 3, 4, 2, 1, 1],
+  barres: [{ fret: 1, fromString: 0, toString: 5 }],
+})
+
+const rules = (key: string, v: ChordVariant, instrument: 'guitar' | 'bass' = 'guitar') =>
+  validateChordVariant(key, v, instrument).map((x) => x.rule)
+
+// ── parseChordKey ─────────────────────────────────────────────────────────────
+
+describe('parseChordKey', () => {
+  it('parses plain keys', () => {
+    expect(parseChordKey('C')).toEqual({ rootPitch: 0, quality: '' })
+    expect(parseChordKey('A#m7')).toEqual({ rootPitch: 10, quality: 'm7' })
+  })
+
+  it('parses slash keys with a bass pitch', () => {
+    expect(parseChordKey('G/B')).toEqual({ rootPitch: 7, quality: '', bassPitch: 11 })
+    expect(parseChordKey('Dm/F')).toEqual({ rootPitch: 2, quality: 'm', bassPitch: 5 })
+    expect(parseChordKey('D/F#')).toEqual({ rootPitch: 2, quality: '', bassPitch: 6 })
+  })
+
+  it('rejects unknown roots, qualities, and bass notes', () => {
+    expect(parseChordKey('H')).toBeNull()
+    expect(parseChordKey('Cfoo')).toBeNull()
+    expect(parseChordKey('C/H')).toBeNull()
+    expect(parseChordKey('')).toBeNull()
+  })
+})
+
+// ── chord tone sets ───────────────────────────────────────────────────────────
+
+describe('getAllowedPitches / getRequiredPitches', () => {
+  it('slash bass joins the allowed and required sets', () => {
+    const parsed = parseChordKey('C/B')
+    expect(parsed).not.toBeNull()
+    expect(getAllowedPitches(parsed!)).toEqual(new Set([0, 4, 7, 11]))
+    expect(getRequiredPitches(parsed!)).toEqual(new Set([0, 4, 7, 11]))
+  })
+
+  it('triads require every tone; 7th chords may omit only the 5th', () => {
+    expect(getRequiredPitches(parseChordKey('D')!)).toEqual(new Set([2, 6, 9]))
+    expect(getRequiredPitches(parseChordKey('C7')!)).toEqual(new Set([0, 4, 10]))
+    expect(getRequiredPitches(parseChordKey('Cmaj7')!)).toEqual(new Set([0, 4, 11]))
+  })
+})
+
+// ── expectedChordKeys ─────────────────────────────────────────────────────────
+
+describe('expectedChordKeys', () => {
+  it('returns 120 plain + 84 slash keys with no duplicates', () => {
+    const keys = expectedChordKeys()
+    expect(keys).toHaveLength(204)
+    expect(new Set(keys).size).toBe(204)
+  })
+
+  it('contains the common alternate-bass chords', () => {
+    const keys = new Set(expectedChordKeys())
+    for (const key of ['G/B', 'D/F#', 'Dm/F', 'C/B', 'C/E', 'C/G', 'Am/G', 'Em/D', 'A/C#']) {
+      expect(keys.has(key), key).toBe(true)
+    }
+  })
+
+  it('every key parses', () => {
+    for (const key of expectedChordKeys()) {
+      expect(parseChordKey(key), key).not.toBeNull()
+    }
+  })
+})
+
+// ── findDuplicateVariants ─────────────────────────────────────────────────────
+
+describe('findDuplicateVariants', () => {
+  it('flags repeated frets/baseFret combinations', () => {
+    expect(findDuplicateVariants([C_OPEN, F_BARRE, variant({ frets: C_OPEN.frets })])).toEqual([2])
+    expect(findDuplicateVariants([C_OPEN, F_BARRE])).toEqual([])
+  })
+})
+
+// ── validateChordVariant: valid fixtures ──────────────────────────────────────
+
+describe('validateChordVariant accepts canonical shapes', () => {
+  it.each([
+    ['C', C_OPEN],
+    ['F', F_BARRE],
+    ['D', variant({ frets: [-1, -1, 0, 2, 3, 2], fingers: [0, 0, 0, 1, 3, 2] })],
+    ['G', variant({ frets: [3, 2, 0, 0, 0, 3], fingers: [2, 1, 0, 0, 0, 3] })],
+    ['C7', variant({ frets: [-1, 3, 2, 3, 1, 0], fingers: [0, 3, 2, 4, 1, 0] })],
+    ['G/B', variant({ frets: [-1, 2, 0, 0, 3, 3], fingers: [0, 1, 0, 0, 2, 3] })],
+    ['D/F#', variant({ frets: [2, 0, 0, 2, 3, 2], fingers: [1, 0, 0, 2, 4, 3] })],
+    [
+      'Bm',
+      variant({
+        frets: [-1, 2, 4, 4, 3, 2],
+        fingers: [0, 1, 3, 4, 2, 1],
+        baseFret: 2,
+        barres: [{ fret: 1, fromString: 1, toString: 5 }],
+      }),
+    ],
+  ])('%s', (key, v) => {
+    expect(validateChordVariant(key, v, 'guitar')).toEqual([])
+  })
+
+  it('accepts a valid bass shape', () => {
+    const cMajor = { frets: [-1, 3, 2, 0], fingers: [0, 2, 1, 0], baseFret: 1, barres: [] }
+    expect(validateChordVariant('C', cMajor, 'bass')).toEqual([])
+  })
+})
+
+// ── validateChordVariant: one failure per rule ────────────────────────────────
+
+describe('validateChordVariant rejects', () => {
+  it('key: unknown chord key', () => {
+    expect(rules('H7b13', C_OPEN)).toContain('key')
+  })
+
+  it('shape: wrong array length / out-of-range values', () => {
+    expect(rules('C', variant({ frets: [0, 0, 0, 0, 0] }))).toContain('shape')
+    expect(rules('C', variant({ frets: [-2, 3, 2, 0, 1, 0] }))).toContain('shape')
+    expect(rules('C', { ...C_OPEN, baseFret: 0 })).toContain('shape')
+    expect(rules('C', { ...C_OPEN, fingers: [0, 5, 2, 0, 1, 0] })).toContain('shape')
+  })
+
+  it('finger-presence: fingers on muted/open strings, none on fretted ones', () => {
+    expect(rules('C', { ...C_OPEN, fingers: [1, 3, 2, 0, 1, 0] })).toContain('finger-presence')
+    expect(rules('C', { ...C_OPEN, fingers: [0, 0, 2, 0, 1, 0] })).toContain('finger-presence')
+  })
+
+  it('window: dots outside the rendered 5-fret window', () => {
+    // E-shape A at fret 5 wrongly labeled baseFret 1: dots vanish in the renderer
+    const high = variant({ frets: [5, 7, 7, 6, 5, 5], fingers: [1, 3, 4, 2, 1, 1], baseFret: 1, barres: [{ fret: 5, fromString: 0, toString: 5 }] })
+    expect(rules('A', high)).toContain('window')
+    // baseFret must equal the lowest fretted note
+    const offBase = variant({ frets: [5, 7, 7, 6, 5, 5], fingers: [1, 3, 4, 2, 1, 1], baseFret: 4, barres: [{ fret: 2, fromString: 0, toString: 5 }] })
+    expect(rules('A', offBase)).toContain('window')
+  })
+
+  it('span: more than a 4-fret stretch', () => {
+    const wide = variant({ frets: [-1, 3, 2, 0, 1, 7], fingers: [0, 3, 2, 0, 1, 4] })
+    expect(rules('C', wide)).toContain('span')
+  })
+
+  it('mute-edges: muted string between sounding strings', () => {
+    const gap = variant({ frets: [-1, 3, -1, 0, 1, 0], fingers: [0, 3, 0, 0, 1, 0] })
+    expect(rules('C', gap)).toContain('mute-edges')
+  })
+
+  it('sounding-min: too few sounding strings', () => {
+    const thin = variant({ frets: [-1, 3, 2, -1, -1, -1], fingers: [0, 3, 2, 0, 0, 0] })
+    expect(rules('C', thin)).toContain('sounding-min')
+  })
+
+  it('notes-valid: notes outside the chord', () => {
+    const sour = variant({ frets: [-1, 3, 2, 0, 2, 0], fingers: [0, 3, 2, 0, 1, 0] })
+    expect(rules('C', sour)).toContain('notes-valid')
+  })
+
+  it('tones-complete: missing third (the real bass-data bug)', () => {
+    const fifthOnly = { frets: [-1, 0, 2, 2], fingers: [0, 0, 1, 2], baseFret: 1, barres: [] }
+    expect(rules('A', fifthOnly, 'bass')).toContain('tones-complete')
+  })
+
+  it('bass-note: lowest sounding string is not the root / slash bass', () => {
+    const cOverG = variant({ frets: [3, 3, 2, 0, 1, 0], fingers: [3, 4, 2, 0, 1, 0] })
+    expect(rules('C', cOverG)).toContain('bass-note')
+    expect(rules('C/G', cOverG)).not.toContain('bass-note')
+    expect(rules('C/E', cOverG)).toContain('bass-note')
+  })
+
+  it('finger-reuse: same finger on two frets without a barre', () => {
+    const impossible = variant({ frets: [-1, 1, 3, 3, 3, 1], fingers: [0, 1, 2, 3, 4, 1], baseFret: 1, barres: [] })
+    expect(rules('A#', impossible)).toContain('finger-reuse')
+    const twoFrets = variant({ frets: [-1, -1, 0, 2, 1, 2], fingers: [0, 0, 0, 1, 1, 2] })
+    expect(rules('D7', twoFrets)).toContain('finger-reuse')
+  })
+
+  it('barre-consistency: barre over open strings or matching no fretted string', () => {
+    // the real A-major bug: barre row 1 with frets at 2 and open strings underneath
+    const phantom = variant({
+      frets: [-1, 0, 2, 2, 2, 0],
+      fingers: [0, 0, 1, 1, 1, 0],
+      barres: [{ fret: 1, fromString: 1, toString: 3 }],
+    })
+    expect(rules('A', phantom)).toContain('barre-consistency')
+    const badRow = variant({
+      frets: [1, 3, 3, 2, 1, 1],
+      fingers: [1, 3, 4, 2, 1, 1],
+      barres: [{ fret: 0, fromString: 0, toString: 5 }],
+    })
+    expect(rules('F', badRow)).toContain('barre-consistency')
+  })
+
+  it('anatomy: lower finger number on a higher fret', () => {
+    const crossed = variant({ frets: [-1, 3, 2, 0, 1, 0], fingers: [0, 1, 2, 0, 3, 0] })
+    expect(rules('C', crossed)).toContain('anatomy')
+  })
+})
+
+// ── properties ────────────────────────────────────────────────────────────────
+
+describe('validateChordVariant properties', () => {
+  const variantArb = fc.record({
+    frets: fc.array(fc.integer({ min: -3, max: 20 }), { minLength: 0, maxLength: 8 }),
+    fingers: fc.array(fc.integer({ min: -1, max: 6 }), { minLength: 0, maxLength: 8 }),
+    baseFret: fc.integer({ min: -2, max: 20 }),
+    barres: fc.array(
+      fc.record({
+        fret: fc.integer({ min: -2, max: 10 }),
+        fromString: fc.integer({ min: -2, max: 8 }),
+        toString: fc.integer({ min: -2, max: 8 }),
+      }),
+      { maxLength: 3 },
+    ),
+  })
+
+  const keyArb = fc.oneof(
+    fc.constantFrom(...expectedChordKeys()),
+    fc.string({ maxLength: 8 }),
+  )
+
+  it('never throws, for any key and any malformed variant', () => {
+    fc.assert(
+      fc.property(keyArb, variantArb, fc.constantFrom('guitar' as const, 'bass' as const), (key, v, instrument) => {
+        expect(() => validateChordVariant(key, v, instrument)).not.toThrow()
+      }),
+    )
+  })
+
+  it('valid variants always render fully: every dot and barre inside rows 1..5', () => {
+    fc.assert(
+      fc.property(keyArb, variantArb, fc.constantFrom('guitar' as const, 'bass' as const), (key, v, instrument) => {
+        if (validateChordVariant(key, v, instrument).length > 0) return
+        for (const fret of v.frets) {
+          if (fret > 0) {
+            const row = fret - v.baseFret + 1
+            expect(row).toBeGreaterThanOrEqual(1)
+            expect(row).toBeLessThanOrEqual(DIAGRAM_ROWS)
+            expect(fret).toBeLessThanOrEqual(MAX_FRET)
+          }
+        }
+        for (const barre of v.barres) {
+          expect(barre.fret).toBeGreaterThanOrEqual(1)
+          expect(barre.fret).toBeLessThanOrEqual(DIAGRAM_ROWS)
+        }
+      }),
+    )
+  })
+
+  it('pitchName round-trips all 12 pitch classes through CHORD_ROOTS spelling', () => {
+    for (const root of CHORD_ROOTS) {
+      const parsed = parseChordKey(root)
+      expect(parsed).not.toBeNull()
+      expect(pitchName(parsed!.rootPitch)).toBe(root)
+    }
+  })
+})

--- a/libs/platform-api/src/lib/chord-theory.spec.ts
+++ b/libs/platform-api/src/lib/chord-theory.spec.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import fc from 'fast-check'
-import type { ChordVariant } from './chord-diagrams.js'
+import type { ChordVariant, Instrument } from './chord-diagrams.js'
 import {
+  CHORD_INTERVALS,
+  CHORD_QUALITIES,
   CHORD_ROOTS,
   DIAGRAM_ROWS,
+  INSTRUMENT_TUNING,
   MAX_FRET,
   expectedChordKeys,
   findDuplicateVariants,
@@ -14,7 +17,7 @@ import {
   validateChordVariant,
 } from './chord-theory.js'
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Fixtures ─────────────────────────────────────────────────────────────────
 
 const variant = (partial: Partial<ChordVariant>): ChordVariant => ({
   frets: [0, 0, 0, 0, 0, 0],
@@ -27,28 +30,89 @@ const variant = (partial: Partial<ChordVariant>): ChordVariant => ({
 /** Open C major — canonical, fully valid. */
 const C_OPEN = variant({ frets: [-1, 3, 2, 0, 1, 0], fingers: [0, 3, 2, 0, 1, 0] })
 
-/** F major barre — canonical, fully valid. */
+/** F major barre — canonical, fully valid, no open strings (transposable). */
 const F_BARRE = variant({
   frets: [1, 3, 3, 2, 1, 1],
   fingers: [1, 3, 4, 2, 1, 1],
   barres: [{ fret: 1, fromString: 0, toString: 5 }],
 })
 
-const rules = (key: string, v: ChordVariant, instrument: 'guitar' | 'bass' = 'guitar') =>
+/** B minor barre — canonical, fully valid, no open strings (transposable). */
+const BM_BARRE = variant({
+  frets: [-1, 2, 4, 4, 3, 2],
+  fingers: [0, 1, 3, 4, 2, 1],
+  baseFret: 2,
+  barres: [{ fret: 1, fromString: 1, toString: 5 }],
+})
+
+type Fixture = { key: string; v: ChordVariant; instrument: Instrument }
+
+/** Canonical shapes, all asserted valid below; mutation properties start here. */
+const FIXTURES: Fixture[] = [
+  { key: 'C', v: C_OPEN, instrument: 'guitar' },
+  { key: 'F', v: F_BARRE, instrument: 'guitar' },
+  { key: 'Bm', v: BM_BARRE, instrument: 'guitar' },
+  { key: 'D', v: variant({ frets: [-1, -1, 0, 2, 3, 2], fingers: [0, 0, 0, 1, 3, 2] }), instrument: 'guitar' },
+  { key: 'G', v: variant({ frets: [3, 2, 0, 0, 0, 3], fingers: [2, 1, 0, 0, 0, 3] }), instrument: 'guitar' },
+  { key: 'C7', v: variant({ frets: [-1, 3, 2, 3, 1, 0], fingers: [0, 3, 2, 4, 1, 0] }), instrument: 'guitar' },
+  { key: 'G/B', v: variant({ frets: [-1, 2, 0, 0, 3, 3], fingers: [0, 1, 0, 0, 2, 3] }), instrument: 'guitar' },
+  { key: 'D/F#', v: variant({ frets: [2, 0, 0, 2, 3, 2], fingers: [1, 0, 0, 2, 4, 3] }), instrument: 'guitar' },
+  { key: 'C', v: { frets: [-1, 3, 2, 0], fingers: [0, 2, 1, 0], baseFret: 1, barres: [] }, instrument: 'bass' },
+]
+
+const rules = (key: string, v: ChordVariant, instrument: Instrument = 'guitar') =>
   validateChordVariant(key, v, instrument).map((x) => x.rule)
+
+const clone = (v: ChordVariant): ChordVariant => structuredClone(v)
+
+const lowestSoundingPitch = (f: Fixture): number => {
+  const tuning = INSTRUMENT_TUNING[f.instrument]
+  const lowest = f.v.frets.findIndex((fret) => fret >= 0)
+  return (tuning[lowest] + f.v.frets[lowest]) % 12
+}
+
+// ── Arbitraries ───────────────────────────────────────────────────────────────
+
+const rootArb = fc.constantFrom(...CHORD_ROOTS)
+const qualityArb = fc.constantFrom(...CHORD_QUALITIES)
+const knownKeyArb = fc.constantFrom(...expectedChordKeys())
+const fixtureArb = fc.constantFrom(...FIXTURES)
+const instrumentArb = fc.constantFrom<Instrument>('guitar', 'bass')
+
+const malformedVariantArb = fc.record({
+  frets: fc.array(fc.integer({ min: -3, max: 20 }), { minLength: 0, maxLength: 8 }),
+  fingers: fc.array(fc.integer({ min: -1, max: 6 }), { minLength: 0, maxLength: 8 }),
+  baseFret: fc.integer({ min: -2, max: 20 }),
+  barres: fc.array(
+    fc.record({
+      fret: fc.integer({ min: -2, max: 10 }),
+      fromString: fc.integer({ min: -2, max: 8 }),
+      toString: fc.integer({ min: -2, max: 8 }),
+    }),
+    { maxLength: 3 },
+  ),
+})
+
+const anyKeyArb = fc.oneof(knownKeyArb, fc.string({ maxLength: 8 }))
 
 // ── parseChordKey ─────────────────────────────────────────────────────────────
 
 describe('parseChordKey', () => {
-  it('parses plain keys', () => {
-    expect(parseChordKey('C')).toEqual({ rootPitch: 0, quality: '' })
-    expect(parseChordKey('A#m7')).toEqual({ rootPitch: 10, quality: 'm7' })
-  })
-
-  it('parses slash keys with a bass pitch', () => {
-    expect(parseChordKey('G/B')).toEqual({ rootPitch: 7, quality: '', bassPitch: 11 })
-    expect(parseChordKey('Dm/F')).toEqual({ rootPitch: 2, quality: 'm', bassPitch: 5 })
-    expect(parseChordKey('D/F#')).toEqual({ rootPitch: 2, quality: '', bassPitch: 6 })
+  it('round-trips every constructible root + quality + optional slash bass', () => {
+    fc.assert(
+      fc.property(rootArb, qualityArb, fc.option(rootArb, { nil: undefined }), (root, quality, bass) => {
+        const key = `${root}${quality}${bass !== undefined ? `/${bass}` : ''}`
+        const parsed = parseChordKey(key)
+        expect(parsed).not.toBeNull()
+        expect(pitchName(parsed!.rootPitch)).toBe(root)
+        expect(parsed!.quality).toBe(quality)
+        if (bass !== undefined) {
+          expect(pitchName(parsed!.bassPitch!)).toBe(bass)
+        } else {
+          expect(parsed!.bassPitch).toBeUndefined()
+        }
+      }),
+    )
   })
 
   it('rejects unknown roots, qualities, and bass notes', () => {
@@ -62,27 +126,45 @@ describe('parseChordKey', () => {
 // ── chord tone sets ───────────────────────────────────────────────────────────
 
 describe('getAllowedPitches / getRequiredPitches', () => {
-  it('slash bass joins the allowed and required sets', () => {
-    const parsed = parseChordKey('C/B')
-    expect(parsed).not.toBeNull()
-    expect(getAllowedPitches(parsed!)).toEqual(new Set([0, 4, 7, 11]))
-    expect(getRequiredPitches(parsed!)).toEqual(new Set([0, 4, 7, 11]))
+  it('for every shipped key: required ⊆ allowed, root and slash bass always required, only 7th chords may drop only the 5th', () => {
+    fc.assert(
+      fc.property(knownKeyArb, (key) => {
+        const parsed = parseChordKey(key)!
+        const allowed = getAllowedPitches(parsed)
+        const required = getRequiredPitches(parsed)
+
+        for (const pitch of required) expect(allowed).toContain(pitch)
+        expect(required).toContain(parsed.rootPitch)
+        if (parsed.bassPitch !== undefined) {
+          expect(required).toContain(parsed.bassPitch)
+          expect(allowed).toContain(parsed.bassPitch)
+        }
+
+        const optional = [...allowed].filter((p) => !required.has(p))
+        if (CHORD_INTERVALS[parsed.quality].length === 4) {
+          expect(optional).toEqual([(parsed.rootPitch + 7) % 12])
+        } else {
+          expect(optional).toEqual([])
+        }
+      }),
+    )
   })
 
-  it('triads require every tone; 7th chords may omit only the 5th', () => {
-    expect(getRequiredPitches(parseChordKey('D')!)).toEqual(new Set([2, 6, 9]))
-    expect(getRequiredPitches(parseChordKey('C7')!)).toEqual(new Set([0, 4, 10]))
-    expect(getRequiredPitches(parseChordKey('Cmaj7')!)).toEqual(new Set([0, 4, 11]))
+  it('slash bass outside the chord joins both sets (C/B)', () => {
+    const parsed = parseChordKey('C/B')!
+    expect(getAllowedPitches(parsed)).toEqual(new Set([0, 4, 7, 11]))
+    expect(getRequiredPitches(parsed)).toEqual(new Set([0, 4, 7, 11]))
   })
 })
 
 // ── expectedChordKeys ─────────────────────────────────────────────────────────
 
 describe('expectedChordKeys', () => {
-  it('returns 120 plain + 84 slash keys with no duplicates', () => {
+  it('returns 120 plain + 84 slash keys, unique, all parseable', () => {
     const keys = expectedChordKeys()
     expect(keys).toHaveLength(204)
     expect(new Set(keys).size).toBe(204)
+    for (const key of keys) expect(parseChordKey(key), key).not.toBeNull()
   })
 
   it('contains the common alternate-bass chords', () => {
@@ -91,54 +173,134 @@ describe('expectedChordKeys', () => {
       expect(keys.has(key), key).toBe(true)
     }
   })
-
-  it('every key parses', () => {
-    for (const key of expectedChordKeys()) {
-      expect(parseChordKey(key), key).not.toBeNull()
-    }
-  })
 })
 
 // ── findDuplicateVariants ─────────────────────────────────────────────────────
 
 describe('findDuplicateVariants', () => {
-  it('flags repeated frets/baseFret combinations', () => {
-    expect(findDuplicateVariants([C_OPEN, F_BARRE, variant({ frets: C_OPEN.frets })])).toEqual([2])
-    expect(findDuplicateVariants([C_OPEN, F_BARRE])).toEqual([])
-  })
-})
+  const fretsArb = fc.array(fc.integer({ min: -1, max: MAX_FRET }), { minLength: 4, maxLength: 6 })
 
-// ── validateChordVariant: valid fixtures ──────────────────────────────────────
-
-describe('validateChordVariant accepts canonical shapes', () => {
-  it.each([
-    ['C', C_OPEN],
-    ['F', F_BARRE],
-    ['D', variant({ frets: [-1, -1, 0, 2, 3, 2], fingers: [0, 0, 0, 1, 3, 2] })],
-    ['G', variant({ frets: [3, 2, 0, 0, 0, 3], fingers: [2, 1, 0, 0, 0, 3] })],
-    ['C7', variant({ frets: [-1, 3, 2, 3, 1, 0], fingers: [0, 3, 2, 4, 1, 0] })],
-    ['G/B', variant({ frets: [-1, 2, 0, 0, 3, 3], fingers: [0, 1, 0, 0, 2, 3] })],
-    ['D/F#', variant({ frets: [2, 0, 0, 2, 3, 2], fingers: [1, 0, 0, 2, 4, 3] })],
-    [
-      'Bm',
-      variant({
-        frets: [-1, 2, 4, 4, 3, 2],
-        fingers: [0, 1, 3, 4, 2, 1],
-        baseFret: 2,
-        barres: [{ fret: 1, fromString: 1, toString: 5 }],
+  it('flags exactly the variants repeating an earlier frets/baseFret pair', () => {
+    fc.assert(
+      fc.property(fc.uniqueArray(fretsArb, { minLength: 1, maxLength: 5, selector: (f) => f.join(',') }), fc.nat(), (fretsList, pick) => {
+        const variants = fretsList.map((frets) => variant({ frets }))
+        expect(findDuplicateVariants(variants)).toEqual([])
+        const copied = [...variants, clone(variants[pick % variants.length])]
+        expect(findDuplicateVariants(copied)).toEqual([variants.length])
       }),
-    ],
-  ])('%s', (key, v) => {
-    expect(validateChordVariant(key, v, 'guitar')).toEqual([])
-  })
-
-  it('accepts a valid bass shape', () => {
-    const cMajor = { frets: [-1, 3, 2, 0], fingers: [0, 2, 1, 0], baseFret: 1, barres: [] }
-    expect(validateChordVariant('C', cMajor, 'bass')).toEqual([])
+    )
   })
 })
 
-// ── validateChordVariant: one failure per rule ────────────────────────────────
+// ── validateChordVariant: canonical shapes are valid ──────────────────────────
+
+describe('validateChordVariant accepts', () => {
+  it.each(FIXTURES.map((f) => [`${f.key} (${f.instrument})`, f] as const))('%s', (_label, f) => {
+    expect(validateChordVariant(f.key, f.v, f.instrument)).toEqual([])
+  })
+
+  it('every transposition of a barre shape stays valid (movable-shape law)', () => {
+    const barreFixtureArb = fc.constantFrom(
+      { key: 'F', v: F_BARRE },
+      { key: 'Bm', v: BM_BARRE },
+    )
+    fc.assert(
+      fc.property(barreFixtureArb, fc.integer({ min: 0, max: 8 }), ({ key, v }, semitones) => {
+        const parsed = parseChordKey(key)!
+        const frets = v.frets.map((f) => (f > 0 ? f + semitones : f))
+        const fretted = frets.filter((f) => f > 0)
+        const baseFret = Math.max(...fretted) <= DIAGRAM_ROWS ? 1 : Math.min(...fretted)
+        const barres = v.barres.map((b) => ({
+          ...b,
+          fret: v.baseFret + b.fret - 1 + semitones - baseFret + 1,
+        }))
+        const transposedKey = pitchName(parsed.rootPitch + semitones) + parsed.quality
+        const transposed = { frets, fingers: v.fingers, baseFret, barres }
+        expect(validateChordVariant(transposedKey, transposed, 'guitar')).toEqual([])
+      }),
+    )
+  })
+})
+
+// ── validateChordVariant: mutation properties (one per mechanisable rule) ─────
+
+describe('validateChordVariant rejects any', () => {
+  it('finger on a non-fretted string, or fretted string without a finger (finger-presence)', () => {
+    fc.assert(
+      fc.property(fixtureArb, fc.nat(), fc.integer({ min: 1, max: 4 }), (f, sRaw, finger) => {
+        const v = clone(f.v)
+        const s = sRaw % v.frets.length
+        v.fingers[s] = v.frets[s] > 0 ? 0 : finger
+        expect(rules(f.key, v, f.instrument)).toContain('finger-presence')
+      }),
+    )
+  })
+
+  it('shape whose dots fall outside the rendered window (window)', () => {
+    fc.assert(
+      fc.property(fixtureArb, (f) => {
+        if (f.v.baseFret !== 1) return
+        const v = clone(f.v)
+        v.frets = v.frets.map((fret) => (fret > 0 ? fret + DIAGRAM_ROWS : fret))
+        expect(rules(f.key, v, f.instrument)).toContain('window')
+      }),
+    )
+  })
+
+  it('shape stretched past a hand span (span)', () => {
+    fc.assert(
+      fc.property(fixtureArb, (f) => {
+        const v = clone(f.v)
+        const max = Math.max(...v.frets)
+        v.frets[v.frets.indexOf(max)] = max + 5
+        expect(rules(f.key, v, f.instrument)).toContain('span')
+      }),
+    )
+  })
+
+  it('muted string between sounding strings (mute-edges)', () => {
+    fc.assert(
+      fc.property(fixtureArb, fc.nat(), (f, pick) => {
+        const v = clone(f.v)
+        const sounding = v.frets.map((fret, i) => (fret >= 0 ? i : -1)).filter((i) => i !== -1)
+        const interior = sounding.slice(1, -1)
+        const s = interior[pick % interior.length]
+        v.frets[s] = -1
+        v.fingers[s] = 0
+        expect(rules(f.key, v, f.instrument)).toContain('mute-edges')
+      }),
+    )
+  })
+
+  it('shape whose lowest note is not the expected bass (bass-note)', () => {
+    fc.assert(
+      fc.property(fixtureArb, rootArb, (f, newRoot) => {
+        if (f.key.includes('/')) return // slash bass stays correct when the root moves
+        const quality = parseChordKey(f.key)!.quality
+        const newRootPitch = parseChordKey(newRoot)!.rootPitch
+        if (newRootPitch === lowestSoundingPitch(f)) return
+        expect(rules(`${newRoot}${quality}`, f.v, f.instrument)).toContain('bass-note')
+      }),
+    )
+  })
+
+  it('fingering with a lower finger on a higher fret (anatomy)', () => {
+    fc.assert(
+      fc.property(fixtureArb, fc.nat(), fc.nat(), (f, aRaw, bRaw) => {
+        const fretted = f.v.frets.map((fret, i) => (fret > 0 ? i : -1)).filter((i) => i !== -1)
+        const a = fretted[aRaw % fretted.length]
+        const b = fretted[bRaw % fretted.length]
+        if (f.v.frets[a] === f.v.frets[b]) return
+        const v = clone(f.v)
+        ;[v.fingers[a], v.fingers[b]] = [v.fingers[b], v.fingers[a]]
+        expect(rules(f.key, v, f.instrument)).toContain('anatomy')
+      }),
+    )
+  })
+})
+
+// ── validateChordVariant: crafted examples for the remaining rules ────────────
+// These document the exact real-world bugs found in the AI-generated data.
 
 describe('validateChordVariant rejects', () => {
   it('key: unknown chord key', () => {
@@ -150,30 +312,6 @@ describe('validateChordVariant rejects', () => {
     expect(rules('C', variant({ frets: [-2, 3, 2, 0, 1, 0] }))).toContain('shape')
     expect(rules('C', { ...C_OPEN, baseFret: 0 })).toContain('shape')
     expect(rules('C', { ...C_OPEN, fingers: [0, 5, 2, 0, 1, 0] })).toContain('shape')
-  })
-
-  it('finger-presence: fingers on muted/open strings, none on fretted ones', () => {
-    expect(rules('C', { ...C_OPEN, fingers: [1, 3, 2, 0, 1, 0] })).toContain('finger-presence')
-    expect(rules('C', { ...C_OPEN, fingers: [0, 0, 2, 0, 1, 0] })).toContain('finger-presence')
-  })
-
-  it('window: dots outside the rendered 5-fret window', () => {
-    // E-shape A at fret 5 wrongly labeled baseFret 1: dots vanish in the renderer
-    const high = variant({ frets: [5, 7, 7, 6, 5, 5], fingers: [1, 3, 4, 2, 1, 1], baseFret: 1, barres: [{ fret: 5, fromString: 0, toString: 5 }] })
-    expect(rules('A', high)).toContain('window')
-    // baseFret must equal the lowest fretted note
-    const offBase = variant({ frets: [5, 7, 7, 6, 5, 5], fingers: [1, 3, 4, 2, 1, 1], baseFret: 4, barres: [{ fret: 2, fromString: 0, toString: 5 }] })
-    expect(rules('A', offBase)).toContain('window')
-  })
-
-  it('span: more than a 4-fret stretch', () => {
-    const wide = variant({ frets: [-1, 3, 2, 0, 1, 7], fingers: [0, 3, 2, 0, 1, 4] })
-    expect(rules('C', wide)).toContain('span')
-  })
-
-  it('mute-edges: muted string between sounding strings', () => {
-    const gap = variant({ frets: [-1, 3, -1, 0, 1, 0], fingers: [0, 3, 0, 0, 1, 0] })
-    expect(rules('C', gap)).toContain('mute-edges')
   })
 
   it('sounding-min: too few sounding strings', () => {
@@ -189,13 +327,6 @@ describe('validateChordVariant rejects', () => {
   it('tones-complete: missing third (the real bass-data bug)', () => {
     const fifthOnly = { frets: [-1, 0, 2, 2], fingers: [0, 0, 1, 2], baseFret: 1, barres: [] }
     expect(rules('A', fifthOnly, 'bass')).toContain('tones-complete')
-  })
-
-  it('bass-note: lowest sounding string is not the root / slash bass', () => {
-    const cOverG = variant({ frets: [3, 3, 2, 0, 1, 0], fingers: [3, 4, 2, 0, 1, 0] })
-    expect(rules('C', cOverG)).toContain('bass-note')
-    expect(rules('C/G', cOverG)).not.toContain('bass-note')
-    expect(rules('C/E', cOverG)).toContain('bass-note')
   })
 
   it('finger-reuse: same finger on two frets without a barre', () => {
@@ -220,46 +351,39 @@ describe('validateChordVariant rejects', () => {
     })
     expect(rules('F', badRow)).toContain('barre-consistency')
   })
-
-  it('anatomy: lower finger number on a higher fret', () => {
-    const crossed = variant({ frets: [-1, 3, 2, 0, 1, 0], fingers: [0, 1, 2, 0, 3, 0] })
-    expect(rules('C', crossed)).toContain('anatomy')
-  })
 })
 
-// ── properties ────────────────────────────────────────────────────────────────
+// ── global properties ─────────────────────────────────────────────────────────
+
+const KNOWN_RULES = [
+  'key',
+  'shape',
+  'finger-presence',
+  'window',
+  'span',
+  'mute-edges',
+  'sounding-min',
+  'notes-valid',
+  'tones-complete',
+  'bass-note',
+  'finger-reuse',
+  'barre-consistency',
+  'anatomy',
+]
 
 describe('validateChordVariant properties', () => {
-  const variantArb = fc.record({
-    frets: fc.array(fc.integer({ min: -3, max: 20 }), { minLength: 0, maxLength: 8 }),
-    fingers: fc.array(fc.integer({ min: -1, max: 6 }), { minLength: 0, maxLength: 8 }),
-    baseFret: fc.integer({ min: -2, max: 20 }),
-    barres: fc.array(
-      fc.record({
-        fret: fc.integer({ min: -2, max: 10 }),
-        fromString: fc.integer({ min: -2, max: 8 }),
-        toString: fc.integer({ min: -2, max: 8 }),
-      }),
-      { maxLength: 3 },
-    ),
-  })
-
-  const keyArb = fc.oneof(
-    fc.constantFrom(...expectedChordKeys()),
-    fc.string({ maxLength: 8 }),
-  )
-
-  it('never throws, for any key and any malformed variant', () => {
+  it('never throws and only reports known rules, for any key and any malformed variant', () => {
     fc.assert(
-      fc.property(keyArb, variantArb, fc.constantFrom('guitar' as const, 'bass' as const), (key, v, instrument) => {
-        expect(() => validateChordVariant(key, v, instrument)).not.toThrow()
+      fc.property(anyKeyArb, malformedVariantArb, instrumentArb, (key, v, instrument) => {
+        const violations = validateChordVariant(key, v, instrument)
+        for (const { rule } of violations) expect(KNOWN_RULES).toContain(rule)
       }),
     )
   })
 
   it('valid variants always render fully: every dot and barre inside rows 1..5', () => {
     fc.assert(
-      fc.property(keyArb, variantArb, fc.constantFrom('guitar' as const, 'bass' as const), (key, v, instrument) => {
+      fc.property(anyKeyArb, malformedVariantArb, instrumentArb, (key, v, instrument) => {
         if (validateChordVariant(key, v, instrument).length > 0) return
         for (const fret of v.frets) {
           if (fret > 0) {
@@ -279,9 +403,7 @@ describe('validateChordVariant properties', () => {
 
   it('pitchName round-trips all 12 pitch classes through CHORD_ROOTS spelling', () => {
     for (const root of CHORD_ROOTS) {
-      const parsed = parseChordKey(root)
-      expect(parsed).not.toBeNull()
-      expect(pitchName(parsed!.rootPitch)).toBe(root)
+      expect(pitchName(parseChordKey(root)!.rootPitch)).toBe(root)
     }
   })
 })

--- a/libs/platform-api/src/lib/chord-theory.ts
+++ b/libs/platform-api/src/lib/chord-theory.ts
@@ -1,4 +1,8 @@
-import type { ChordVariant, Instrument } from './chord-diagrams.js'
+import type { ChordBarre, ChordVariant, Instrument } from './chord-diagrams.js'
+
+// NOTE: keep this module free of runtime imports (type-only imports are fine).
+// tools/chord-data/ imports it directly as a .ts file under Node's type
+// stripping, which cannot resolve the workspace's `.js`-suffixed specifiers.
 
 /** Open string pitches for each instrument, C=0, low-to-high string order. */
 export const GUITAR_TUNING = [4, 9, 2, 7, 11, 4] as const  // E A D G B E
@@ -23,21 +27,73 @@ export const CHORD_INTERVALS: Record<string, readonly number[]> = {
   '5': [0, 7],             // power chord
 }
 
+/** Roots in the order the chord JSON files enumerate them. */
+export const CHORD_ROOTS = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'] as const
+
+/** Alternate-bass intervals shipped as slash-chord keys, per quality.
+ *  Major: 3rd, 5th, maj7 bass (C/B), b7 bass (A/G). Minor: b3rd, 5th, b7 bass (Am/G). */
+export const SLASH_BASS_INTERVALS: Record<string, readonly number[]> = {
+  '': [4, 7, 11, 10],
+  m: [3, 7, 10],
+}
+
+/** Number of fret rows a chord diagram renders (see ChordDiagram.tsx). */
+export const DIAGRAM_ROWS = 5
+/** Maximum fret distance between lowest and highest fretted note (4-fret hand span). */
+export const MAX_SPAN = 3
+/** Highest absolute fret the data may use. */
+export const MAX_FRET = 15
+
 const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const
 
 const NOTE_PITCH: Record<string, number> = {
   A: 9, 'A#': 10, B: 11, C: 0, 'C#': 1, D: 2, 'D#': 3, E: 4, F: 5, 'F#': 6, G: 7, 'G#': 8,
 }
 
-export type ParsedChord = { rootPitch: number; quality: string }
+export type ParsedChord = { rootPitch: number; quality: string; bassPitch?: number }
 
-/** Split a chord key (in sharps form) into root pitch and quality suffix. */
+/** Split a chord key (in sharps form) into root pitch, quality suffix, and
+ *  optional slash-bass pitch (e.g. "Dm/F" → { rootPitch: 2, quality: 'm', bassPitch: 5 }). */
 export function parseChordKey(key: string): ParsedChord | null {
-  const root    = key[1] === '#' ? key.slice(0, 2) : key[0]
-  const quality = key[1] === '#' ? key.slice(2)    : key.slice(1)
+  const slashIdx = key.indexOf('/')
+  const base = slashIdx !== -1 ? key.slice(0, slashIdx) : key
+  const bass = slashIdx !== -1 ? key.slice(slashIdx + 1) : undefined
+
+  const root    = base[1] === '#' ? base.slice(0, 2) : base[0]
+  const quality = base[1] === '#' ? base.slice(2)    : base.slice(1)
   const rootPitch = NOTE_PITCH[root]
   if (rootPitch === undefined || !(quality in CHORD_INTERVALS)) return null
-  return { rootPitch, quality }
+
+  if (bass === undefined) return { rootPitch, quality }
+  const bassPitch = NOTE_PITCH[bass]
+  if (bassPitch === undefined) return null
+  return { rootPitch, quality, bassPitch }
+}
+
+/** Pitch class name in sharps form (C=0). */
+export function pitchName(pitch: number): string {
+  return NOTE_NAMES[((pitch % 12) + 12) % 12]
+}
+
+/** Pitch classes a parsed chord may sound: chord tones plus the slash bass, if any. */
+export function getAllowedPitches(parsed: ParsedChord): Set<number> {
+  const allowed = new Set(CHORD_INTERVALS[parsed.quality].map((i) => (parsed.rootPitch + i) % 12))
+  if (parsed.bassPitch !== undefined) allowed.add(parsed.bassPitch)
+  return allowed
+}
+
+/** Pitch classes a variant must contain to be a complete chord.
+ *  All chord tones are required; only 4-note qualities (7, m7, maj7) may omit the 5th. */
+export function getRequiredPitches(parsed: ParsedChord): Set<number> {
+  const intervals = CHORD_INTERVALS[parsed.quality]
+  const fifthOptional = intervals.length === 4
+  const required = new Set<number>()
+  for (const interval of intervals) {
+    if (fifthOptional && interval === 7) continue
+    required.add((parsed.rootPitch + interval) % 12)
+  }
+  if (parsed.bassPitch !== undefined) required.add(parsed.bassPitch)
+  return required
 }
 
 /** Pitch classes (C=0) played by a variant; muted strings (-1) are excluded. */
@@ -54,8 +110,8 @@ export function getVariantNotes(variant: ChordVariant, tuning: readonly number[]
 export type InvalidNote = { name: string; pitch: number }
 
 /**
- * Returns the list of pitch classes in the variant that do not belong to the chord.
- * An empty array means the variant is musically correct.
+ * Returns the list of pitch classes in the variant that do not belong to the chord
+ * (slash-bass notes count as belonging). An empty array means the notes are correct.
  */
 export function getInvalidNotes(
   chordKey: string,
@@ -64,14 +120,275 @@ export function getInvalidNotes(
 ): InvalidNote[] {
   const parsed = parseChordKey(chordKey)
   if (!parsed) return []
-  const { rootPitch, quality } = parsed
-  const intervals = CHORD_INTERVALS[quality]
-  const allowed = new Set(intervals.map((i) => (rootPitch + i) % 12))
+  const allowed = getAllowedPitches(parsed)
   const errors: InvalidNote[] = []
   for (const pitch of getVariantNotes(variant, tuning)) {
     if (!allowed.has(pitch)) {
-      errors.push({ name: NOTE_NAMES[pitch], pitch })
+      errors.push({ name: pitchName(pitch), pitch })
     }
   }
   return errors
+}
+
+/** Every chord key the JSON data files must define, in file order:
+ *  plain keys grouped by quality, then slash keys grouped by root. */
+export function expectedChordKeys(): string[] {
+  const keys: string[] = []
+  for (const quality of Object.keys(CHORD_INTERVALS)) {
+    for (const root of CHORD_ROOTS) keys.push(root + quality)
+  }
+  for (const root of CHORD_ROOTS) {
+    for (const [quality, intervals] of Object.entries(SLASH_BASS_INTERVALS)) {
+      const rootPitch = NOTE_PITCH[root]
+      for (const interval of intervals) {
+        keys.push(`${root}${quality}/${pitchName(rootPitch + interval)}`)
+      }
+    }
+  }
+  return keys
+}
+
+/** Indices of variants that repeat an earlier variant's frets and baseFret. */
+export function findDuplicateVariants(variants: readonly ChordVariant[]): number[] {
+  const seen = new Set<string>()
+  const duplicates: number[] = []
+  variants.forEach((variant, i) => {
+    const signature = `${variant.frets.join(',')}|${variant.baseFret}`
+    if (seen.has(signature)) duplicates.push(i)
+    seen.add(signature)
+  })
+  return duplicates
+}
+
+export type VariantViolation = { rule: string; message: string }
+
+const isInt = (n: unknown): n is number => typeof n === 'number' && Number.isInteger(n)
+
+function checkShape(variant: ChordVariant, tuning: readonly number[]): VariantViolation[] {
+  const violations: VariantViolation[] = []
+  const { frets, fingers, baseFret, barres } = variant
+  if (!Array.isArray(frets) || frets.length !== tuning.length) {
+    violations.push({ rule: 'shape', message: `frets must have ${tuning.length} entries` })
+  }
+  if (!Array.isArray(fingers) || fingers.length !== tuning.length) {
+    violations.push({ rule: 'shape', message: `fingers must have ${tuning.length} entries` })
+  }
+  if (violations.length > 0) return violations
+
+  frets.forEach((fret, i) => {
+    if (!isInt(fret) || fret < -1 || fret > MAX_FRET) {
+      violations.push({ rule: 'shape', message: `frets[${i}]=${fret} outside -1..${MAX_FRET}` })
+    }
+  })
+  fingers.forEach((finger, i) => {
+    if (!isInt(finger) || finger < 0 || finger > 4) {
+      violations.push({ rule: 'shape', message: `fingers[${i}]=${finger} outside 0..4` })
+    }
+  })
+  if (!isInt(baseFret) || baseFret < 1) {
+    violations.push({ rule: 'shape', message: `baseFret=${baseFret} must be >= 1` })
+  }
+  if (!Array.isArray(barres)) {
+    violations.push({ rule: 'shape', message: 'barres must be an array' })
+  }
+  return violations
+}
+
+function checkBarre(
+  barre: ChordBarre,
+  variant: ChordVariant,
+  tuning: readonly number[],
+): VariantViolation[] {
+  const violations: VariantViolation[] = []
+  const { frets, fingers, baseFret } = variant
+  const { fret: row, fromString, toString } = barre
+
+  if (!isInt(row) || row < 1 || row > DIAGRAM_ROWS) {
+    violations.push({ rule: 'barre-consistency', message: `barre row ${row} outside 1..${DIAGRAM_ROWS}` })
+    return violations
+  }
+  if (!isInt(fromString) || !isInt(toString) ||
+      fromString < 0 || toString >= tuning.length || fromString >= toString) {
+    violations.push({ rule: 'barre-consistency', message: `barre strings ${fromString}..${toString} invalid` })
+    return violations
+  }
+
+  const absFret = baseFret + row - 1
+  if (frets[fromString] !== absFret || frets[toString] !== absFret) {
+    violations.push({
+      rule: 'barre-consistency',
+      message: `barre at fret ${absFret} must start and end on strings fretted there`,
+    })
+  }
+
+  const barred: number[] = []
+  for (let s = fromString; s <= toString; s++) {
+    if (frets[s] < absFret) {
+      violations.push({
+        rule: 'barre-consistency',
+        message: `string ${s} (fret ${frets[s]}) lies under the barre at fret ${absFret}`,
+      })
+    }
+    if (frets[s] === absFret) barred.push(s)
+  }
+  if (barred.length < 2) {
+    violations.push({ rule: 'barre-consistency', message: `barre at fret ${absFret} covers fewer than 2 strings` })
+  }
+  const barreFingers = new Set(barred.map((s) => fingers[s]))
+  if (barreFingers.size > 1) {
+    violations.push({ rule: 'barre-consistency', message: `barred strings use different fingers` })
+  }
+  return violations
+}
+
+/**
+ * Validates a chord variant against every structural, musical, and playability
+ * invariant the renderer and the data contract rely on. Returns one entry per
+ * violated rule; an empty array means the variant is valid.
+ */
+export function validateChordVariant(
+  chordKey: string,
+  variant: ChordVariant,
+  instrument: Instrument,
+): VariantViolation[] {
+  const tuning = INSTRUMENT_TUNING[instrument]
+  const parsed = parseChordKey(chordKey)
+  if (!parsed) return [{ rule: 'key', message: `unknown chord key "${chordKey}"` }]
+
+  const shapeViolations = checkShape(variant, tuning)
+  if (shapeViolations.length > 0) return shapeViolations
+
+  const violations: VariantViolation[] = []
+  const { frets, fingers, baseFret, barres } = variant
+  const fretted = frets.filter((f) => f > 0)
+  const soundingIdx = frets.map((f, i) => (f >= 0 ? i : -1)).filter((i) => i !== -1)
+
+  // finger-presence: a finger is assigned exactly to the fretted strings
+  frets.forEach((fret, i) => {
+    if (fret > 0 && fingers[i] === 0) {
+      violations.push({ rule: 'finger-presence', message: `string ${i} fretted at ${fret} has no finger` })
+    }
+    if (fret <= 0 && fingers[i] !== 0) {
+      violations.push({ rule: 'finger-presence', message: `string ${i} is ${fret === 0 ? 'open' : 'muted'} but has finger ${fingers[i]}` })
+    }
+  })
+
+  // window: every dot must land in the rendered 5-row window
+  if (fretted.length === 0) {
+    if (baseFret !== 1) {
+      violations.push({ rule: 'window', message: `baseFret=${baseFret} with no fretted notes` })
+    }
+  } else {
+    const min = Math.min(...fretted)
+    const max = Math.max(...fretted)
+    if (baseFret === 1) {
+      if (max > DIAGRAM_ROWS) {
+        violations.push({ rule: 'window', message: `fret ${max} outside rows 1..${DIAGRAM_ROWS} at baseFret 1` })
+      }
+    } else {
+      if (baseFret !== min) {
+        violations.push({ rule: 'window', message: `baseFret=${baseFret} but lowest fretted note is ${min}` })
+      }
+      if (max > baseFret + DIAGRAM_ROWS - 1) {
+        violations.push({ rule: 'window', message: `fret ${max} outside window ${baseFret}..${baseFret + DIAGRAM_ROWS - 1}` })
+      }
+    }
+
+    // span: must fit a hand
+    if (max - min > MAX_SPAN) {
+      violations.push({ rule: 'span', message: `fret span ${min}..${max} exceeds ${MAX_SPAN + 1} frets` })
+    }
+  }
+
+  // mute-edges: muted strings only at the outside edges
+  if (soundingIdx.length > 0) {
+    for (let i = soundingIdx[0]; i <= soundingIdx[soundingIdx.length - 1]; i++) {
+      if (frets[i] === -1) {
+        violations.push({ rule: 'mute-edges', message: `muted string ${i} between sounding strings` })
+      }
+    }
+  }
+
+  // sounding-min: enough strings to voice the chord
+  const minSounding = parsed.quality === '5' ? 2 : 3
+  if (soundingIdx.length < minSounding) {
+    violations.push({ rule: 'sounding-min', message: `only ${soundingIdx.length} sounding strings (need ${minSounding})` })
+  }
+
+  // notes-valid: every sounding note belongs to the chord
+  for (const { name } of getInvalidNotes(chordKey, variant, tuning)) {
+    violations.push({ rule: 'notes-valid', message: `note ${name} does not belong to ${chordKey}` })
+  }
+
+  // tones-complete: the chord contains all of its tones (5th omissible on 7th chords)
+  const sounded = getVariantNotes(variant, tuning)
+  for (const pitch of getRequiredPitches(parsed)) {
+    if (!sounded.has(pitch)) {
+      violations.push({ rule: 'tones-complete', message: `missing chord tone ${pitchName(pitch)}` })
+    }
+  }
+
+  // bass-note: lowest sounding string plays the root (or the slash bass)
+  if (soundingIdx.length > 0) {
+    const lowest = soundingIdx[0]
+    const expected = parsed.bassPitch ?? parsed.rootPitch
+    const actual = (tuning[lowest] + frets[lowest]) % 12
+    if (actual !== expected) {
+      violations.push({
+        rule: 'bass-note',
+        message: `lowest note is ${pitchName(actual)}, expected ${pitchName(expected)}`,
+      })
+    }
+  }
+
+  // finger-reuse: a finger on several strings means a barre at one fret
+  const stringsByFinger = new Map<number, number[]>()
+  frets.forEach((fret, i) => {
+    if (fret > 0 && fingers[i] > 0) {
+      const list = stringsByFinger.get(fingers[i]) ?? []
+      list.push(i)
+      stringsByFinger.set(fingers[i], list)
+    }
+  })
+  for (const [finger, strings] of stringsByFinger) {
+    if (strings.length < 2) continue
+    const fretsUsed = new Set(strings.map((s) => frets[s]))
+    if (fretsUsed.size > 1) {
+      violations.push({
+        rule: 'finger-reuse',
+        message: `finger ${finger} on different frets ${[...fretsUsed].join(', ')} without a barre`,
+      })
+      continue
+    }
+    const fret = frets[strings[0]]
+    const row = fret - baseFret + 1
+    const covering = barres.find(
+      (b) => b.fret === row && b.fromString <= strings[0] && b.toString >= strings[strings.length - 1],
+    )
+    if (!covering) {
+      violations.push({
+        rule: 'finger-reuse',
+        message: `finger ${finger} spans strings ${strings.join(', ')} at fret ${fret} but no barre covers them`,
+      })
+    }
+  }
+
+  // barre-consistency
+  for (const barre of barres) {
+    violations.push(...checkBarre(barre, variant, tuning))
+  }
+
+  // anatomy: finger numbers must not decrease as frets rise
+  for (const i of soundingIdx) {
+    for (const j of soundingIdx) {
+      if (frets[i] > 0 && frets[j] > 0 && frets[i] < frets[j] && fingers[i] > fingers[j]) {
+        violations.push({
+          rule: 'anatomy',
+          message: `finger ${fingers[i]} at fret ${frets[i]} below finger ${fingers[j]} at fret ${frets[j]}`,
+        })
+      }
+    }
+  }
+
+  return violations
 }

--- a/libs/platform-api/src/lib/chord-theory.ts
+++ b/libs/platform-api/src/lib/chord-theory.ts
@@ -27,6 +27,10 @@ export const CHORD_INTERVALS: Record<string, readonly number[]> = {
   '5': [0, 7],             // power chord
 }
 
+/** Qualities in the order the chord JSON files enumerate them.
+ *  (Object.keys(CHORD_INTERVALS) won't do: JS hoists integer-like keys like '5'.) */
+export const CHORD_QUALITIES = ['', 'm', '7', 'm7', 'maj7', 'sus2', 'sus4', 'dim', 'aug', '5'] as const
+
 /** Roots in the order the chord JSON files enumerate them. */
 export const CHORD_ROOTS = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'] as const
 
@@ -134,7 +138,7 @@ export function getInvalidNotes(
  *  plain keys grouped by quality, then slash keys grouped by root. */
 export function expectedChordKeys(): string[] {
   const keys: string[] = []
-  for (const quality of Object.keys(CHORD_INTERVALS)) {
+  for (const quality of CHORD_QUALITIES) {
     for (const root of CHORD_ROOTS) keys.push(root + quality)
   }
   for (const root of CHORD_ROOTS) {

--- a/tools/chord-data/generate-chord-data.ts
+++ b/tools/chord-data/generate-chord-data.ts
@@ -1,0 +1,132 @@
+/**
+ * Regenerates apps/klank/public/chords-guitar.json and chords-bass.json from
+ * music theory: every voicing is searched, finger-assigned, and checked
+ * against the strict validator in @klank/platform-api's chord-theory.
+ *
+ *   node tools/chord-data/generate-chord-data.ts             # write both files
+ *   node tools/chord-data/generate-chord-data.ts --preview C G/B Dm   # ASCII diagrams
+ *
+ * Output is deterministic — rerunning produces byte-identical files.
+ */
+import { writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { ChordDiagramMap, ChordVariant, Instrument } from '../../libs/platform-api/src/lib/chord-diagrams.ts'
+import {
+  DIAGRAM_ROWS,
+  INSTRUMENT_TUNING,
+  expectedChordKeys,
+  validateChordVariant,
+} from '../../libs/platform-api/src/lib/chord-theory.ts'
+import { searchVoicings, selectVoicings } from './voicing-search.ts'
+import { SEED_SHAPES, seedVariant } from './seeds.ts'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PUBLIC_DIR = resolve(__dirname, '../../apps/klank/public')
+
+const VARIANT_COUNT: Record<Instrument, { plain: number; slash: number }> = {
+  guitar: { plain: 3, slash: 2 },
+  bass: { plain: 2, slash: 2 },
+}
+
+function buildMap(instrument: Instrument): ChordDiagramMap {
+  const map: ChordDiagramMap = {}
+  for (const key of expectedChordKeys()) {
+    const counts = VARIANT_COUNT[instrument]
+    const count = key.includes('/') ? counts.slash : counts.plain
+
+    const preselected: ChordVariant[] = []
+    const seed = SEED_SHAPES[instrument][key]
+    if (seed) preselected.push(seedVariant(seed))
+
+    const ranked = searchVoicings(key, instrument)
+    const variants = selectVoicings(ranked, count, preselected)
+    if (variants.length === 0) {
+      throw new Error(`${instrument} ${key}: search produced no valid voicing`)
+    }
+    for (const [i, variant] of variants.entries()) {
+      const violations = validateChordVariant(key, variant, instrument)
+      if (violations.length > 0) {
+        const detail = violations.map((v) => `${v.rule}: ${v.message}`).join('; ')
+        throw new Error(`${instrument} ${key}[${i}] frets=[${variant.frets}] invalid — ${detail}`)
+      }
+    }
+    map[key] = variants
+  }
+  return map
+}
+
+/** One variant per line, matching the hand-reviewable style of the data files. */
+function formatMap(map: ChordDiagramMap): string {
+  const lines: string[] = ['{']
+  const keys = Object.keys(map)
+  keys.forEach((key, keyIdx) => {
+    lines.push(`  ${JSON.stringify(key)}: [`)
+    map[key].forEach((v, i) => {
+      const barres = v.barres
+        .map((b) => `{ "fret": ${b.fret}, "fromString": ${b.fromString}, "toString": ${b.toString} }`)
+        .join(', ')
+      const comma = i < map[key].length - 1 ? ',' : ''
+      lines.push(
+        `    { "frets": [${v.frets.join(', ')}], "fingers": [${v.fingers.join(', ')}], ` +
+          `"baseFret": ${v.baseFret}, "barres": [${barres}] }${comma}`,
+      )
+    })
+    lines.push(`  ]${keyIdx < keys.length - 1 ? ',' : ''}`)
+  })
+  lines.push('}')
+  return lines.join('\n') + '\n'
+}
+
+function previewVariant(key: string, variant: ChordVariant, instrument: Instrument): string {
+  const tuning = INSTRUMENT_TUNING[instrument]
+  const n = tuning.length
+  const { frets, fingers, baseFret, barres } = variant
+  const lines: string[] = []
+
+  const fretLabel = (f: number) => (f === -1 ? 'x' : String(f))
+  lines.push(`${key} (${instrument})  frets=[${frets.map(fretLabel).join(' ')}]  baseFret=${baseFret}`)
+  lines.push('  ' + frets.map((f) => (f === -1 ? 'x' : f === 0 ? 'o' : ' ')).join(' '))
+  lines.push('  ' + (baseFret === 1 ? '='.repeat(n * 2 - 1) : '-'.repeat(n * 2 - 1)) + (baseFret > 1 ? `  ${baseFret}fr` : ''))
+  for (let row = 1; row <= DIAGRAM_ROWS; row++) {
+    const cells = frets.map((f, s) => {
+      if (f - baseFret + 1 === row && f > 0) return String(fingers[s])
+      if (barres.some((b) => b.fret === row && s >= b.fromString && s <= b.toString)) return '='
+      return '|'
+    })
+    lines.push('  ' + cells.join(' '))
+  }
+  return lines.join('\n')
+}
+
+const args = process.argv.slice(2)
+
+if (args[0] === '--preview') {
+  const keys = args.slice(1)
+  if (keys.length === 0) {
+    console.error('usage: generate-chord-data.ts --preview <chordKey> [...]')
+    process.exit(1)
+  }
+  for (const instrument of ['guitar', 'bass'] as const) {
+    const map = buildMap(instrument)
+    for (const key of keys) {
+      const variants = map[key]
+      if (!variants) {
+        console.log(`${key} (${instrument}): not a generated key`)
+        continue
+      }
+      for (const variant of variants) {
+        console.log(previewVariant(key, variant, instrument))
+        console.log()
+      }
+    }
+  }
+} else {
+  for (const instrument of ['guitar', 'bass'] as const) {
+    const map = buildMap(instrument)
+    const file = resolve(PUBLIC_DIR, `chords-${instrument}.json`)
+    writeFileSync(file, formatMap(map))
+    const variantCount = Object.values(map).reduce((sum, v) => sum + v.length, 0)
+    console.log(`wrote ${file}: ${Object.keys(map).length} keys, ${variantCount} variants`)
+  }
+}

--- a/tools/chord-data/package.json
+++ b/tools/chord-data/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@klank/chord-data-tool",
+  "private": true,
+  "type": "module"
+}

--- a/tools/chord-data/seeds.ts
+++ b/tools/chord-data/seeds.ts
@@ -1,0 +1,83 @@
+import type { ChordVariant } from '../../libs/platform-api/src/lib/chord-diagrams.ts'
+
+type Seed = {
+  frets: number[]
+  fingers: number[]
+  barres?: ChordVariant['barres']
+}
+
+/**
+ * Canonical open-position guitar shapes, pinned as the first variant of their
+ * key so the diagram players see first is the one they know. Every seed is
+ * validated by the generator like any searched voicing — a typo here fails
+ * the build loudly.
+ */
+const GUITAR_SEED_SHAPES: Record<string, Seed> = {
+  // majors
+  C: { frets: [-1, 3, 2, 0, 1, 0], fingers: [0, 3, 2, 0, 1, 0] },
+  D: { frets: [-1, -1, 0, 2, 3, 2], fingers: [0, 0, 0, 1, 3, 2] },
+  E: { frets: [0, 2, 2, 1, 0, 0], fingers: [0, 2, 3, 1, 0, 0] },
+  G: { frets: [3, 2, 0, 0, 0, 3], fingers: [2, 1, 0, 0, 0, 3] },
+  A: { frets: [-1, 0, 2, 2, 2, 0], fingers: [0, 0, 1, 2, 3, 0] },
+  F: {
+    frets: [1, 3, 3, 2, 1, 1],
+    fingers: [1, 3, 4, 2, 1, 1],
+    barres: [{ fret: 1, fromString: 0, toString: 5 }],
+  },
+  // minors
+  Dm: { frets: [-1, -1, 0, 2, 3, 1], fingers: [0, 0, 0, 2, 3, 1] },
+  Em: { frets: [0, 2, 2, 0, 0, 0], fingers: [0, 2, 3, 0, 0, 0] },
+  Am: { frets: [-1, 0, 2, 2, 1, 0], fingers: [0, 0, 2, 3, 1, 0] },
+  // dominant 7
+  C7: { frets: [-1, 3, 2, 3, 1, 0], fingers: [0, 3, 2, 4, 1, 0] },
+  D7: { frets: [-1, -1, 0, 2, 1, 2], fingers: [0, 0, 0, 2, 1, 3] },
+  E7: { frets: [0, 2, 0, 1, 0, 0], fingers: [0, 2, 0, 1, 0, 0] },
+  G7: { frets: [3, 2, 0, 0, 0, 1], fingers: [3, 2, 0, 0, 0, 1] },
+  A7: { frets: [-1, 0, 2, 0, 2, 0], fingers: [0, 0, 2, 0, 3, 0] },
+  B7: { frets: [-1, 2, 1, 2, 0, 2], fingers: [0, 2, 1, 3, 0, 4] },
+  // minor 7
+  Dm7: {
+    frets: [-1, -1, 0, 2, 1, 1],
+    fingers: [0, 0, 0, 2, 1, 1],
+    barres: [{ fret: 1, fromString: 4, toString: 5 }],
+  },
+  Em7: { frets: [0, 2, 0, 0, 0, 0], fingers: [0, 2, 0, 0, 0, 0] },
+  Am7: { frets: [-1, 0, 2, 0, 1, 0], fingers: [0, 0, 2, 0, 1, 0] },
+  // major 7
+  Cmaj7: { frets: [-1, 3, 2, 0, 0, 0], fingers: [0, 3, 2, 0, 0, 0] },
+  Emaj7: { frets: [0, 2, 1, 1, 0, 0], fingers: [0, 3, 1, 2, 0, 0] },
+  Amaj7: { frets: [-1, 0, 2, 1, 2, 0], fingers: [0, 0, 2, 1, 3, 0] },
+  // suspended
+  Dsus2: { frets: [-1, -1, 0, 2, 3, 0], fingers: [0, 0, 0, 1, 3, 0] },
+  Dsus4: { frets: [-1, -1, 0, 2, 3, 3], fingers: [0, 0, 0, 1, 3, 4] },
+  Asus2: { frets: [-1, 0, 2, 2, 0, 0], fingers: [0, 0, 1, 2, 0, 0] },
+  Asus4: { frets: [-1, 0, 2, 2, 3, 0], fingers: [0, 0, 1, 2, 3, 0] },
+  Esus4: { frets: [0, 2, 2, 2, 0, 0], fingers: [0, 1, 2, 3, 0, 0] },
+  // power chords
+  E5: { frets: [0, 2, 2, -1, -1, -1], fingers: [0, 1, 3, 0, 0, 0] },
+  A5: { frets: [-1, 0, 2, 2, -1, -1], fingers: [0, 0, 1, 3, 0, 0] },
+  D5: { frets: [-1, -1, 0, 2, 3, -1], fingers: [0, 0, 0, 1, 3, 0] },
+  G5: { frets: [3, 5, 5, -1, -1, -1], fingers: [1, 3, 4, 0, 0, 0] },
+  // common alternate-bass shapes
+  'G/B': { frets: [-1, 2, 0, 0, 3, 3], fingers: [0, 1, 0, 0, 3, 4] },
+  'D/F#': { frets: [2, 0, 0, 2, 3, 2], fingers: [1, 0, 0, 2, 4, 3] },
+  'C/B': { frets: [-1, 2, 2, 0, 1, 0], fingers: [0, 2, 3, 0, 1, 0] },
+  'C/E': { frets: [0, 3, 2, 0, 1, 0], fingers: [0, 3, 2, 0, 1, 0] },
+  'C/G': { frets: [3, 3, 2, 0, 1, 0], fingers: [3, 4, 2, 0, 1, 0] },
+  'Am/G': { frets: [3, 0, 2, 2, 1, 0], fingers: [4, 0, 2, 3, 1, 0] },
+}
+
+/** Seed shapes per instrument; bass voicings are fully search-generated. */
+export const SEED_SHAPES: Record<'guitar' | 'bass', Record<string, Seed>> = {
+  guitar: GUITAR_SEED_SHAPES,
+  bass: {},
+}
+
+export function seedVariant(seed: Seed): ChordVariant {
+  return {
+    frets: seed.frets,
+    fingers: seed.fingers,
+    baseFret: 1,
+    barres: seed.barres ?? [],
+  }
+}

--- a/tools/chord-data/tsconfig.json
+++ b/tools/chord-data/tsconfig.json
@@ -11,5 +11,10 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
   },
-  "include": ["*.ts"]
+  "include": ["*.ts"],
+  "references": [
+    {
+      "path": "../../libs/platform-api"
+    }
+  ]
 }

--- a/tools/chord-data/tsconfig.json
+++ b/tools/chord-data/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}

--- a/tools/chord-data/voicing-search.ts
+++ b/tools/chord-data/voicing-search.ts
@@ -1,3 +1,7 @@
+// Relative imports (not @klank/platform-api): this tool runs under plain
+// `node` with type stripping, which can't resolve workspace path aliases, and
+// the lib barrel pulls in Tauri-importing modules. chord-theory.ts is kept
+// free of runtime imports for exactly this reason.
 import type { ChordVariant, Instrument } from '../../libs/platform-api/src/lib/chord-diagrams.ts'
 import {
   CHORD_INTERVALS,
@@ -10,13 +14,16 @@ import {
   validateChordVariant,
 } from '../../libs/platform-api/src/lib/chord-theory.ts'
 
+/** Highest neck position a voicing search window may start at. */
 const MAX_BASE = 12
 const MAX_FINGERS = 4
+/** Even power chords get 3 strings (root, 5th, octave) — the shape players know. */
+const MIN_SOUNDING = 3
 
 export type ScoredVariant = { variant: ChordVariant; score: number }
 
 /** Lowest fretted fret — the neck position of a shape (0 = all open). */
-export function positionOf(variant: ChordVariant): number {
+function positionOf(variant: ChordVariant): number {
   const fretted = variant.frets.filter((f) => f > 0)
   return fretted.length > 0 ? Math.min(...fretted) : 0
 }
@@ -63,7 +70,7 @@ function compareFrets(a: readonly number[], b: readonly number[]): number {
  * order, which reproduces canonical fingerings for open shapes; five or more
  * fretted positions become an index-finger barre at the lowest fret.
  */
-export function assignFingering(frets: number[], strings: number): ChordVariant | null {
+function assignFingering(frets: number[], strings: number): ChordVariant | null {
   const positions = frets
     .map((fret, string) => ({ fret, string }))
     .filter((p) => p.fret > 0)
@@ -119,8 +126,6 @@ export function searchVoicings(chordKey: string, instrument: Instrument): Scored
   const allowed = getAllowedPitches(parsed)
   const required = getRequiredPitches(parsed)
   const bassPitch = parsed.bassPitch ?? parsed.rootPitch
-  // even power chords get 3 strings (root, 5th, octave) — the shape players know
-  const minSounding = 3
 
   const seen = new Set<string>()
   const results: ScoredVariant[] = []
@@ -141,8 +146,8 @@ export function searchVoicings(chordKey: string, instrument: Instrument): Scored
 
   for (let base = 1; base <= MAX_BASE; base++) {
     const windowMax = base + MAX_SPAN
-    for (let start = 0; start <= n - minSounding; start++) {
-      for (let end = start + minSounding - 1; end < n; end++) {
+    for (let start = 0; start <= n - MIN_SOUNDING; start++) {
+      for (let end = start + MIN_SOUNDING - 1; end < n; end++) {
         // options per sounding string: open string or an allowed tone inside the
         // window; open strings only mix with shapes at the nut — ringing opens
         // under a hand parked at the 5th fret are unidiomatic
@@ -186,8 +191,9 @@ export function searchVoicings(chordKey: string, instrument: Instrument): Scored
   return results
 }
 
-/** Diverse picks below this score are too awkward to ship as alternatives. */
-const DIVERSITY_SCORE_FLOOR = -12
+/** Shapes scoring below this are too awkward to ship as alternatives;
+ *  only the first (best) pick of a key may ignore it. */
+const SCORE_FLOOR = -12
 
 /**
  * Picks up to `count` voicings from a best-first list. A first pass prefers
@@ -209,7 +215,7 @@ export function selectVoicings(
     for (const { variant, score } of ranked) {
       if (picked.length >= count) break
       if (isDuplicate(variant)) continue
-      if (score < DIVERSITY_SCORE_FLOOR && picked.length > 0) continue
+      if (score < SCORE_FLOOR && picked.length > 0) continue
       if (diverse && picked.some((p) => Math.abs(positionOf(p) - positionOf(variant)) < 2)) continue
       picked.push(variant)
     }
@@ -223,5 +229,5 @@ export function selectVoicings(
       (scoreOf.get(b.frets.join(',')) ?? 0) - (scoreOf.get(a.frets.join(',')) ?? 0) ||
       compareFrets(a.frets, b.frets),
   )
-  return [...picked.slice(0, preselected.length), ...searched]
+  return [...preselected, ...searched]
 }

--- a/tools/chord-data/voicing-search.ts
+++ b/tools/chord-data/voicing-search.ts
@@ -1,0 +1,227 @@
+import type { ChordVariant, Instrument } from '../../libs/platform-api/src/lib/chord-diagrams.ts'
+import {
+  CHORD_INTERVALS,
+  INSTRUMENT_TUNING,
+  MAX_SPAN,
+  getAllowedPitches,
+  getRequiredPitches,
+  getVariantNotes,
+  parseChordKey,
+  validateChordVariant,
+} from '../../libs/platform-api/src/lib/chord-theory.ts'
+
+const MAX_BASE = 12
+const MAX_FINGERS = 4
+
+export type ScoredVariant = { variant: ChordVariant; score: number }
+
+/** Lowest fretted fret — the neck position of a shape (0 = all open). */
+export function positionOf(variant: ChordVariant): number {
+  const fretted = variant.frets.filter((f) => f > 0)
+  return fretted.length > 0 ? Math.min(...fretted) : 0
+}
+
+/** Deterministic playability/idiomaticity score — higher is better. */
+function scoreVariant(variant: ChordVariant, quality: string, rootPitch: number, tuning: readonly number[]): number {
+  const { frets, barres } = variant
+  const sounding = frets.filter((f) => f >= 0)
+  const fretted = frets.filter((f) => f > 0)
+  const open = frets.filter((f) => f === 0)
+  const maxFret = fretted.length > 0 ? Math.max(...fretted) : 0
+  const span = fretted.length > 0 ? maxFret - Math.min(...fretted) : 0
+  const openPosition = maxFret <= 3
+
+  let score = 4 * sounding.length
+  if (openPosition) {
+    score += 8 + 2 * open.length
+  } else {
+    // open strings ringing under a shape played up the neck are unidiomatic
+    score -= 6 * open.length
+  }
+  score -= 2 * Math.max(0, positionOf(variant) - 1)
+  if (barres.length > 0) score -= 6
+  score -= 2 * fretted.length
+  score -= 4 * Math.max(0, span - 2)
+  if (CHORD_INTERVALS[quality].length === 4) {
+    const fifth = (rootPitch + 7) % 12
+    if (getVariantNotes(variant, tuning).has(fifth)) score += 6
+  }
+  return score
+}
+
+/** Lexicographic comparison of fret arrays — the deterministic tie-breaker. */
+function compareFrets(a: readonly number[], b: readonly number[]): number {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i]
+  }
+  return 0
+}
+
+/**
+ * Assigns fingers and barres to a fret combination, or returns null when no
+ * physically sensible assignment exists. Fingers follow sorted (fret, string)
+ * order, which reproduces canonical fingerings for open shapes; five or more
+ * fretted positions become an index-finger barre at the lowest fret.
+ */
+export function assignFingering(frets: number[], strings: number): ChordVariant | null {
+  const positions = frets
+    .map((fret, string) => ({ fret, string }))
+    .filter((p) => p.fret > 0)
+    .sort((a, b) => a.fret - b.fret || a.string - b.string)
+
+  const fretted = positions.map((p) => p.fret)
+  const maxFret = fretted.length > 0 ? Math.max(...fretted) : 0
+  const minFret = fretted.length > 0 ? Math.min(...fretted) : 0
+  const baseFret = maxFret <= 5 ? 1 : minFret
+
+  const fingers = Array.from({ length: strings }, () => 0)
+  const barres: ChordVariant['barres'] = []
+
+  if (positions.length <= MAX_FINGERS) {
+    positions.forEach((p, i) => {
+      fingers[p.string] = i + 1
+    })
+  } else {
+    // barre with the index finger across every string at the lowest fret
+    const barred = positions.filter((p) => p.fret === minFret)
+    if (barred.length < 2) return null
+    const rest = positions.filter((p) => p.fret > minFret)
+    if (rest.length > MAX_FINGERS - 1) return null
+
+    const fromString = barred[0].string
+    const toString = barred[barred.length - 1].string
+    for (let s = fromString; s <= toString; s++) {
+      if (frets[s] < minFret) return null // open or muted string under the bar
+    }
+    for (const p of barred) fingers[p.string] = 1
+    rest.forEach((p, i) => {
+      fingers[p.string] = i + 2
+    })
+    barres.push({ fret: minFret - baseFret + 1, fromString, toString })
+  }
+
+  return { frets, fingers, baseFret, barres }
+}
+
+/**
+ * Enumerates every valid voicing of a chord on an instrument: contiguous
+ * sounding strings, fretted notes inside a sliding 4-fret window, lowest
+ * sounding string playing the root (or slash bass), all required chord tones
+ * present, and a physically assignable fingering that passes the full
+ * validator. Results are deterministic and sorted best-first.
+ */
+export function searchVoicings(chordKey: string, instrument: Instrument): ScoredVariant[] {
+  const parsed = parseChordKey(chordKey)
+  if (!parsed) throw new Error(`unknown chord key "${chordKey}"`)
+  const tuning = INSTRUMENT_TUNING[instrument]
+  const n = tuning.length
+
+  const allowed = getAllowedPitches(parsed)
+  const required = getRequiredPitches(parsed)
+  const bassPitch = parsed.bassPitch ?? parsed.rootPitch
+  // even power chords get 3 strings (root, 5th, octave) — the shape players know
+  const minSounding = 3
+
+  const seen = new Set<string>()
+  const results: ScoredVariant[] = []
+
+  const tryCandidate = (frets: number[]) => {
+    const signature = frets.join(',')
+    if (seen.has(signature)) return
+    seen.add(signature)
+
+    const variant = assignFingering(frets, n)
+    if (!variant) return
+    if (validateChordVariant(chordKey, variant, instrument).length > 0) return
+    results.push({
+      variant,
+      score: scoreVariant(variant, parsed.quality, parsed.rootPitch, tuning),
+    })
+  }
+
+  for (let base = 1; base <= MAX_BASE; base++) {
+    const windowMax = base + MAX_SPAN
+    for (let start = 0; start <= n - minSounding; start++) {
+      for (let end = start + minSounding - 1; end < n; end++) {
+        // options per sounding string: open string or an allowed tone inside the
+        // window; open strings only mix with shapes at the nut — ringing opens
+        // under a hand parked at the 5th fret are unidiomatic
+        const options: number[][] = []
+        for (let s = start; s <= end; s++) {
+          const stringOptions: number[] = []
+          if (base === 1 && allowed.has(tuning[s] % 12)) stringOptions.push(0)
+          for (let f = base; f <= windowMax; f++) {
+            if (allowed.has((tuning[s] + f) % 12)) stringOptions.push(f)
+          }
+          options.push(stringOptions)
+        }
+        if (options.some((o) => o.length === 0)) continue
+
+        const frets = Array.from({ length: n }, () => -1)
+        const sounded = new Map<number, number>() // pitch -> count
+
+        const dfs = (s: number) => {
+          if (s > end) {
+            if ([...required].every((p) => (sounded.get(p) ?? 0) > 0)) {
+              tryCandidate([...frets])
+            }
+            return
+          }
+          for (const f of options[s - start]) {
+            const pitch = (tuning[s] + f) % 12
+            if (s === start && pitch !== bassPitch) continue
+            frets[s] = f
+            sounded.set(pitch, (sounded.get(pitch) ?? 0) + 1)
+            dfs(s + 1)
+            sounded.set(pitch, (sounded.get(pitch) ?? 0) - 1)
+            frets[s] = -1
+          }
+        }
+        dfs(start)
+      }
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score || compareFrets(a.variant.frets, b.variant.frets))
+  return results
+}
+
+/** Diverse picks below this score are too awkward to ship as alternatives. */
+const DIVERSITY_SCORE_FLOOR = -12
+
+/**
+ * Picks up to `count` voicings from a best-first list. A first pass prefers
+ * shapes whose neck position differs by at least 2 frets from everything
+ * already chosen (genuinely different voicings, not near-duplicates), a
+ * second pass fills remaining slots best-first. The preselected seed stays
+ * first; other picks are ordered low position to high.
+ */
+export function selectVoicings(
+  ranked: readonly ScoredVariant[],
+  count: number,
+  preselected: readonly ChordVariant[] = [],
+): ChordVariant[] {
+  const picked: ChordVariant[] = [...preselected]
+  const isDuplicate = (v: ChordVariant) =>
+    picked.some((p) => p.frets.join(',') === v.frets.join(','))
+
+  for (const diverse of [true, false]) {
+    for (const { variant, score } of ranked) {
+      if (picked.length >= count) break
+      if (isDuplicate(variant)) continue
+      if (score < DIVERSITY_SCORE_FLOOR && picked.length > 0) continue
+      if (diverse && picked.some((p) => Math.abs(positionOf(p) - positionOf(variant)) < 2)) continue
+      picked.push(variant)
+    }
+  }
+
+  const searched = picked.slice(preselected.length)
+  const scoreOf = new Map(ranked.map(({ variant, score }) => [variant.frets.join(','), score]))
+  searched.sort(
+    (a, b) =>
+      positionOf(a) - positionOf(b) ||
+      (scoreOf.get(b.frets.join(',')) ?? 0) - (scoreOf.get(a.frets.join(',')) ?? 0) ||
+      compareFrets(a.frets, b.frets),
+  )
+  return [...picked.slice(0, preselected.length), ...searched]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     },
     {
       "path": "./libs/platform-api"
-    },
+    }
   ]
 }


### PR DESCRIPTION
# Sanitize AI-generated chord diagram data

## Problem

An audit of the AI-generated `chords-guitar.json` / `chords-bass.json` found **~60 of 290 variants broken**, none caught by the existing test (it only checked for wrong notes):

- 11 bass chords missing their **root** (D# major contained no D#); bass `A`, `Am`, and `Asus4` were the identical root+fifth shape — no third, so qualities were indistinguishable
- 16 impossible fingerings (same finger on two different frets with no barre), 19 fingers assigned to muted/open strings
- 13 frets outside the rendered 5-fret window (dots silently vanish in `ChordDiagram`)
- 7 phantom barres matching no fretted string, 4 barres drawn across open strings
- Mixed absolute/row barre semantics, while the renderer strictly expects rows
- Span/baseFret inconsistencies and exact duplicates

## Approach: regenerate, don't hand-patch

1. **Strict validator** (`libs/platform-api/src/lib/chord-theory.ts`): `validateChordVariant` enforces the full data contract — shape, finger presence, render window, 4-fret span, contiguous sounding strings, note correctness, **chord completeness** (every triad sounds all of its tones; 7th chords always sound root/3rd/7th and may omit only the 5th), root-or-slash-bass as the lowest note, finger/barre consistency in row semantics, and finger anatomy.
2. **Deterministic generator** (`tools/chord-data/`): `node tools/chord-data/generate-chord-data.ts` regenerates both JSON files — enumerates voicings per key, assigns fingers/barres, rejects anything the validator refuses, ranks by playability, and pins canonical open shapes (C = x32010, F barre, …) as the first guitar variant. Byte-identical across reruns; `--preview <keys>` prints ASCII diagrams.
3. **Permanent audit** (`chord-correctness.spec.ts`): the committed JSON is validated rule-by-rule in CI, so a future bad edit fails with the key, frets, and rule named.

## New: alternate-bass (slash) chords

Each instrument now ships 204 keys — 120 root×quality plus **84 slash keys** (each major: /3rd, /5th, /maj7-bass, /b7-bass; each minor: /b3rd, /5th, /b7-bass), covering G/B, D/F#, Dm/F, C/B, Am/G, C/E, …. The tab parser already recognized slash chords; `normalizeChordKey` now preserves the bass note (`Dm/Gb` → `Dm/F#`) and `lookupChordDiagram` falls back to the plain root chord for slash names not shipped. No UI changes needed.

## Testing strategy

Property-based (fast-check) wherever a law exists, examples where they document ground truth:

- **Laws**: `parseChordKey` round-trips every constructible root/quality/slash-bass key; tone sets satisfy required ⊆ allowed with only 7th chords allowed to drop only the 5th; **barre shapes stay valid under transposition** (movable-shape law); flat-root/flat-bass normalization and slash-key lookup fallback.
- **Mutation properties**: each mechanisable validator rule has a property that corrupts a canonical fixture and asserts the rule fires (finger-presence, window, span, mute-edges, bass-note, anatomy). A global property pins the rule-id vocabulary and proves the validator never throws on arbitrary malformed input; another proves zero-violation variants always render fully inside the 5-row window.
- **Examples kept deliberately**: canonical shape fixtures (C = x32010 etc. are ground truth, not laws) and crafted reproductions of the real-world data bugs (phantom A-major barre, bass missing-third).
- **Exhaustive audit**: `chord-correctness.spec.ts` validates every committed variant rather than sampling — for shipped data, exhaustive beats property-based.

## Tooling notes

- nx infers `tools/chord-data` as a project; `@nx/enforce-module-boundaries` is disabled for `tools/**` because the script runs under plain `node` (type stripping) which cannot resolve `@klank/*` aliases — it imports the lib sources relatively, and `chord-theory.ts` is documented as runtime-import-free to keep that working.
- `nx sync` reference updates to `tsconfig.json` files are included.

## Verification

- `nx run-many -t lint,typecheck,test` across the workspace + `nx build klank` — all green
- Generator run twice → byte-identical output; rerun after cleanup → data unchanged
- ASCII preview review of former offenders (bass D#/A/Am, guitar barre and window bugs) and of canonical/slash shapes

https://claude.ai/code/session_018jdGd76rY16TBaAvPJsifm