### PR TITLE
Unify chord detection with the chord theory engine; jazz spellings + expanded diagram data

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,131 @@
+name: PR Build
+
+# On-demand application build for a pull request: apply the `build` label
+# (re-apply it to rebuild), or dispatch manually with a PR number. Produces
+# the Windows installers (the distribution format release-windows.yml ships)
+# and publishes them to a rolling `pr-<number>` prerelease, then comments the
+# release URL on the PR.
+#
+# NOTE: the GITHUB_TOKEN of fork PRs is read-only; the release/comment steps
+# only work for branches in this repository.
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to build
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'build'
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve PR number and version
+        id: meta
+        shell: pwsh
+        run: |
+          $pr = '${{ github.event.pull_request.number || inputs.pr }}'
+          # MSI requires a purely numeric x.y.z version; 0.<pr>.<run> keeps PR
+          # builds unique and visibly distinct from real 2.x releases.
+          $ver = "0.$pr.${{ github.run_number }}"
+          Write-Output "PR=$pr" >> $env:GITHUB_OUTPUT
+          Write-Output "VERSION=$ver" >> $env:GITHUB_OUTPUT
+          Write-Host "Building PR #$pr as version $ver"
+
+      - name: Patch tauri.conf.json
+        shell: pwsh
+        run: |
+          $ver = '${{ steps.meta.outputs.VERSION }}'
+          $path = 'apps/klank/src-tauri/tauri.conf.json'
+          $json = Get-Content $path -Raw | ConvertFrom-Json
+          $json.version = $ver
+          $json | ConvertTo-Json -Depth 10 | Set-Content $path -Encoding UTF8
+
+      - name: Patch Cargo.toml
+        shell: pwsh
+        run: |
+          $ver = '${{ steps.meta.outputs.VERSION }}'
+          $path = 'apps/klank/src-tauri/Cargo.toml'
+          $content = Get-Content $path -Raw
+          $patched = $content -replace '(?m)^version = "[\d.]+"', "version = `"$ver`""
+          Set-Content $path -Value $patched -Encoding UTF8 -NoNewline
+
+      # Reads the pnpm version from packageManager in package.json
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/klank/src-tauri -> target
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Windows installers
+        run: pnpm tauri:build:windows
+
+      - name: Publish rolling prerelease
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $pr  = '${{ steps.meta.outputs.PR }}'
+          $ver = '${{ steps.meta.outputs.VERSION }}'
+          $tag = "pr-$pr"
+          $nsis = Get-ChildItem apps/klank/src-tauri/target/release/bundle/nsis/*.exe | Select-Object -First 1
+          $msi  = Get-ChildItem apps/klank/src-tauri/target/release/bundle/msi/*.msi  | Select-Object -First 1
+
+          # Rolling release: each build of the PR replaces the previous one.
+          gh release delete $tag --yes --cleanup-tag 2>$null
+          if ($LASTEXITCODE -ne 0) { Write-Host "no previous $tag release" }
+
+          gh release create $tag `
+            --prerelease `
+            --target $env:GITHUB_SHA `
+            --title "klank PR #$pr build ($ver)" `
+            --notes "On-demand build of PR #$pr at $env:GITHUB_SHA — not a release." `
+            $nsis.FullName $msi.FullName
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+          Write-Output "URL=https://github.com/${{ github.repository }}/releases/tag/$tag" >> $env:GITHUB_OUTPUT
+
+      - name: Comment release URL on the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          gh pr comment '${{ steps.meta.outputs.PR }}' --repo '${{ github.repository }}' --body @"
+          :package: PR build ``${{ steps.meta.outputs.VERSION }}`` is ready: ${{ steps.release.outputs.URL }}
+          "@
+
+      - name: Comment failure on the PR
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          gh pr comment '${{ steps.meta.outputs.PR }}' --repo '${{ github.repository }}' --body @"
+          :x: PR build failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          "@

--- a/apps/klank/public/chords-bass.json
+++ b/apps/klank/public/chords-bass.json
@@ -467,6 +467,588 @@
   "G#5": [
     { "frets": [4, 6, 6, -1], "fingers": [1, 2, 3, 0], "baseFret": 4, "barres": [] }
   ],
+  "Am7b5": [
+    { "frets": [5, 6, 5, 5], "fingers": [1, 4, 2, 3], "baseFret": 5, "barres": [] }
+  ],
+  "A#m7b5": [
+    { "frets": [6, 7, 6, 6], "fingers": [1, 4, 2, 3], "baseFret": 6, "barres": [] }
+  ],
+  "Bm7b5": [
+    { "frets": [7, 8, 7, 7], "fingers": [1, 4, 2, 3], "baseFret": 7, "barres": [] }
+  ],
+  "Cm7b5": [
+    { "frets": [8, 9, 8, 8], "fingers": [1, 4, 2, 3], "baseFret": 8, "barres": [] }
+  ],
+  "C#m7b5": [
+    { "frets": [9, 10, 9, 9], "fingers": [1, 4, 2, 3], "baseFret": 9, "barres": [] }
+  ],
+  "Dm7b5": [
+    { "frets": [10, 11, 10, 10], "fingers": [1, 4, 2, 3], "baseFret": 10, "barres": [] }
+  ],
+  "D#m7b5": [
+    { "frets": [11, 12, 11, 11], "fingers": [1, 4, 2, 3], "baseFret": 11, "barres": [] }
+  ],
+  "Em7b5": [
+    { "frets": [0, 1, 0, 0], "fingers": [0, 1, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "Fm7b5": [
+    { "frets": [1, 2, 1, 1], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "F#m7b5": [
+    { "frets": [2, 3, 2, 2], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Gm7b5": [
+    { "frets": [3, 4, 3, 3], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#m7b5": [
+    { "frets": [4, 5, 4, 4], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Adim7": [
+    { "frets": [5, 6, 4, 5], "fingers": [2, 4, 1, 3], "baseFret": 4, "barres": [] }
+  ],
+  "A#dim7": [
+    { "frets": [6, 7, 5, 6], "fingers": [2, 4, 1, 3], "baseFret": 5, "barres": [] }
+  ],
+  "Bdim7": [
+    { "frets": [7, 8, 6, 7], "fingers": [2, 4, 1, 3], "baseFret": 6, "barres": [] }
+  ],
+  "Cdim7": [
+    { "frets": [8, 9, 7, 8], "fingers": [2, 4, 1, 3], "baseFret": 7, "barres": [] }
+  ],
+  "C#dim7": [
+    { "frets": [9, 10, 8, 9], "fingers": [2, 4, 1, 3], "baseFret": 8, "barres": [] }
+  ],
+  "Ddim7": [
+    { "frets": [10, 11, 9, 10], "fingers": [2, 4, 1, 3], "baseFret": 9, "barres": [] }
+  ],
+  "D#dim7": [
+    { "frets": [11, 12, 10, 11], "fingers": [2, 4, 1, 3], "baseFret": 10, "barres": [] }
+  ],
+  "Edim7": [
+    { "frets": [12, 13, 11, 12], "fingers": [2, 4, 1, 3], "baseFret": 11, "barres": [] }
+  ],
+  "Fdim7": [
+    { "frets": [1, 2, 0, 1], "fingers": [1, 3, 0, 2], "baseFret": 1, "barres": [] }
+  ],
+  "F#dim7": [
+    { "frets": [2, 3, 1, 2], "fingers": [2, 4, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Gdim7": [
+    { "frets": [3, 4, 2, 3], "fingers": [2, 4, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#dim7": [
+    { "frets": [4, 5, 3, 4], "fingers": [2, 4, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "A6": [
+    { "frets": [5, 7, 4, 6], "fingers": [2, 4, 1, 3], "baseFret": 4, "barres": [] }
+  ],
+  "A#6": [
+    { "frets": [6, 8, 5, 7], "fingers": [2, 4, 1, 3], "baseFret": 5, "barres": [] }
+  ],
+  "B6": [
+    { "frets": [7, 9, 6, 8], "fingers": [2, 4, 1, 3], "baseFret": 6, "barres": [] }
+  ],
+  "C6": [
+    { "frets": [8, 10, 7, 9], "fingers": [2, 4, 1, 3], "baseFret": 7, "barres": [] }
+  ],
+  "C#6": [
+    { "frets": [9, 11, 8, 10], "fingers": [2, 4, 1, 3], "baseFret": 8, "barres": [] }
+  ],
+  "D6": [
+    { "frets": [10, 12, 9, 11], "fingers": [2, 4, 1, 3], "baseFret": 9, "barres": [] }
+  ],
+  "D#6": [
+    { "frets": [11, 13, 10, 12], "fingers": [2, 4, 1, 3], "baseFret": 10, "barres": [] }
+  ],
+  "E6": [
+    { "frets": [12, 14, 11, 13], "fingers": [2, 4, 1, 3], "baseFret": 11, "barres": [] }
+  ],
+  "F6": [
+    { "frets": [1, 3, 0, 2], "fingers": [1, 3, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [13, 15, 12, 14], "fingers": [2, 4, 1, 3], "baseFret": 12, "barres": [] }
+  ],
+  "F#6": [
+    { "frets": [2, 4, 1, 3], "fingers": [2, 4, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G6": [
+    { "frets": [3, 5, 2, 4], "fingers": [2, 4, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#6": [
+    { "frets": [4, 6, 3, 5], "fingers": [2, 4, 1, 3], "baseFret": 3, "barres": [] }
+  ],
+  "Am6": [
+    { "frets": [5, 7, 4, 5], "fingers": [2, 4, 1, 3], "baseFret": 4, "barres": [] }
+  ],
+  "A#m6": [
+    { "frets": [6, 8, 5, 6], "fingers": [2, 4, 1, 3], "baseFret": 5, "barres": [] }
+  ],
+  "Bm6": [
+    { "frets": [7, 9, 6, 7], "fingers": [2, 4, 1, 3], "baseFret": 6, "barres": [] }
+  ],
+  "Cm6": [
+    { "frets": [8, 10, 7, 8], "fingers": [2, 4, 1, 3], "baseFret": 7, "barres": [] }
+  ],
+  "C#m6": [
+    { "frets": [9, 11, 8, 9], "fingers": [2, 4, 1, 3], "baseFret": 8, "barres": [] }
+  ],
+  "Dm6": [
+    { "frets": [10, 12, 9, 10], "fingers": [2, 4, 1, 3], "baseFret": 9, "barres": [] }
+  ],
+  "D#m6": [
+    { "frets": [11, 13, 10, 11], "fingers": [2, 4, 1, 3], "baseFret": 10, "barres": [] }
+  ],
+  "Em6": [
+    { "frets": [12, 14, 11, 12], "fingers": [2, 4, 1, 3], "baseFret": 11, "barres": [] }
+  ],
+  "Fm6": [
+    { "frets": [1, 3, 0, 1], "fingers": [1, 3, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [13, 15, 12, 13], "fingers": [2, 4, 1, 3], "baseFret": 12, "barres": [] }
+  ],
+  "F#m6": [
+    { "frets": [2, 4, 1, 2], "fingers": [2, 4, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Gm6": [
+    { "frets": [3, 5, 2, 3], "fingers": [2, 4, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#m6": [
+    { "frets": [4, 6, 3, 4], "fingers": [2, 4, 1, 3], "baseFret": 3, "barres": [] }
+  ],
+  "A69": [
+    { "frets": [5, 4, 4, 4], "fingers": [4, 1, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "A#69": [
+    { "frets": [6, 5, 5, 5], "fingers": [4, 1, 2, 3], "baseFret": 5, "barres": [] }
+  ],
+  "B69": [
+    { "frets": [7, 6, 6, 6], "fingers": [4, 1, 2, 3], "baseFret": 6, "barres": [] }
+  ],
+  "C69": [
+    { "frets": [8, 7, 7, 7], "fingers": [4, 1, 2, 3], "baseFret": 7, "barres": [] }
+  ],
+  "C#69": [
+    { "frets": [9, 8, 8, 8], "fingers": [4, 1, 2, 3], "baseFret": 8, "barres": [] }
+  ],
+  "D69": [
+    { "frets": [10, 9, 9, 9], "fingers": [4, 1, 2, 3], "baseFret": 9, "barres": [] }
+  ],
+  "D#69": [
+    { "frets": [11, 10, 10, 10], "fingers": [4, 1, 2, 3], "baseFret": 10, "barres": [] }
+  ],
+  "E69": [
+    { "frets": [0, 4, 4, 1], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [12, 11, 11, 11], "fingers": [4, 1, 2, 3], "baseFret": 11, "barres": [] }
+  ],
+  "F69": [
+    { "frets": [1, 0, 0, 0], "fingers": [1, 0, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "F#69": [
+    { "frets": [2, 1, 1, 1], "fingers": [4, 1, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G69": [
+    { "frets": [3, 2, 2, 2], "fingers": [4, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 2, 4], "fingers": [2, 0, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#69": [
+    { "frets": [4, 3, 3, 3], "fingers": [4, 1, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Aadd9": [
+    { "frets": [5, 4, 2, 4], "fingers": [4, 2, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "A#add9": [
+    { "frets": [6, 5, 3, 5], "fingers": [4, 2, 1, 3], "baseFret": 3, "barres": [] }
+  ],
+  "Badd9": [
+    { "frets": [7, 6, 4, 6], "fingers": [4, 2, 1, 3], "baseFret": 4, "barres": [] }
+  ],
+  "Cadd9": [
+    { "frets": [8, 7, 5, 7], "fingers": [4, 2, 1, 3], "baseFret": 5, "barres": [] }
+  ],
+  "C#add9": [
+    { "frets": [9, 8, 6, 8], "fingers": [4, 2, 1, 3], "baseFret": 6, "barres": [] }
+  ],
+  "Dadd9": [
+    { "frets": [10, 9, 7, 9], "fingers": [4, 2, 1, 3], "baseFret": 7, "barres": [] }
+  ],
+  "D#add9": [
+    { "frets": [11, 10, 8, 10], "fingers": [4, 2, 1, 3], "baseFret": 8, "barres": [] }
+  ],
+  "Eadd9": [
+    { "frets": [0, 2, 4, 1], "fingers": [0, 2, 3, 1], "baseFret": 1, "barres": [] },
+    { "frets": [12, 11, 9, 11], "fingers": [4, 2, 1, 3], "baseFret": 9, "barres": [] }
+  ],
+  "Fadd9": [
+    { "frets": [13, 12, 10, 12], "fingers": [4, 2, 1, 3], "baseFret": 10, "barres": [] }
+  ],
+  "F#add9": [
+    { "frets": [14, 13, 11, 13], "fingers": [4, 2, 1, 3], "baseFret": 11, "barres": [] }
+  ],
+  "Gadd9": [
+    { "frets": [3, 2, 0, 2], "fingers": [3, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [15, 14, 12, 14], "fingers": [4, 2, 1, 3], "baseFret": 12, "barres": [] }
+  ],
+  "G#add9": [
+    { "frets": [4, 3, 1, 3], "fingers": [4, 2, 1, 3], "baseFret": 1, "barres": [] }
+  ],
+  "A9": [
+    { "frets": [5, 4, 5, 4], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+  ],
+  "A#9": [
+    { "frets": [6, 5, 6, 5], "fingers": [3, 1, 4, 2], "baseFret": 5, "barres": [] }
+  ],
+  "B9": [
+    { "frets": [7, 6, 7, 6], "fingers": [3, 1, 4, 2], "baseFret": 6, "barres": [] }
+  ],
+  "C9": [
+    { "frets": [8, 7, 8, 7], "fingers": [3, 1, 4, 2], "baseFret": 7, "barres": [] }
+  ],
+  "C#9": [
+    { "frets": [9, 8, 9, 8], "fingers": [3, 1, 4, 2], "baseFret": 8, "barres": [] }
+  ],
+  "D9": [
+    { "frets": [10, 9, 10, 9], "fingers": [3, 1, 4, 2], "baseFret": 9, "barres": [] }
+  ],
+  "D#9": [
+    { "frets": [11, 10, 11, 10], "fingers": [3, 1, 4, 2], "baseFret": 10, "barres": [] }
+  ],
+  "E9": [
+    { "frets": [12, 11, 12, 11], "fingers": [3, 1, 4, 2], "baseFret": 11, "barres": [] }
+  ],
+  "F9": [
+    { "frets": [1, 0, 1, 0], "fingers": [1, 0, 2, 0], "baseFret": 1, "barres": [] }
+  ],
+  "F#9": [
+    { "frets": [2, 1, 2, 1], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+  ],
+  "G9": [
+    { "frets": [3, 2, 3, 2], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 3, 4], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#9": [
+    { "frets": [4, 3, 4, 3], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+  ],
+  "Am9": [
+    { "frets": [5, 2, 5, 5], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [5, 3, 5, 4], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+  ],
+  "A#m9": [
+    { "frets": [6, 3, 6, 6], "fingers": [2, 1, 3, 4], "baseFret": 3, "barres": [] },
+    { "frets": [6, 4, 6, 5], "fingers": [3, 1, 4, 2], "baseFret": 4, "barres": [] }
+  ],
+  "Bm9": [
+    { "frets": [7, 4, 7, 7], "fingers": [2, 1, 3, 4], "baseFret": 4, "barres": [] },
+    { "frets": [7, 5, 7, 6], "fingers": [3, 1, 4, 2], "baseFret": 5, "barres": [] }
+  ],
+  "Cm9": [
+    { "frets": [8, 5, 8, 8], "fingers": [2, 1, 3, 4], "baseFret": 5, "barres": [] },
+    { "frets": [8, 6, 8, 7], "fingers": [3, 1, 4, 2], "baseFret": 6, "barres": [] }
+  ],
+  "C#m9": [
+    { "frets": [9, 6, 9, 9], "fingers": [2, 1, 3, 4], "baseFret": 6, "barres": [] },
+    { "frets": [9, 7, 9, 8], "fingers": [3, 1, 4, 2], "baseFret": 7, "barres": [] }
+  ],
+  "Dm9": [
+    { "frets": [10, 7, 10, 10], "fingers": [2, 1, 3, 4], "baseFret": 7, "barres": [] },
+    { "frets": [10, 8, 10, 9], "fingers": [3, 1, 4, 2], "baseFret": 8, "barres": [] }
+  ],
+  "D#m9": [
+    { "frets": [11, 8, 11, 11], "fingers": [2, 1, 3, 4], "baseFret": 8, "barres": [] },
+    { "frets": [11, 9, 11, 10], "fingers": [3, 1, 4, 2], "baseFret": 9, "barres": [] }
+  ],
+  "Em9": [
+    { "frets": [12, 9, 12, 12], "fingers": [2, 1, 3, 4], "baseFret": 9, "barres": [] },
+    { "frets": [12, 10, 12, 11], "fingers": [3, 1, 4, 2], "baseFret": 10, "barres": [] }
+  ],
+  "Fm9": [
+    { "frets": [13, 11, 13, 12], "fingers": [3, 1, 4, 2], "baseFret": 11, "barres": [] }
+  ],
+  "F#m9": [
+    { "frets": [2, 0, 2, 1], "fingers": [2, 0, 3, 1], "baseFret": 1, "barres": [] }
+  ],
+  "Gm9": [
+    { "frets": [3, 1, 3, 2], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 3, 3], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#m9": [
+    { "frets": [4, 1, 4, 4], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [4, 2, 4, 3], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+  ],
+  "Amaj9": [
+    { "frets": [5, 4, 6, 4], "fingers": [3, 1, 4, 2], "baseFret": 4, "barres": [] }
+  ],
+  "A#maj9": [
+    { "frets": [6, 5, 7, 5], "fingers": [3, 1, 4, 2], "baseFret": 5, "barres": [] }
+  ],
+  "Bmaj9": [
+    { "frets": [7, 6, 8, 6], "fingers": [3, 1, 4, 2], "baseFret": 6, "barres": [] }
+  ],
+  "Cmaj9": [
+    { "frets": [8, 7, 9, 7], "fingers": [3, 1, 4, 2], "baseFret": 7, "barres": [] }
+  ],
+  "C#maj9": [
+    { "frets": [9, 8, 10, 8], "fingers": [3, 1, 4, 2], "baseFret": 8, "barres": [] }
+  ],
+  "Dmaj9": [
+    { "frets": [10, 9, 11, 9], "fingers": [3, 1, 4, 2], "baseFret": 9, "barres": [] }
+  ],
+  "D#maj9": [
+    { "frets": [11, 10, 12, 10], "fingers": [3, 1, 4, 2], "baseFret": 10, "barres": [] }
+  ],
+  "Emaj9": [
+    { "frets": [12, 11, 13, 11], "fingers": [3, 1, 4, 2], "baseFret": 11, "barres": [] }
+  ],
+  "Fmaj9": [
+    { "frets": [1, 0, 2, 0], "fingers": [1, 0, 2, 0], "baseFret": 1, "barres": [] }
+  ],
+  "F#maj9": [
+    { "frets": [2, 1, 3, 1], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+  ],
+  "Gmaj9": [
+    { "frets": [3, 2, 4, 2], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 4, 4], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G#maj9": [
+    { "frets": [4, 3, 5, 3], "fingers": [3, 1, 4, 2], "baseFret": 1, "barres": [] }
+  ],
+  "A7b5": [
+    { "frets": [5, 6, 5, 6], "fingers": [1, 3, 2, 4], "baseFret": 5, "barres": [] }
+  ],
+  "A#7b5": [
+    { "frets": [6, 7, 6, 7], "fingers": [1, 3, 2, 4], "baseFret": 6, "barres": [] }
+  ],
+  "B7b5": [
+    { "frets": [7, 8, 7, 8], "fingers": [1, 3, 2, 4], "baseFret": 7, "barres": [] }
+  ],
+  "C7b5": [
+    { "frets": [8, 9, 8, 9], "fingers": [1, 3, 2, 4], "baseFret": 8, "barres": [] }
+  ],
+  "C#7b5": [
+    { "frets": [9, 10, 9, 10], "fingers": [1, 3, 2, 4], "baseFret": 9, "barres": [] }
+  ],
+  "D7b5": [
+    { "frets": [10, 11, 10, 11], "fingers": [1, 3, 2, 4], "baseFret": 10, "barres": [] }
+  ],
+  "D#7b5": [
+    { "frets": [11, 12, 11, 12], "fingers": [1, 3, 2, 4], "baseFret": 11, "barres": [] }
+  ],
+  "E7b5": [
+    { "frets": [0, 1, 0, 1], "fingers": [0, 1, 0, 2], "baseFret": 1, "barres": [] }
+  ],
+  "F7b5": [
+    { "frets": [1, 2, 1, 2], "fingers": [1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [1, 0, 1, 4], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "F#7b5": [
+    { "frets": [2, 3, 2, 3], "fingers": [1, 3, 2, 4], "baseFret": 1, "barres": [] }
+  ],
+  "G7b5": [
+    { "frets": [3, 4, 3, 4], "fingers": [1, 3, 2, 4], "baseFret": 1, "barres": [] }
+  ],
+  "G#7b5": [
+    { "frets": [4, 5, 4, 5], "fingers": [1, 3, 2, 4], "baseFret": 1, "barres": [] }
+  ],
+  "A7#5": [
+    { "frets": [5, 8, 5, 6], "fingers": [1, 4, 2, 3], "baseFret": 5, "barres": [] }
+  ],
+  "A#7#5": [
+    { "frets": [6, 9, 6, 7], "fingers": [1, 4, 2, 3], "baseFret": 6, "barres": [] }
+  ],
+  "B7#5": [
+    { "frets": [7, 10, 7, 8], "fingers": [1, 4, 2, 3], "baseFret": 7, "barres": [] }
+  ],
+  "C7#5": [
+    { "frets": [8, 11, 8, 9], "fingers": [1, 4, 2, 3], "baseFret": 8, "barres": [] }
+  ],
+  "C#7#5": [
+    { "frets": [9, 12, 9, 10], "fingers": [1, 4, 2, 3], "baseFret": 9, "barres": [] }
+  ],
+  "D7#5": [
+    { "frets": [10, 13, 10, 11], "fingers": [1, 4, 2, 3], "baseFret": 10, "barres": [] }
+  ],
+  "D#7#5": [
+    { "frets": [11, 14, 11, 12], "fingers": [1, 4, 2, 3], "baseFret": 11, "barres": [] }
+  ],
+  "E7#5": [
+    { "frets": [0, 3, 0, 1], "fingers": [0, 2, 0, 1], "baseFret": 1, "barres": [] }
+  ],
+  "F7#5": [
+    { "frets": [1, 4, 1, 2], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "F#7#5": [
+    { "frets": [2, 5, 2, 3], "fingers": [1, 4, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G7#5": [
+    { "frets": [3, 6, 3, 4], "fingers": [1, 4, 2, 3], "baseFret": 3, "barres": [] }
+  ],
+  "G#7#5": [
+    { "frets": [4, 7, 4, 5], "fingers": [1, 4, 2, 3], "baseFret": 4, "barres": [] }
+  ],
+  "A7b9": [
+    { "frets": [5, 4, 5, 3], "fingers": [3, 2, 4, 1], "baseFret": 1, "barres": [] }
+  ],
+  "A#7b9": [
+    { "frets": [6, 5, 6, 4], "fingers": [3, 2, 4, 1], "baseFret": 4, "barres": [] }
+  ],
+  "B7b9": [
+    { "frets": [7, 6, 7, 5], "fingers": [3, 2, 4, 1], "baseFret": 5, "barres": [] }
+  ],
+  "C7b9": [
+    { "frets": [8, 7, 8, 6], "fingers": [3, 2, 4, 1], "baseFret": 6, "barres": [] }
+  ],
+  "C#7b9": [
+    { "frets": [9, 8, 9, 7], "fingers": [3, 2, 4, 1], "baseFret": 7, "barres": [] }
+  ],
+  "D7b9": [
+    { "frets": [10, 9, 10, 8], "fingers": [3, 2, 4, 1], "baseFret": 8, "barres": [] }
+  ],
+  "D#7b9": [
+    { "frets": [11, 10, 11, 9], "fingers": [3, 2, 4, 1], "baseFret": 9, "barres": [] }
+  ],
+  "E7b9": [
+    { "frets": [12, 11, 12, 10], "fingers": [3, 2, 4, 1], "baseFret": 10, "barres": [] }
+  ],
+  "F7b9": [
+    { "frets": [13, 12, 13, 11], "fingers": [3, 2, 4, 1], "baseFret": 11, "barres": [] }
+  ],
+  "F#7b9": [
+    { "frets": [2, 1, 2, 0], "fingers": [2, 1, 3, 0], "baseFret": 1, "barres": [] }
+  ],
+  "G7b9": [
+    { "frets": [3, 2, 3, 1], "fingers": [3, 2, 4, 1], "baseFret": 1, "barres": [] }
+  ],
+  "G#7b9": [
+    { "frets": [4, 3, 4, 2], "fingers": [3, 2, 4, 1], "baseFret": 1, "barres": [] }
+  ],
+  "A7#9": [
+    { "frets": [5, 3, 5, 6], "fingers": [2, 1, 3, 4], "baseFret": 3, "barres": [] },
+    { "frets": [5, 4, 5, 5], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] }
+  ],
+  "A#7#9": [
+    { "frets": [6, 4, 6, 7], "fingers": [2, 1, 3, 4], "baseFret": 4, "barres": [] },
+    { "frets": [6, 5, 6, 6], "fingers": [2, 1, 3, 4], "baseFret": 5, "barres": [] }
+  ],
+  "B7#9": [
+    { "frets": [7, 5, 7, 8], "fingers": [2, 1, 3, 4], "baseFret": 5, "barres": [] },
+    { "frets": [7, 6, 7, 7], "fingers": [2, 1, 3, 4], "baseFret": 6, "barres": [] }
+  ],
+  "C7#9": [
+    { "frets": [8, 6, 8, 9], "fingers": [2, 1, 3, 4], "baseFret": 6, "barres": [] },
+    { "frets": [8, 7, 8, 8], "fingers": [2, 1, 3, 4], "baseFret": 7, "barres": [] }
+  ],
+  "C#7#9": [
+    { "frets": [9, 7, 9, 10], "fingers": [2, 1, 3, 4], "baseFret": 7, "barres": [] },
+    { "frets": [9, 8, 9, 9], "fingers": [2, 1, 3, 4], "baseFret": 8, "barres": [] }
+  ],
+  "D7#9": [
+    { "frets": [10, 8, 10, 11], "fingers": [2, 1, 3, 4], "baseFret": 8, "barres": [] },
+    { "frets": [10, 9, 10, 10], "fingers": [2, 1, 3, 4], "baseFret": 9, "barres": [] }
+  ],
+  "D#7#9": [
+    { "frets": [11, 9, 11, 12], "fingers": [2, 1, 3, 4], "baseFret": 9, "barres": [] },
+    { "frets": [11, 10, 11, 11], "fingers": [2, 1, 3, 4], "baseFret": 10, "barres": [] }
+  ],
+  "E7#9": [
+    { "frets": [12, 11, 12, 12], "fingers": [2, 1, 3, 4], "baseFret": 11, "barres": [] }
+  ],
+  "F7#9": [
+    { "frets": [1, 0, 1, 1], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "F#7#9": [
+    { "frets": [2, 1, 2, 2], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [2, 0, 2, 3], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "G7#9": [
+    { "frets": [3, 1, 3, 4], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [3, 2, 3, 3], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] }
+  ],
+  "G#7#9": [
+    { "frets": [4, 2, 4, 5], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [4, 3, 4, 4], "fingers": [2, 1, 3, 4], "baseFret": 1, "barres": [] }
+  ],
+  "A11": [
+    { "frets": [-1, 0, 0, 0], "fingers": [0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 5, 5, 2], "fingers": [2, 3, 4, 1], "baseFret": 1, "barres": [] }
+  ],
+  "A#11": [
+    { "frets": [-1, 1, 1, 1], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 6, 6, 3], "fingers": [2, 3, 4, 1], "baseFret": 3, "barres": [] }
+  ],
+  "B11": [
+    { "frets": [-1, 2, 2, 2], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 7, 7, 4], "fingers": [2, 3, 4, 1], "baseFret": 4, "barres": [] }
+  ],
+  "C11": [
+    { "frets": [-1, 3, 3, 3], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [8, 8, 8, 5], "fingers": [2, 3, 4, 1], "baseFret": 5, "barres": [] }
+  ],
+  "C#11": [
+    { "frets": [-1, 4, 4, 4], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [9, 9, 9, 6], "fingers": [2, 3, 4, 1], "baseFret": 6, "barres": [] }
+  ],
+  "D11": [
+    { "frets": [-1, 5, 5, 5], "fingers": [0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [10, 10, 10, 7], "fingers": [2, 3, 4, 1], "baseFret": 7, "barres": [] }
+  ],
+  "D#11": [
+    { "frets": [-1, 6, 6, 6], "fingers": [0, 1, 2, 3], "baseFret": 6, "barres": [] },
+    { "frets": [11, 11, 11, 8], "fingers": [2, 3, 4, 1], "baseFret": 8, "barres": [] }
+  ],
+  "E11": [
+    { "frets": [0, 0, 0, 1], "fingers": [0, 0, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 7], "fingers": [0, 1, 2, 3], "baseFret": 7, "barres": [] }
+  ],
+  "F11": [
+    { "frets": [1, 0, 1, 3], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 8, 8], "fingers": [0, 1, 2, 3], "baseFret": 8, "barres": [] }
+  ],
+  "F#11": [
+    { "frets": [2, 2, 2, 1], "fingers": [2, 3, 4, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 9, 9], "fingers": [0, 1, 2, 3], "baseFret": 9, "barres": [] }
+  ],
+  "G11": [
+    { "frets": [3, 3, 3, 0], "fingers": [1, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 10, 10], "fingers": [0, 1, 2, 3], "baseFret": 10, "barres": [] }
+  ],
+  "G#11": [
+    { "frets": [4, 4, 4, 1], "fingers": [2, 3, 4, 1], "baseFret": 1, "barres": [] },
+    { "frets": [4, 4, 4, 3], "fingers": [2, 3, 4, 1], "baseFret": 1, "barres": [] }
+  ],
+  "Am11": [
+    { "frets": [5, 5, 5, 5], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] }
+  ],
+  "A#m11": [
+    { "frets": [6, 6, 6, 6], "fingers": [1, 2, 3, 4], "baseFret": 6, "barres": [] }
+  ],
+  "Bm11": [
+    { "frets": [7, 7, 7, 7], "fingers": [1, 2, 3, 4], "baseFret": 7, "barres": [] }
+  ],
+  "Cm11": [
+    { "frets": [8, 8, 8, 8], "fingers": [1, 2, 3, 4], "baseFret": 8, "barres": [] }
+  ],
+  "C#m11": [
+    { "frets": [9, 9, 9, 9], "fingers": [1, 2, 3, 4], "baseFret": 9, "barres": [] }
+  ],
+  "Dm11": [
+    { "frets": [10, 10, 10, 10], "fingers": [1, 2, 3, 4], "baseFret": 10, "barres": [] }
+  ],
+  "D#m11": [
+    { "frets": [11, 11, 11, 11], "fingers": [1, 2, 3, 4], "baseFret": 11, "barres": [] }
+  ],
+  "Em11": [
+    { "frets": [0, 0, 0, 0], "fingers": [0, 0, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "Fm11": [
+    { "frets": [1, 1, 1, 1], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] }
+  ],
+  "F#m11": [
+    { "frets": [2, 2, 2, 2], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [2, 0, 2, 4], "fingers": [1, 0, 2, 3], "baseFret": 1, "barres": [] }
+  ],
+  "Gm11": [
+    { "frets": [3, 3, 3, 3], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] }
+  ],
+  "G#m11": [
+    { "frets": [4, 4, 4, 4], "fingers": [1, 2, 3, 4], "baseFret": 1, "barres": [] }
+  ],
   "A/C#": [
     { "frets": [-1, 4, 2, 2], "fingers": [0, 3, 1, 2], "baseFret": 1, "barres": [] },
     { "frets": [9, 7, 7, 9], "fingers": [3, 1, 2, 4], "baseFret": 7, "barres": [] }

--- a/apps/klank/public/chords-guitar.json
+++ b/apps/klank/public/chords-guitar.json
@@ -599,6 +599,1026 @@
     { "frets": [4, 6, 6, -1, -1, -1], "fingers": [1, 2, 3, 0, 0, 0], "baseFret": 4, "barres": [] },
     { "frets": [-1, -1, 6, 8, 9, -1], "fingers": [0, 0, 1, 2, 3, 0], "baseFret": 6, "barres": [] }
   ],
+  "Am7b5": [
+    { "frets": [-1, 0, 1, 0, 1, 3], "fingers": [0, 0, 1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 6, 5, 5, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 8, 8, 8], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 7, "barres": [] }
+  ],
+  "A#m7b5": [
+    { "frets": [-1, 1, 2, 1, 2, 0], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 7, 6, 6, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, -1, 8, 9, 9, 9], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 8, "barres": [] }
+  ],
+  "Bm7b5": [
+    { "frets": [-1, 2, 0, 2, 0, 1], "fingers": [0, 2, 0, 3, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [7, 8, 7, 7, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 7, "barres": [] },
+    { "frets": [-1, -1, 9, 10, 10, 10], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 9, "barres": [] }
+  ],
+  "Cm7b5": [
+    { "frets": [-1, 3, 1, 3, 1, 2], "fingers": [0, 3, 1, 4, 1, 2], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [-1, 3, 4, 3, 4, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 9, 8, 8, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "C#m7b5": [
+    { "frets": [-1, 4, 2, 4, 0, 3], "fingers": [0, 3, 1, 4, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 5, 4, 5, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 10, 9, 9, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "Dm7b5": [
+    { "frets": [-1, -1, 0, 1, 1, 1], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 3, 5, 3, 4], "fingers": [0, 3, 1, 4, 1, 2], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 2, "toString": 4 }] },
+    { "frets": [-1, 5, 6, 5, 6, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 5, "barres": [] }
+  ],
+  "D#m7b5": [
+    { "frets": [-1, -1, 1, 2, 2, 2], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 4, 6, 4, 5], "fingers": [0, 3, 1, 4, 1, 2], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [-1, 6, 7, 6, 7, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 6, "barres": [] }
+  ],
+  "Em7b5": [
+    { "frets": [0, 1, 0, 0, 3, 0], "fingers": [0, 1, 0, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 5, 7, 5, 6], "fingers": [0, 3, 1, 4, 1, 2], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [-1, 7, 8, 7, 8, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 7, "barres": [] }
+  ],
+  "Fm7b5": [
+    { "frets": [1, 2, 1, 1, 0, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 4, 4, 4], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 6, 8, 6, 7], "fingers": [0, 3, 1, 4, 1, 2], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
+  ],
+  "F#m7b5": [
+    { "frets": [2, 0, 2, 2, 1, 0], "fingers": [2, 0, 3, 4, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 5, 5, 5], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 7, 9, 7, 8], "fingers": [0, 3, 1, 4, 1, 2], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
+  ],
+  "Gm7b5": [
+    { "frets": [3, 1, 3, 0, 2, -1], "fingers": [3, 1, 4, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 4, 3, 3, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 6, 6, 6], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 5, "barres": [] }
+  ],
+  "G#m7b5": [
+    { "frets": [4, 2, 0, 4, 0, 2], "fingers": [3, 1, 0, 4, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [4, 5, 4, 4, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 7, 7, 7], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 6, "barres": [] }
+  ],
+  "Adim7": [
+    { "frets": [-1, 0, 1, 2, 1, 2], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [5, 6, 4, 5, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 7, 8, 7, 8], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 7, "barres": [] }
+  ],
+  "A#dim7": [
+    { "frets": [-1, 1, 2, 0, 2, 0], "fingers": [0, 1, 2, 0, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 7, 5, 6, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 8, 9, 8, 9], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 8, "barres": [] }
+  ],
+  "Bdim7": [
+    { "frets": [-1, 2, 0, 1, 0, 1], "fingers": [0, 3, 0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [7, 8, 6, 7, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, -1, 9, 10, 9, 10], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 9, "barres": [] }
+  ],
+  "Cdim7": [
+    { "frets": [-1, 3, 1, 2, 1, 2], "fingers": [0, 4, 1, 2, 1, 3], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [8, 9, 7, 8, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 7, "barres": [] },
+    { "frets": [-1, -1, 10, 11, 10, 11], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 10, "barres": [] }
+  ],
+  "C#dim7": [
+    { "frets": [-1, 4, 5, 3, 5, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 10, 8, 9, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 8, "barres": [] },
+    { "frets": [-1, -1, 11, 12, 11, 12], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 11, "barres": [] }
+  ],
+  "Ddim7": [
+    { "frets": [-1, -1, 0, 1, 0, 1], "fingers": [0, 0, 0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 6, 4, 6, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 4, "barres": [] },
+    { "frets": [10, 11, 9, 10, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "D#dim7": [
+    { "frets": [-1, -1, 1, 2, 1, 2], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 7, 5, 7, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [11, 12, 10, 11, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 10, "barres": [] }
+  ],
+  "Edim7": [
+    { "frets": [0, 1, 2, 0, 2, 0], "fingers": [0, 1, 2, 0, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 8, 6, 8, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 6, "barres": [] },
+    { "frets": [12, 13, 11, 12, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 11, "barres": [] }
+  ],
+  "Fdim7": [
+    { "frets": [1, 2, 0, 1, 0, 1], "fingers": [1, 4, 0, 2, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 4, 3, 4], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 9, 7, 9, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F#dim7": [
+    { "frets": [2, 0, 1, 2, 1, -1], "fingers": [3, 0, 1, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 5, 4, 5], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 10, 8, 10, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 8, "barres": [] }
+  ],
+  "Gdim7": [
+    { "frets": [3, 1, 2, 0, 2, 0], "fingers": [4, 1, 2, 0, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 4, 5, 3, 5, 3], "fingers": [1, 2, 3, 1, 4, 1], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 0, "toString": 5 }] },
+    { "frets": [-1, -1, 5, 6, 5, 6], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 5, "barres": [] }
+  ],
+  "G#dim7": [
+    { "frets": [4, 2, 0, 1, 0, 1], "fingers": [4, 3, 0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [4, 5, 3, 4, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 7, 6, 7], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 6, "barres": [] }
+  ],
+  "A6": [
+    { "frets": [-1, 0, 2, 2, 2, 2], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [5, 4, 4, 6, 5, -1], "fingers": [2, 1, 1, 4, 3, 0], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 2 }] },
+    { "frets": [-1, -1, 7, 9, 7, 9], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 7, "barres": [] }
+  ],
+  "A#6": [
+    { "frets": [-1, 1, 0, 0, 3, 1], "fingers": [0, 1, 0, 0, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [6, 5, 3, 3, 3, 3], "fingers": [3, 2, 1, 1, 1, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [6, 5, 5, 7, 6, -1], "fingers": [2, 1, 1, 4, 3, 0], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 1, "toString": 2 }] }
+  ],
+  "B6": [
+    { "frets": [-1, 2, 1, 1, 0, 2], "fingers": [0, 3, 1, 2, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [7, 6, 4, 4, 4, 4], "fingers": [3, 2, 1, 1, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [7, 6, 6, 8, 7, -1], "fingers": [2, 1, 1, 4, 3, 0], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 2 }] }
+  ],
+  "C6": [
+    { "frets": [-1, 3, 5, 2, 5, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 5, 5, 5, 5], "fingers": [3, 2, 1, 1, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [8, 7, 7, 9, 8, -1], "fingers": [2, 1, 1, 4, 3, 0], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 1, "toString": 2 }] }
+  ],
+  "C#6": [
+    { "frets": [-1, 4, 6, 3, 6, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 3, "barres": [] },
+    { "frets": [9, 8, 6, 6, 6, 6], "fingers": [3, 2, 1, 1, 1, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [9, 8, 8, 10, 9, -1], "fingers": [2, 1, 1, 4, 3, 0], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 1, "toString": 2 }] }
+  ],
+  "D6": [
+    { "frets": [-1, -1, 0, 2, 0, 2], "fingers": [0, 0, 0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 7, 4, 7, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 4, "barres": [] },
+    { "frets": [10, 9, 7, 7, 7, 7], "fingers": [3, 2, 1, 1, 1, 1], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "D#6": [
+    { "frets": [-1, -1, 1, 3, 1, 3], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 8, 5, 8, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [11, 10, 8, 8, 8, 8], "fingers": [3, 2, 1, 1, 1, 1], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "E6": [
+    { "frets": [0, 2, 2, 1, 2, 0], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 9, 6, 9, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 6, "barres": [] },
+    { "frets": [12, 11, 9, 9, 9, 9], "fingers": [3, 2, 1, 1, 1, 1], "baseFret": 9, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "F6": [
+    { "frets": [1, 0, 0, 2, 1, 1], "fingers": [1, 0, 0, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 3, 5], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 10, 7, 10, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F#6": [
+    { "frets": [2, 1, 1, 3, 2, -1], "fingers": [2, 1, 1, 4, 3, 0], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 2 }] },
+    { "frets": [-1, -1, 4, 6, 4, 6], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 11, 8, 11, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 8, "barres": [] }
+  ],
+  "G6": [
+    { "frets": [3, 2, 0, 0, 0, 0], "fingers": [2, 1, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 7, 5, 7], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 10, 12, 9, 12, -1], "fingers": [0, 2, 3, 1, 4, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G#6": [
+    { "frets": [4, 3, 1, 1, 1, 1], "fingers": [3, 2, 1, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [4, 3, 3, 5, 4, -1], "fingers": [2, 1, 1, 4, 3, 0], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 1, "toString": 2 }] },
+    { "frets": [-1, -1, 6, 8, 6, 8], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 6, "barres": [] }
+  ],
+  "Am6": [
+    { "frets": [-1, 0, 2, 2, 1, 2], "fingers": [0, 0, 2, 3, 1, 4], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 4, 5, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 7, 9, 7, 8], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 7, "barres": [] }
+  ],
+  "A#m6": [
+    { "frets": [-1, 1, 3, 0, 2, 1], "fingers": [0, 1, 4, 0, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [6, 4, 3, 3, 6, 3], "fingers": [3, 2, 1, 1, 4, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [6, 8, 5, 6, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "Bm6": [
+    { "frets": [-1, 2, 0, 1, 0, 2], "fingers": [0, 2, 0, 1, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 4, 4, 7, 4], "fingers": [3, 2, 1, 1, 4, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [7, 9, 6, 7, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "Cm6": [
+    { "frets": [-1, 3, 1, 2, 1, 3], "fingers": [0, 3, 1, 2, 1, 4], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [8, 6, 5, 5, 8, 5], "fingers": [3, 2, 1, 1, 4, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [8, 10, 7, 8, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 7, "barres": [] }
+  ],
+  "C#m6": [
+    { "frets": [-1, 4, 2, 3, 2, 4], "fingers": [0, 3, 1, 2, 1, 4], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 2, "toString": 4 }] },
+    { "frets": [9, 7, 6, 6, 9, 6], "fingers": [3, 2, 1, 1, 4, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [9, 11, 8, 9, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "Dm6": [
+    { "frets": [-1, -1, 0, 2, 0, 1], "fingers": [0, 0, 0, 2, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 3, 4, 3, 5], "fingers": [0, 3, 1, 2, 1, 4], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 2, "toString": 4 }] },
+    { "frets": [10, 8, 7, 7, 10, 7], "fingers": [3, 2, 1, 1, 4, 1], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "D#m6": [
+    { "frets": [-1, -1, 1, 3, 1, 2], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 4, 5, 4, 6], "fingers": [0, 3, 1, 2, 1, 4], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [11, 9, 8, 8, 11, 8], "fingers": [3, 2, 1, 1, 4, 1], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "Em6": [
+    { "frets": [0, 2, 2, 0, 2, 0], "fingers": [0, 1, 2, 0, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 5, 6, 5, 7], "fingers": [0, 3, 1, 2, 1, 4], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [12, 10, 9, 9, 12, 9], "fingers": [3, 2, 1, 1, 4, 1], "baseFret": 9, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "Fm6": [
+    { "frets": [1, 3, 0, 1, 1, -1], "fingers": [1, 4, 0, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 5, 3, 4], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 6, 7, 6, 8], "fingers": [0, 3, 1, 2, 1, 4], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
+  ],
+  "F#m6": [
+    { "frets": [2, 0, 1, 2, 2, -1], "fingers": [2, 0, 1, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 6, 4, 5], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 7, 8, 7, 9], "fingers": [0, 3, 1, 2, 1, 4], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] }
+  ],
+  "Gm6": [
+    { "frets": [3, 1, 0, 0, 3, 0], "fingers": [2, 1, 0, 0, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 5, 5, 3, 5, 3], "fingers": [1, 2, 3, 1, 4, 1], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 0, "toString": 5 }] },
+    { "frets": [-1, -1, 5, 7, 5, 6], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 5, "barres": [] }
+  ],
+  "G#m6": [
+    { "frets": [4, 2, 1, 1, 4, 1], "fingers": [3, 2, 1, 1, 4, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [4, 6, 3, 4, -1, -1], "fingers": [2, 4, 1, 3, 0, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, -1, 6, 8, 6, 7], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 6, "barres": [] }
+  ],
+  "A69": [
+    { "frets": [-1, 0, 2, 4, 2, 2], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 4, 4, 4, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 6, 7, 7], "fingers": [0, 0, 2, 1, 3, 4], "baseFret": 6, "barres": [] }
+  ],
+  "A#69": [
+    { "frets": [-1, 1, 0, 0, 1, 1], "fingers": [0, 1, 0, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 3, 3, 3, 3, 3], "fingers": [2, 1, 1, 1, 1, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [6, 5, 5, 5, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "B69": [
+    { "frets": [-1, 2, 1, 1, 2, -1], "fingers": [0, 3, 1, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 4, 4, 4, 4, 4], "fingers": [2, 1, 1, 1, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [7, 6, 6, 6, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "C69": [
+    { "frets": [-1, 3, 0, 2, 1, 0], "fingers": [0, 3, 0, 2, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 5, 5, 5, 5, 5], "fingers": [2, 1, 1, 1, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [8, 7, 7, 7, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 7, "barres": [] }
+  ],
+  "C#69": [
+    { "frets": [-1, 4, 1, 3, 2, 1], "fingers": [0, 4, 1, 3, 2, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 4, 3, 3, 4, -1], "fingers": [0, 3, 1, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 8, 8, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "D69": [
+    { "frets": [-1, 5, 2, 4, 3, 2], "fingers": [0, 4, 1, 3, 2, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 5, 4, 4, 5, -1], "fingers": [0, 3, 1, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [10, 9, 9, 9, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "D#69": [
+    { "frets": [-1, -1, 1, 0, 1, 1], "fingers": [0, 0, 1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 3, 5, 4, 3], "fingers": [0, 4, 1, 3, 2, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 6, 5, 5, 6, -1], "fingers": [0, 3, 1, 2, 4, 0], "baseFret": 5, "barres": [] }
+  ],
+  "E69": [
+    { "frets": [-1, -1, 2, 1, 2, 2], "fingers": [0, 0, 2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [0, 4, 4, 4, 0, 4], "fingers": [0, 1, 2, 3, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 6, 7, -1], "fingers": [0, 3, 1, 2, 4, 0], "baseFret": 6, "barres": [] }
+  ],
+  "F69": [
+    { "frets": [1, 0, 0, 0, 1, 1], "fingers": [1, 0, 0, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 5, 7, 6, 5], "fingers": [0, 4, 1, 3, 2, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 8, 7, 7, 8, -1], "fingers": [0, 3, 1, 2, 4, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F#69": [
+    { "frets": [2, 1, 1, 1, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 3, 4, 4], "fingers": [0, 0, 2, 1, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 8, 9, -1], "fingers": [0, 3, 1, 2, 4, 0], "baseFret": 8, "barres": [] }
+  ],
+  "G69": [
+    { "frets": [3, 0, 0, 0, 0, 0], "fingers": [1, 0, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 7, 9, 8, 7], "fingers": [0, 4, 1, 3, 2, 1], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 10, 9, 9, 10, -1], "fingers": [0, 3, 1, 2, 4, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G#69": [
+    { "frets": [4, 1, 1, 1, 1, 1], "fingers": [2, 1, 1, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [4, 3, 3, 3, -1, -1], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 5, 6, 6], "fingers": [0, 0, 2, 1, 3, 4], "baseFret": 5, "barres": [] }
+  ],
+  "Aadd9": [
+    { "frets": [-1, 0, 2, 4, 2, -1], "fingers": [0, 0, 1, 3, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 6, 5, 7], "fingers": [0, 0, 3, 2, 1, 4], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 12, 11, 9, 12, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 9, "barres": [] }
+  ],
+  "A#add9": [
+    { "frets": [-1, 1, 0, 3, 1, 1], "fingers": [0, 1, 0, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 5, 3, 5, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, -1, 8, 7, 6, 8], "fingers": [0, 0, 3, 2, 1, 4], "baseFret": 6, "barres": [] }
+  ],
+  "Badd9": [
+    { "frets": [7, 6, 4, 6, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 9, 8, 7, 9], "fingers": [0, 0, 3, 2, 1, 4], "baseFret": 7, "barres": [] },
+    { "frets": [-1, 14, 13, 11, 14, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 11, "barres": [] }
+  ],
+  "Cadd9": [
+    { "frets": [-1, 3, 0, 0, 1, 0], "fingers": [0, 2, 0, 0, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 0, 0, 3, 0], "fingers": [0, 1, 0, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 5, 7, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "C#add9": [
+    { "frets": [-1, 4, 3, 1, 4, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 6, 8, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, -1, 11, 10, 9, 11], "fingers": [0, 0, 3, 2, 1, 4], "baseFret": 9, "barres": [] }
+  ],
+  "Dadd9": [
+    { "frets": [-1, 5, 4, 2, 5, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [10, 9, 7, 9, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 7, "barres": [] },
+    { "frets": [-1, -1, 12, 11, 10, 12], "fingers": [0, 0, 3, 2, 1, 4], "baseFret": 10, "barres": [] }
+  ],
+  "D#add9": [
+    { "frets": [-1, 6, 5, 3, 6, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 3, "barres": [] },
+    { "frets": [11, 10, 8, 10, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 8, "barres": [] },
+    { "frets": [-1, -1, 13, 12, 11, 13], "fingers": [0, 0, 3, 2, 1, 4], "baseFret": 11, "barres": [] }
+  ],
+  "Eadd9": [
+    { "frets": [0, 2, 2, 1, 0, 2], "fingers": [0, 2, 3, 1, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 4, 7, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 4, "barres": [] },
+    { "frets": [12, 11, 9, 11, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "Fadd9": [
+    { "frets": [1, 0, 3, 0, 1, 1], "fingers": [1, 0, 4, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 5, 8, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [13, 12, 10, 12, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 10, "barres": [] }
+  ],
+  "F#add9": [
+    { "frets": [-1, -1, 4, 3, 2, 4], "fingers": [0, 0, 3, 2, 1, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 6, 9, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 6, "barres": [] },
+    { "frets": [14, 13, 11, 13, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 11, "barres": [] }
+  ],
+  "Gadd9": [
+    { "frets": [3, 0, 0, 0, 0, 3], "fingers": [1, 0, 0, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 9, 7, 10, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 7, "barres": [] },
+    { "frets": [15, 14, 12, 14, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 12, "barres": [] }
+  ],
+  "G#add9": [
+    { "frets": [4, 3, 1, 3, -1, -1], "fingers": [4, 2, 1, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 5, 4, 6], "fingers": [0, 0, 3, 2, 1, 4], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 11, 10, 8, 11, -1], "fingers": [0, 3, 2, 1, 4, 0], "baseFret": 8, "barres": [] }
+  ],
+  "A9": [
+    { "frets": [-1, 0, 2, 4, 2, 3], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 4, 5, 4, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 6, 8, 7], "fingers": [0, 0, 2, 1, 4, 3], "baseFret": 6, "barres": [] }
+  ],
+  "A#9": [
+    { "frets": [-1, 1, 0, 1, 1, 1], "fingers": [0, 1, 0, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [6, 3, 3, 3, 3, 4], "fingers": [3, 1, 1, 1, 1, 2], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [6, 5, 6, 5, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "B9": [
+    { "frets": [-1, 2, 1, 2, 2, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 4, 4, 4, 4, 5], "fingers": [3, 1, 1, 1, 1, 2], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [7, 6, 7, 6, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "C9": [
+    { "frets": [-1, 3, 0, 3, 1, 0], "fingers": [0, 2, 0, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 0, 3, 3, 0], "fingers": [0, 1, 0, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 8, 7, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 7, "barres": [] }
+  ],
+  "C#9": [
+    { "frets": [-1, 4, 1, 1, 0, 1], "fingers": [0, 4, 1, 2, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 3, 4, 4, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 9, 8, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "D9": [
+    { "frets": [-1, 5, 2, 5, 3, 2], "fingers": [0, 3, 1, 4, 2, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 5, 4, 5, 5, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [10, 9, 10, 9, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "D#9": [
+    { "frets": [-1, -1, 1, 0, 2, 1], "fingers": [0, 0, 1, 0, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 3, 6, 4, 3], "fingers": [0, 3, 1, 4, 2, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 6, 5, 6, 6, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 5, "barres": [] }
+  ],
+  "E9": [
+    { "frets": [0, 2, 0, 1, 0, 2], "fingers": [0, 2, 0, 1, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 4, 7, 5, 4], "fingers": [0, 3, 1, 4, 2, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 7, 6, 7, 7, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 6, "barres": [] }
+  ],
+  "F9": [
+    { "frets": [1, 0, 1, 0, 1, 1], "fingers": [1, 0, 2, 0, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 5, 8, 6, 5], "fingers": [0, 3, 1, 4, 2, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 8, 7, 8, 8, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F#9": [
+    { "frets": [2, 1, 2, 1, 2, 0], "fingers": [2, 1, 3, 1, 4, 0], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [-1, -1, 4, 3, 5, 4], "fingers": [0, 0, 2, 1, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 9, 9, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 8, "barres": [] }
+  ],
+  "G9": [
+    { "frets": [3, 0, 0, 0, 0, 1], "fingers": [2, 0, 0, 0, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 3, 0, 0, 3], "fingers": [1, 0, 2, 0, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 9, 10, 10, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G#9": [
+    { "frets": [4, 1, 1, 1, 1, 2], "fingers": [3, 1, 1, 1, 1, 2], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [4, 3, 4, 3, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 5, 7, 6], "fingers": [0, 0, 2, 1, 4, 3], "baseFret": 5, "barres": [] }
+  ],
+  "Am9": [
+    { "frets": [-1, 0, 2, 4, 1, 3], "fingers": [0, 0, 2, 4, 1, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 3, 5, 4, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 7, 5, 5, 5, 7], "fingers": [1, 2, 1, 1, 1, 3], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] }
+  ],
+  "A#m9": [
+    { "frets": [6, 4, 6, 5, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [6, 8, 6, 6, 6, 8], "fingers": [1, 2, 1, 1, 1, 3], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] },
+    { "frets": [-1, 13, 11, 13, 13, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 11, "barres": [] }
+  ],
+  "Bm9": [
+    { "frets": [-1, 2, 0, 2, 2, 2], "fingers": [0, 1, 0, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 7, 6, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [7, 9, 7, 7, 7, 9], "fingers": [1, 2, 1, 1, 1, 3], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] }
+  ],
+  "Cm9": [
+    { "frets": [-1, 3, 1, 3, 3, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 0, 3, 4, 3], "fingers": [0, 1, 0, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [8, 6, 8, 7, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "C#m9": [
+    { "frets": [-1, 4, 2, 4, 4, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 7, 9, 8, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 7, "barres": [] },
+    { "frets": [9, 11, 9, 9, 9, 11], "fingers": [1, 2, 1, 1, 1, 3], "baseFret": 9, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] }
+  ],
+  "Dm9": [
+    { "frets": [-1, 5, 3, 5, 5, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [10, 8, 10, 9, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 8, "barres": [] },
+    { "frets": [10, 12, 10, 10, 10, 12], "fingers": [1, 2, 1, 1, 1, 3], "baseFret": 10, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] }
+  ],
+  "D#m9": [
+    { "frets": [-1, 6, 4, 6, 6, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 4, "barres": [] },
+    { "frets": [11, 8, 11, 11, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 8, "barres": [] },
+    { "frets": [11, 9, 11, 10, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "Em9": [
+    { "frets": [0, 2, 0, 0, 0, 2], "fingers": [0, 1, 0, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 5, 7, 7, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [12, 10, 12, 11, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 10, "barres": [] }
+  ],
+  "Fm9": [
+    { "frets": [1, 3, 1, 1, 1, 3], "fingers": [1, 2, 1, 1, 1, 3], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] },
+    { "frets": [-1, -1, 3, 0, 4, 4], "fingers": [0, 0, 1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 6, 8, 8, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 6, "barres": [] }
+  ],
+  "F#m9": [
+    { "frets": [2, 0, 2, 1, 2, 0], "fingers": [2, 0, 3, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [2, 0, 2, 1, 2, -1], "fingers": [2, 0, 3, 1, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 7, 9, 9, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 7, "barres": [] }
+  ],
+  "Gm9": [
+    { "frets": [3, 0, 0, 3, 3, 1], "fingers": [2, 0, 0, 3, 4, 1], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 3, 3, 3, -1], "fingers": [1, 0, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 10, 8, 10, 10, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 8, "barres": [] }
+  ],
+  "G#m9": [
+    { "frets": [4, 2, 4, 3, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [4, 6, 4, 4, 4, 6], "fingers": [1, 2, 1, 1, 1, 3], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] },
+    { "frets": [-1, 11, 9, 11, 11, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 9, "barres": [] }
+  ],
+  "Amaj9": [
+    { "frets": [-1, 0, 2, 4, 2, 4], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [5, 4, 6, 4, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 7, 6, 9, 7], "fingers": [0, 0, 2, 1, 4, 3], "baseFret": 6, "barres": [] }
+  ],
+  "A#maj9": [
+    { "frets": [-1, 1, 0, 2, 1, 1], "fingers": [0, 1, 0, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 3, 3, 3, 3, 5], "fingers": [3, 1, 1, 1, 1, 2], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [6, 5, 7, 5, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "Bmaj9": [
+    { "frets": [-1, 2, 1, 3, 2, -1], "fingers": [0, 2, 1, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 4, 4, 4, 4, 6], "fingers": [3, 1, 1, 1, 1, 2], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [7, 6, 8, 6, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "Cmaj9": [
+    { "frets": [-1, 3, 0, 4, 1, 0], "fingers": [0, 2, 0, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 0, 0, 0, 0], "fingers": [0, 1, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 9, 7, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 7, "barres": [] }
+  ],
+  "C#maj9": [
+    { "frets": [-1, 4, 1, 1, 1, 1], "fingers": [0, 2, 1, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 4, 3, 5, 4, -1], "fingers": [0, 2, 1, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 10, 8, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "Dmaj9": [
+    { "frets": [-1, 5, 2, 2, 2, 2], "fingers": [0, 2, 1, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 5, 4, 6, 5, -1], "fingers": [0, 2, 1, 4, 3, 0], "baseFret": 4, "barres": [] },
+    { "frets": [10, 9, 11, 9, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "D#maj9": [
+    { "frets": [-1, -1, 1, 0, 3, 1], "fingers": [0, 0, 1, 0, 3, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 3, 3, 3, 3], "fingers": [0, 2, 1, 1, 1, 1], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 6, 5, 7, 6, -1], "fingers": [0, 2, 1, 4, 3, 0], "baseFret": 5, "barres": [] }
+  ],
+  "Emaj9": [
+    { "frets": [0, 2, 1, 1, 0, 2], "fingers": [0, 3, 1, 2, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 4, 4, 4, 4], "fingers": [0, 2, 1, 1, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 7, 6, 8, 7, -1], "fingers": [0, 2, 1, 4, 3, 0], "baseFret": 6, "barres": [] }
+  ],
+  "Fmaj9": [
+    { "frets": [1, 0, 2, 0, 1, 0], "fingers": [1, 0, 3, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 5, 5, 5, 5], "fingers": [0, 2, 1, 1, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 8, 7, 9, 8, -1], "fingers": [0, 2, 1, 4, 3, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F#maj9": [
+    { "frets": [2, 1, 3, 1, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 3, 6, 4], "fingers": [0, 0, 2, 1, 4, 3], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 9, 8, 10, 9, -1], "fingers": [0, 2, 1, 4, 3, 0], "baseFret": 8, "barres": [] }
+  ],
+  "Gmaj9": [
+    { "frets": [3, 0, 0, 0, 0, 2], "fingers": [2, 0, 0, 0, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 4, 7, 5], "fingers": [0, 0, 2, 1, 4, 3], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 10, 9, 11, 10, -1], "fingers": [0, 2, 1, 4, 3, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G#maj9": [
+    { "frets": [4, 1, 1, 0, 1, -1], "fingers": [4, 1, 2, 0, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [4, 3, 5, 3, -1, -1], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 5, 8, 6], "fingers": [0, 0, 2, 1, 4, 3], "baseFret": 5, "barres": [] }
+  ],
+  "A7b5": [
+    { "frets": [-1, 0, 1, 0, 2, 3], "fingers": [0, 0, 1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 6, 5, 6, -1, -1], "fingers": [1, 3, 2, 4, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 8, 8, 9], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 7, "barres": [] }
+  ],
+  "A#7b5": [
+    { "frets": [-1, 1, 0, 1, 3, 0], "fingers": [0, 1, 0, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 7, 6, 7, -1, -1], "fingers": [1, 3, 2, 4, 0, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, -1, 8, 9, 9, 10], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 8, "barres": [] }
+  ],
+  "B7b5": [
+    { "frets": [-1, 2, 1, 2, 0, 1], "fingers": [0, 3, 1, 4, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [7, 8, 7, 8, -1, -1], "fingers": [1, 3, 2, 4, 0, 0], "baseFret": 7, "barres": [] },
+    { "frets": [-1, -1, 9, 10, 10, 11], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 9, "barres": [] }
+  ],
+  "C7b5": [
+    { "frets": [-1, 3, 4, 3, 1, 0], "fingers": [0, 2, 4, 3, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 4, 3, 5, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 9, 8, 9, -1, -1], "fingers": [1, 3, 2, 4, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "C#7b5": [
+    { "frets": [-1, 4, 3, 0, 0, 1], "fingers": [0, 3, 2, 0, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 3, 4, 0, 3], "fingers": [0, 3, 1, 4, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [9, 10, 9, 10, -1, -1], "fingers": [1, 3, 2, 4, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "D7b5": [
+    { "frets": [-1, -1, 0, 1, 1, 2], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 6, 5, 7, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [10, 11, 10, 11, -1, -1], "fingers": [1, 3, 2, 4, 0, 0], "baseFret": 10, "barres": [] }
+  ],
+  "D#7b5": [
+    { "frets": [-1, -1, 1, 2, 2, 3], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 7, 6, 8, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 6, "barres": [] },
+    { "frets": [11, 12, 11, 12, -1, -1], "fingers": [1, 3, 2, 4, 0, 0], "baseFret": 11, "barres": [] }
+  ],
+  "E7b5": [
+    { "frets": [0, 1, 0, 1, 3, 0], "fingers": [0, 1, 0, 2, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [0, 1, 2, 1, 3, 0], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 8, 7, 9, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F7b5": [
+    { "frets": [1, 0, 1, 2, 0, 1], "fingers": [1, 0, 2, 4, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 4, 4, 5], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 9, 8, 10, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 8, "barres": [] }
+  ],
+  "F#7b5": [
+    { "frets": [2, 1, 2, 3, 1, 0], "fingers": [2, 1, 3, 4, 1, 0], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [-1, -1, 4, 5, 5, 6], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 9, 10, 9, 11, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G7b5": [
+    { "frets": [3, 2, 3, 0, 2, -1], "fingers": [3, 1, 4, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 6, 6, 7], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 10, 11, 10, 12, -1], "fingers": [0, 1, 3, 2, 4, 0], "baseFret": 10, "barres": [] }
+  ],
+  "G#7b5": [
+    { "frets": [4, 3, 0, 1, 1, 2], "fingers": [4, 3, 0, 1, 1, 2], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 3, "toString": 4 }] },
+    { "frets": [4, 5, 4, 5, -1, -1], "fingers": [1, 3, 2, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 7, 7, 8], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 6, "barres": [] }
+  ],
+  "A7#5": [
+    { "frets": [-1, 0, 3, 0, 2, 1], "fingers": [0, 0, 3, 0, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [5, 8, 5, 6, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 7, 10, 8, 9], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 7, "barres": [] }
+  ],
+  "A#7#5": [
+    { "frets": [-1, 1, 0, 1, 3, 2], "fingers": [0, 1, 0, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 9, 6, 7, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, -1, 8, 11, 9, 10], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 8, "barres": [] }
+  ],
+  "B7#5": [
+    { "frets": [-1, 2, 1, 2, 0, 3], "fingers": [0, 2, 1, 3, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [7, 10, 7, 8, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 7, "barres": [] },
+    { "frets": [-1, -1, 9, 12, 10, 11], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 9, "barres": [] }
+  ],
+  "C7#5": [
+    { "frets": [-1, 3, 6, 3, 5, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 3, 6, 3, 5, 4], "fingers": [0, 1, 4, 1, 3, 2], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [8, 11, 8, 9, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "C#7#5": [
+    { "frets": [-1, 4, 3, 2, 0, -1], "fingers": [0, 3, 2, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 7, 4, 6, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 4, "barres": [] },
+    { "frets": [9, 12, 9, 10, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "D7#5": [
+    { "frets": [-1, -1, 0, 3, 1, 2], "fingers": [0, 0, 0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 8, 5, 7, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 5, 8, 5, 7, 6], "fingers": [0, 1, 4, 1, 3, 2], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] }
+  ],
+  "D#7#5": [
+    { "frets": [-1, -1, 1, 4, 2, 3], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 9, 6, 8, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, 6, 9, 6, 8, 7], "fingers": [0, 1, 4, 1, 3, 2], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] }
+  ],
+  "E7#5": [
+    { "frets": [0, 3, 0, 1, 1, 0], "fingers": [0, 3, 0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [0, 3, 0, 1, 3, 0], "fingers": [0, 2, 0, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 10, 7, 9, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F7#5": [
+    { "frets": [1, 0, 1, 2, 2, -1], "fingers": [1, 0, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 6, 4, 5], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 3, "barres": [] },
+    { "frets": [-1, 8, 11, 8, 10, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 8, "barres": [] }
+  ],
+  "F#7#5": [
+    { "frets": [2, 1, 0, 3, 3, 0], "fingers": [2, 1, 0, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 3, 3, 0], "fingers": [0, 0, 3, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 12, 9, 11, -1], "fingers": [0, 1, 4, 2, 3, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G7#5": [
+    { "frets": [3, 2, 1, 0, 0, 1], "fingers": [4, 3, 1, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [3, 6, 3, 4, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 3, "barres": [] },
+    { "frets": [-1, -1, 5, 8, 6, 7], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 5, "barres": [] }
+  ],
+  "G#7#5": [
+    { "frets": [4, 3, 4, 1, 1, 0], "fingers": [3, 2, 4, 1, 1, 0], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 3, "toString": 4 }] },
+    { "frets": [4, 7, 4, 5, -1, -1], "fingers": [1, 4, 2, 3, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 6, 9, 7, 8], "fingers": [0, 0, 1, 4, 2, 3], "baseFret": 6, "barres": [] }
+  ],
+  "A7b9": [
+    { "frets": [-1, 0, 2, 3, 2, 3], "fingers": [0, 0, 1, 3, 2, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 6, 8, 6], "fingers": [0, 0, 3, 1, 4, 2], "baseFret": 6, "barres": [] },
+    { "frets": [-1, 12, 11, 12, 11, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 11, "barres": [] }
+  ],
+  "A#7b9": [
+    { "frets": [-1, 1, 0, 1, 0, 1], "fingers": [0, 1, 0, 2, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 5, 6, 4, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, -1, 8, 7, 9, 7], "fingers": [0, 0, 3, 1, 4, 2], "baseFret": 7, "barres": [] }
+  ],
+  "B7b9": [
+    { "frets": [-1, 2, 1, 2, 1, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 6, 7, 5, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 5, "barres": [] },
+    { "frets": [-1, -1, 9, 8, 10, 8], "fingers": [0, 0, 3, 1, 4, 2], "baseFret": 8, "barres": [] }
+  ],
+  "C7b9": [
+    { "frets": [-1, 3, 2, 3, 2, 0], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 7, 8, 6, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 6, "barres": [] },
+    { "frets": [-1, -1, 10, 9, 11, 9], "fingers": [0, 0, 3, 1, 4, 2], "baseFret": 9, "barres": [] }
+  ],
+  "C#7b9": [
+    { "frets": [-1, 4, 0, 4, 2, 1], "fingers": [0, 3, 0, 4, 2, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 3, 4, 3, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 8, 9, 7, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 7, "barres": [] }
+  ],
+  "D7b9": [
+    { "frets": [-1, 5, 4, 5, 4, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [10, 9, 10, 8, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 8, "barres": [] },
+    { "frets": [-1, -1, 12, 11, 13, 11], "fingers": [0, 0, 3, 1, 4, 2], "baseFret": 11, "barres": [] }
+  ],
+  "D#7b9": [
+    { "frets": [-1, -1, 1, 0, 2, 0], "fingers": [0, 0, 1, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 5, 6, 5, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 5, "barres": [] },
+    { "frets": [11, 10, 11, 9, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "E7b9": [
+    { "frets": [0, 2, 0, 1, 0, 1], "fingers": [0, 3, 0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 7, 6, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 6, "barres": [] },
+    { "frets": [12, 11, 12, 10, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 10, "barres": [] }
+  ],
+  "F7b9": [
+    { "frets": [1, 3, 1, 2, 1, 2], "fingers": [1, 4, 1, 2, 1, 3], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 4 }] },
+    { "frets": [-1, 8, 7, 8, 7, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 7, "barres": [] },
+    { "frets": [13, 12, 13, 11, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 11, "barres": [] }
+  ],
+  "F#7b9": [
+    { "frets": [2, 1, 2, 0, 2, 0], "fingers": [2, 1, 3, 0, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 3, 5, 3], "fingers": [0, 0, 3, 1, 4, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 9, 8, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 8, "barres": [] }
+  ],
+  "G7b9": [
+    { "frets": [3, 2, 0, 1, 0, 1], "fingers": [4, 3, 0, 1, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 4, 6, 4], "fingers": [0, 0, 3, 1, 4, 2], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 10, 9, 10, 9, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G#7b9": [
+    { "frets": [4, 3, 4, 2, -1, -1], "fingers": [3, 2, 4, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 5, 7, 5], "fingers": [0, 0, 3, 1, 4, 2], "baseFret": 5, "barres": [] },
+    { "frets": [-1, 11, 10, 11, 10, -1], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 10, "barres": [] }
+  ],
+  "A7#9": [
+    { "frets": [5, 3, 2, 2, 2, 3], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 2, "toString": 4 }] },
+    { "frets": [5, 4, 5, 5, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 7, 6, 8, 8], "fingers": [0, 0, 2, 1, 3, 4], "baseFret": 6, "barres": [] }
+  ],
+  "A#7#9": [
+    { "frets": [-1, 1, 0, 1, 2, 1], "fingers": [0, 1, 0, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 4, 3, 3, 3, 4], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [6, 5, 6, 6, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "B7#9": [
+    { "frets": [-1, 2, 1, 2, 3, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 4, 4, 4, 5], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [7, 6, 7, 7, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "C7#9": [
+    { "frets": [-1, 3, 1, 3, 1, 0], "fingers": [0, 3, 1, 4, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 6, 5, 5, 5, 6], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [8, 7, 8, 8, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 7, "barres": [] }
+  ],
+  "C#7#9": [
+    { "frets": [-1, 4, 3, 4, 2, 0], "fingers": [0, 3, 2, 4, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 7, 6, 6, 6, 7], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [9, 8, 9, 9, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 8, "barres": [] }
+  ],
+  "D7#9": [
+    { "frets": [-1, 5, 4, 5, 6, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 4, "barres": [] },
+    { "frets": [10, 8, 7, 7, 7, 8], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [10, 9, 10, 10, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 9, "barres": [] }
+  ],
+  "D#7#9": [
+    { "frets": [-1, -1, 1, 0, 2, 2], "fingers": [0, 0, 1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 5, 6, 7, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 5, "barres": [] },
+    { "frets": [11, 10, 11, 11, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 10, "barres": [] }
+  ],
+  "E7#9": [
+    { "frets": [0, 2, 0, 1, 0, 3], "fingers": [0, 2, 0, 1, 0, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 6, 7, 8, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 6, "barres": [] },
+    { "frets": [12, 11, 12, 12, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 11, "barres": [] }
+  ],
+  "F7#9": [
+    { "frets": [1, 0, 1, 1, 1, -1], "fingers": [1, 0, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [1, 0, 1, 1, -1, -1], "fingers": [1, 0, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 7, 8, 9, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 7, "barres": [] }
+  ],
+  "F#7#9": [
+    { "frets": [2, 0, 2, 3, 2, 0], "fingers": [1, 0, 2, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [2, 0, 2, 3, 2, -1], "fingers": [1, 0, 2, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 8, 9, 10, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 8, "barres": [] }
+  ],
+  "G7#9": [
+    { "frets": [3, 1, 0, 0, 0, 1], "fingers": [3, 1, 0, 0, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 4, 6, 6], "fingers": [0, 0, 2, 1, 3, 4], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 10, 9, 10, 11, -1], "fingers": [0, 2, 1, 3, 4, 0], "baseFret": 9, "barres": [] }
+  ],
+  "G#7#9": [
+    { "frets": [4, 2, 1, 1, 1, 2], "fingers": [4, 2, 1, 1, 1, 3], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 4 }] },
+    { "frets": [4, 3, 4, 4, -1, -1], "fingers": [2, 1, 3, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 5, 7, 7], "fingers": [0, 0, 2, 1, 3, 4], "baseFret": 5, "barres": [] }
+  ],
+  "A11": [
+    { "frets": [-1, 0, 0, 0, 0, 0], "fingers": [0, 0, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 0, 0, 0, 2, 0], "fingers": [0, 0, 0, 0, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 5, 5, 4, -1, -1], "fingers": [2, 3, 4, 1, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "A#11": [
+    { "frets": [-1, 1, 1, 1, 1, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 3, 4, 4], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [6, 6, 6, 5, -1, -1], "fingers": [2, 3, 4, 1, 0, 0], "baseFret": 5, "barres": [] }
+  ],
+  "B11": [
+    { "frets": [-1, 2, 1, 2, 0, 0], "fingers": [0, 2, 1, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 4, 5, 5], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [7, 7, 7, 6, -1, -1], "fingers": [2, 3, 4, 1, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "C11": [
+    { "frets": [-1, 3, 0, 3, 1, 1], "fingers": [0, 3, 0, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 3, 3, 3, 3, 0], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 5, 6, 6], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 5, "barres": [] }
+  ],
+  "C#11": [
+    { "frets": [-1, 4, 4, 4, 2, -1], "fingers": [0, 2, 3, 4, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 4, 4, 4, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, -1, 6, 7, 7], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 6, "barres": [] }
+  ],
+  "D11": [
+    { "frets": [-1, -1, 0, 0, 1, 0], "fingers": [0, 0, 0, 0, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 5, 5, 3, -1], "fingers": [0, 2, 3, 4, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 5, 5, 5, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] }
+  ],
+  "D#11": [
+    { "frets": [-1, -1, 1, 1, 2, 1], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 6, 6, 4, -1], "fingers": [0, 2, 3, 4, 1, 0], "baseFret": 4, "barres": [] },
+    { "frets": [-1, 6, 6, 6, 6, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 6, "barres": [] }
+  ],
+  "E11": [
+    { "frets": [0, 0, 0, 1, 0, 0], "fingers": [0, 0, 0, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [0, 0, 4, 4, 3, 4], "fingers": [0, 0, 2, 3, 1, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 7, 5, -1], "fingers": [0, 2, 3, 4, 1, 0], "baseFret": 5, "barres": [] }
+  ],
+  "F11": [
+    { "frets": [1, 0, 1, 3, 1, -1], "fingers": [1, 0, 2, 4, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 3, 4, 3], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 8, 8, 6, -1], "fingers": [0, 2, 3, 4, 1, 0], "baseFret": 6, "barres": [] }
+  ],
+  "F#11": [
+    { "frets": [2, 1, 2, 1, 0, 0], "fingers": [3, 1, 4, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 4, 5, 4], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 9, 9, 7, -1], "fingers": [0, 2, 3, 4, 1, 0], "baseFret": 7, "barres": [] }
+  ],
+  "G11": [
+    { "frets": [3, 0, 0, 0, 1, 1], "fingers": [3, 0, 0, 0, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [3, 3, 3, 0, 0, 3], "fingers": [1, 2, 3, 0, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 5, 6, 5], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 5, "barres": [] }
+  ],
+  "G#11": [
+    { "frets": [-1, -1, -1, 1, 2, 2], "fingers": [0, 0, 0, 1, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [4, 4, 4, 3, -1, -1], "fingers": [2, 3, 4, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 6, 7, 6], "fingers": [0, 0, 1, 2, 4, 3], "baseFret": 6, "barres": [] }
+  ],
+  "Am11": [
+    { "frets": [-1, 0, 0, 0, 1, 0], "fingers": [0, 0, 0, 0, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [5, 3, 5, 4, 3, 3], "fingers": [3, 1, 4, 2, 1, 1], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 1, "toString": 5 }] },
+    { "frets": [5, 5, 5, 5, -1, -1], "fingers": [1, 2, 3, 4, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "A#m11": [
+    { "frets": [-1, 1, 1, 1, 2, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [6, 4, 6, 5, 4, 4], "fingers": [3, 1, 4, 2, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [6, 6, 6, 6, -1, -1], "fingers": [1, 2, 3, 4, 0, 0], "baseFret": 6, "barres": [] }
+  ],
+  "Bm11": [
+    { "frets": [-1, 2, 0, 2, 0, 0], "fingers": [0, 1, 0, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 7, 6, 5, 5], "fingers": [3, 1, 4, 2, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [7, 7, 7, 7, -1, -1], "fingers": [1, 2, 3, 4, 0, 0], "baseFret": 7, "barres": [] }
+  ],
+  "Cm11": [
+    { "frets": [-1, 3, 1, 3, 1, 1], "fingers": [0, 2, 1, 3, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 3, 3, 3, 4, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [8, 6, 8, 7, 6, 6], "fingers": [3, 1, 4, 2, 1, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] }
+  ],
+  "C#m11": [
+    { "frets": [-1, 4, 2, 4, 0, 2], "fingers": [0, 3, 1, 4, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 4, 4, 5, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 1, "barres": [] },
+    { "frets": [9, 7, 9, 8, 7, 7], "fingers": [3, 1, 4, 2, 1, 1], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] }
+  ],
+  "Dm11": [
+    { "frets": [-1, -1, 0, 0, 1, 1], "fingers": [0, 0, 0, 0, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 3, 5, 3, 3], "fingers": [0, 2, 1, 3, 1, 1], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 5, 5, 5, 6, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 5, "barres": [] }
+  ],
+  "D#m11": [
+    { "frets": [-1, -1, 1, 1, 2, 2], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 6, 4, 6, 4, 4], "fingers": [0, 2, 1, 3, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] },
+    { "frets": [-1, 6, 6, 6, 7, -1], "fingers": [0, 1, 2, 3, 4, 0], "baseFret": 6, "barres": [] }
+  ],
+  "Em11": [
+    { "frets": [0, 0, 0, 0, 0, 0], "fingers": [0, 0, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [0, 0, 0, 0, 0, 2], "fingers": [0, 0, 0, 0, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 5, 7, 5, 5], "fingers": [0, 2, 1, 3, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "Fm11": [
+    { "frets": [1, 1, 1, 1, -1, -1], "fingers": [1, 2, 3, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 3, 3, 4, 4], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 6, 8, 6, 6], "fingers": [0, 2, 1, 3, 1, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "F#m11": [
+    { "frets": [2, 0, 2, 1, 0, 0], "fingers": [2, 0, 3, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 4, 5, 5], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 7, 9, 7, 7], "fingers": [0, 2, 1, 3, 1, 1], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 2, "toString": 5 }] }
+  ],
+  "Gm11": [
+    { "frets": [3, 0, 0, 3, 1, 1], "fingers": [3, 0, 0, 4, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [3, 3, 3, 3, -1, -1], "fingers": [1, 2, 3, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 5, 5, 6, 6], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 5, "barres": [] }
+  ],
+  "G#m11": [
+    { "frets": [4, 2, 4, 3, 2, 2], "fingers": [3, 1, 4, 2, 1, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 1, "toString": 5 }] },
+    { "frets": [4, 4, 4, 4, -1, -1], "fingers": [1, 2, 3, 4, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 6, 6, 7, 7], "fingers": [0, 0, 1, 2, 3, 4], "baseFret": 6, "barres": [] }
+  ],
+  "A13": [
+    { "frets": [-1, 0, 0, 0, 2, 2], "fingers": [0, 0, 0, 0, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 0, 2, 0, 2, 2], "fingers": [0, 0, 1, 0, 2, 3], "baseFret": 1, "barres": [] },
+    { "frets": [5, 5, 5, 6, 7, 5], "fingers": [1, 1, 1, 2, 3, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "A#13": [
+    { "frets": [-1, 1, 0, 1, 1, 3], "fingers": [0, 1, 0, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [6, 3, 5, 3, 3, 4], "fingers": [4, 1, 3, 1, 1, 2], "baseFret": 3, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [6, 6, 6, 7, 8, 6], "fingers": [1, 1, 1, 2, 3, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "B13": [
+    { "frets": [-1, 2, 1, 2, 0, 4], "fingers": [0, 2, 1, 3, 0, 4], "baseFret": 1, "barres": [] },
+    { "frets": [7, 4, 6, 4, 4, 5], "fingers": [4, 1, 3, 1, 1, 2], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [7, 7, 7, 8, 9, 7], "fingers": [1, 1, 1, 2, 3, 1], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "C13": [
+    { "frets": [-1, 3, 3, 3, 5, 5], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 1, "toString": 3 }] },
+    { "frets": [8, 5, 7, 5, 5, 6], "fingers": [4, 1, 3, 1, 1, 2], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [8, 8, 8, 9, 10, 8], "fingers": [1, 1, 1, 2, 3, 1], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "C#13": [
+    { "frets": [-1, 4, 3, 3, 0, 2], "fingers": [0, 4, 2, 3, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 4, 4, 6, 6], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [9, 6, 8, 6, 6, 7], "fingers": [4, 1, 3, 1, 1, 2], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] }
+  ],
+  "D13": [
+    { "frets": [-1, -1, 0, 4, 1, 2], "fingers": [0, 0, 0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 5, 5, 7, 7], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [10, 7, 9, 7, 7, 8], "fingers": [4, 1, 3, 1, 1, 2], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] }
+  ],
+  "D#13": [
+    { "frets": [-1, 6, 6, 6, 8, 8], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [-1, 6, 8, 6, 8, 8], "fingers": [0, 1, 2, 1, 3, 4], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [11, 8, 10, 8, 8, 9], "fingers": [4, 1, 3, 1, 1, 2], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] }
+  ],
+  "E13": [
+    { "frets": [0, 0, 0, 1, 2, 0], "fingers": [0, 0, 0, 1, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [0, 4, 0, 4, 3, 4], "fingers": [0, 2, 0, 3, 1, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 7, 9, 9], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] }
+  ],
+  "F13": [
+    { "frets": [1, 0, 1, 0, 3, 1], "fingers": [1, 0, 2, 0, 4, 3], "baseFret": 1, "barres": [] },
+    { "frets": [1, 0, 1, 0, 3, 3], "fingers": [1, 0, 2, 0, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 8, 8, 8, 10, 10], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] }
+  ],
+  "F#13": [
+    { "frets": [2, 1, 1, 1, 0, 0], "fingers": [4, 1, 2, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, -1, 4, 3, 4, 0], "fingers": [0, 0, 2, 1, 3, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 9, 9, 11, 11], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 9, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] }
+  ],
+  "G13": [
+    { "frets": [3, 0, 2, 0, 0, 1], "fingers": [3, 0, 2, 0, 0, 1], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 3, 2, 0, 0], "fingers": [2, 0, 3, 1, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 3, 0, 0, 0], "fingers": [1, 0, 2, 0, 0, 0], "baseFret": 1, "barres": [] }
+  ],
+  "G#13": [
+    { "frets": [4, 1, 3, 1, 1, 2], "fingers": [4, 1, 3, 1, 1, 2], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 4 }] },
+    { "frets": [4, 1, 4, 1, 1, 1], "fingers": [2, 1, 3, 1, 1, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [4, 4, 4, 5, 6, 4], "fingers": [1, 1, 1, 2, 3, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "Am13": [
+    { "frets": [-1, 0, 0, 0, 1, 2], "fingers": [0, 0, 0, 0, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [5, 3, 4, 4, 3, 3], "fingers": [4, 1, 2, 3, 1, 1], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 1, "toString": 5 }] },
+    { "frets": [5, 5, 5, 5, 7, 5], "fingers": [1, 1, 1, 1, 2, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "A#m13": [
+    { "frets": [-1, 1, 1, 1, 2, 3], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [6, 4, 5, 5, 4, 4], "fingers": [4, 1, 2, 3, 1, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [6, 6, 6, 6, 8, 6], "fingers": [1, 1, 1, 1, 2, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "Bm13": [
+    { "frets": [-1, 2, 0, 2, 2, 4], "fingers": [0, 1, 0, 2, 3, 4], "baseFret": 1, "barres": [] },
+    { "frets": [7, 5, 6, 6, 5, 5], "fingers": [4, 1, 2, 3, 1, 1], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [7, 7, 7, 7, 9, 7], "fingers": [1, 1, 1, 1, 2, 1], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "Cm13": [
+    { "frets": [-1, 3, 3, 3, 4, 5], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 1, "barres": [{ "fret": 3, "fromString": 1, "toString": 3 }] },
+    { "frets": [8, 6, 7, 7, 6, 6], "fingers": [4, 1, 2, 3, 1, 1], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] },
+    { "frets": [8, 8, 8, 8, 10, 8], "fingers": [1, 1, 1, 1, 2, 1], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
+  "C#m13": [
+    { "frets": [-1, 4, 2, 3, 0, 2], "fingers": [0, 4, 1, 3, 0, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 4, 4, 4, 5, 6], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [9, 7, 8, 8, 7, 7], "fingers": [4, 1, 2, 3, 1, 1], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] }
+  ],
+  "Dm13": [
+    { "frets": [-1, -1, 0, 4, 1, 1], "fingers": [0, 0, 0, 3, 1, 2], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 5, 5, 5, 6, 7], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 5, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [10, 8, 9, 9, 8, 8], "fingers": [4, 1, 2, 3, 1, 1], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] }
+  ],
+  "D#m13": [
+    { "frets": [-1, 6, 6, 6, 7, 8], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [-1, 6, 8, 6, 7, 8], "fingers": [0, 1, 3, 1, 2, 4], "baseFret": 6, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] },
+    { "frets": [11, 9, 10, 10, 9, 9], "fingers": [4, 1, 2, 3, 1, 1], "baseFret": 9, "barres": [{ "fret": 1, "fromString": 1, "toString": 5 }] }
+  ],
+  "Em13": [
+    { "frets": [0, 0, 0, 0, 2, 0], "fingers": [0, 0, 0, 0, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [0, 4, 0, 0, -1, -1], "fingers": [0, 1, 0, 0, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 7, 7, 7, 8, 9], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 7, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] }
+  ],
+  "Fm13": [
+    { "frets": [1, 1, 1, 1, 3, 1], "fingers": [1, 1, 1, 1, 2, 1], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] },
+    { "frets": [1, 1, 1, 1, 3, 3], "fingers": [1, 1, 1, 1, 2, 3], "baseFret": 1, "barres": [{ "fret": 1, "fromString": 0, "toString": 3 }] },
+    { "frets": [-1, 8, 8, 8, 9, 10], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 8, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] }
+  ],
+  "F#m13": [
+    { "frets": [2, 0, 1, 1, 0, 0], "fingers": [3, 0, 1, 2, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [2, 0, 1, 2, 0, 0], "fingers": [2, 0, 1, 3, 0, 0], "baseFret": 1, "barres": [] },
+    { "frets": [-1, 9, 9, 9, 10, 11], "fingers": [0, 1, 1, 1, 2, 3], "baseFret": 9, "barres": [{ "fret": 1, "fromString": 1, "toString": 3 }] }
+  ],
+  "Gm13": [
+    { "frets": [3, 0, 3, 3, 1, 0], "fingers": [2, 0, 3, 4, 1, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 1, 3, 0, 1, 0], "fingers": [3, 1, 4, 0, 2, 0], "baseFret": 1, "barres": [] },
+    { "frets": [3, 0, 3, 3, 3, 0], "fingers": [1, 0, 2, 3, 4, 0], "baseFret": 1, "barres": [] }
+  ],
+  "G#m13": [
+    { "frets": [4, 2, 3, 3, 2, 2], "fingers": [4, 1, 2, 3, 1, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 1, "toString": 5 }] },
+    { "frets": [4, 2, 3, 4, 2, 2], "fingers": [3, 1, 2, 4, 1, 1], "baseFret": 1, "barres": [{ "fret": 2, "fromString": 1, "toString": 5 }] },
+    { "frets": [4, 4, 4, 4, 6, 4], "fingers": [1, 1, 1, 1, 2, 1], "baseFret": 4, "barres": [{ "fret": 1, "fromString": 0, "toString": 5 }] }
+  ],
   "A/C#": [
     { "frets": [-1, 4, 2, 2, 2, -1], "fingers": [0, 4, 1, 2, 3, 0], "baseFret": 1, "barres": [] },
     { "frets": [-1, -1, -1, 6, 5, 5], "fingers": [0, 0, 0, 3, 1, 2], "baseFret": 5, "barres": [] }

--- a/libs/platform-api/README.md
+++ b/libs/platform-api/README.md
@@ -29,9 +29,9 @@ import { createFileService, transposeChord, getSheetFromUG } from '@klank/platfo
 
 ## Chord Symbols
 
-All chord interpretation flows through one model: `parseChordSymbol()` resolves a symbol's root and slash-bass notes to pitch classes (C = 0, shared with `chord-theory.ts`) and validates the quality suffix against a permissive grammar (maj, min, dim, aug, sus, add, extensions like 7/9/11/13, altered tones like `m7b5` or `7#9`, and `6/9`). Output is always spelled in sharps: A, A#, B, C, C#, D, D#, E, F, F#, G, G#.
+All chord interpretation flows through one model: `parseChordSymbol()` resolves a symbol's root and slash-bass notes to pitch classes (C = 0, shared with `chord-theory.ts`) and validates the quality suffix against a permissive grammar (maj, min, dim, aug, sus, add, extensions like 7/9/11/13, altered tones like `m7b5` or `7#9`, `6/9`, and the jazz symbols `-` minor, `+` augmented, `°` diminished, `ø` half-diminished). Output is always spelled in sharps: A, A#, B, C, C#, D, D#, E, F, F#, G, G#.
 
-`transposeChord()` transposes a chord string by semitones, preserving the suffix verbatim and moving root and bass together; non-chord input is returned unchanged. `toTheoryChord()` bridges parsed symbols to the strict `chord-theory.ts` model when the suffix is one of the canonical diagram qualities.
+`transposeChord()` transposes a chord string by semitones, preserving the suffix verbatim and moving root and bass together; non-chord input is returned unchanged. `toTheoryChord()` bridges parsed symbols to the strict `chord-theory.ts` model, and `canonicalSuffix()` folds equivalent spellings (`D-7`, `Dmin7`, `DM7`, `Cø`) onto the canonical quality so chord-diagram lookups resolve regardless of spelling.
 
 ## UG Scraper
 

--- a/libs/platform-api/README.md
+++ b/libs/platform-api/README.md
@@ -7,7 +7,11 @@ Platform abstraction layer between the React app and Tauri IPC. All communicatio
 | Module | Exports | Purpose |
 |--------|---------|---------|
 | `fs.ts` | `FileService`, `createFileService()`, `mapTreeStructure()` | File I/O via Tauri FS plugin |
-| `chords.ts` | `transposeChord()`, `testChords()`, `isTablatureLine()`, etc. | Chord parsing and transposition |
+| `chord-symbol.ts` | `parseChordSymbol()`, `formatChordSymbol()`, `transposeChordSymbol()` | Structured chord-symbol parsing, formatting, and transposition |
+| `chord-theory.ts` | `parseChordKey()`, `CHORD_INTERVALS`, `validateChordVariant()`, etc. | Pitch-class theory and chord-diagram validation |
+| `chords.ts` | `transposeChord()`, `testChords()`, `isTablatureLine()`, etc. | Tab-text heuristics and string-level chord helpers |
+| `sheet-lines.ts` | `classifySheetLine()` | Pure tab-sheet line classification for the renderer |
+| `chord-diagrams.ts` | `loadChordDiagrams()`, `lookupChordDiagram()`, `normalizeChordKey()` | Chord diagram data loading and lookup |
 | `download.ts` | `getSheetFromUG()` | Downloads tabs from Ultimate Guitar via Tauri scraper |
 | `sort.ts` | `sortByArtist()` | Groups and sorts `FileEntry[]` by artist |
 | `userAgent.ts` | `isMobile()` | Mobile device detection |
@@ -23,9 +27,11 @@ import { createFileService, transposeChord, getSheetFromUG } from '@klank/platfo
 - Only `.tab.txt` files are recognized; `fs.ts` filters all other extensions.
 - Filenames must follow the pattern `Artist - Song.tab.txt`. `mapTreeStructure()` splits on ` - ` to extract artist and song name.
 
-## Chord Transposition
+## Chord Symbols
 
-`transposeChord()` uses a 12-note chromatic scale: A, A#, B, C, C#, D, D#, E, F, F#, G, G#. Supports accidentals, slash bass notes, and chord quality suffixes (maj, min, dim, sus, add, etc.).
+All chord interpretation flows through one model: `parseChordSymbol()` resolves a symbol's root and slash-bass notes to pitch classes (C = 0, shared with `chord-theory.ts`) and validates the quality suffix against a permissive grammar (maj, min, dim, aug, sus, add, extensions like 7/9/11/13, altered tones like `m7b5` or `7#9`, and `6/9`). Output is always spelled in sharps: A, A#, B, C, C#, D, D#, E, F, F#, G, G#.
+
+`transposeChord()` transposes a chord string by semitones, preserving the suffix verbatim and moving root and bass together; non-chord input is returned unchanged. `toTheoryChord()` bridges parsed symbols to the strict `chord-theory.ts` model when the suffix is one of the canonical diagram qualities.
 
 ## UG Scraper
 

--- a/libs/platform-api/src/index.ts
+++ b/libs/platform-api/src/index.ts
@@ -2,8 +2,10 @@ export * from './lib/fs';
 export * from './lib/git';
 export * from './lib/sort'
 export * from './lib/chords';
+export * from './lib/chord-symbol';
 export * from './lib/chord-diagrams';
 export * from './lib/chord-theory';
+export * from './lib/sheet-lines';
 export * from './lib/userAgent';
 export * from './lib/download';
 export * from './lib/app';

--- a/libs/platform-api/src/lib/chord-correctness.spec.ts
+++ b/libs/platform-api/src/lib/chord-correctness.spec.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
-  CHORD_INTERVALS,
+  OPTIONAL_INTERVALS,
   expectedChordKeys,
   findDuplicateVariants,
   getInvalidNotes,
@@ -38,7 +38,7 @@ describe.each(INSTRUMENTS)('%s chord data', (instrument) => {
   const map = loadMap(instrument)
 
   it('defines exactly the expected chord keys, in order', () => {
-    expect(Object.keys(map)).toEqual(expectedChordKeys())
+    expect(Object.keys(map)).toEqual(expectedChordKeys(instrument))
   })
 
   it('has 1 to 4 variants per key with no duplicates', () => {
@@ -65,11 +65,11 @@ describe.each(INSTRUMENTS)('%s chord data', (instrument) => {
     expect(failures, failures.join('\n')).toHaveLength(0)
   })
 
-  it('every triad variant is complete — all chord tones present', () => {
+  it('every variant of a no-omission quality is complete — all chord tones present', () => {
     const failures: string[] = []
     for (const [key, variants] of Object.entries(map)) {
       const parsed = parseChordKey(key)
-      if (!parsed || CHORD_INTERVALS[parsed.quality].length === 4) continue
+      if (!parsed || (OPTIONAL_INTERVALS[parsed.quality] ?? []).length > 0) continue
       for (const [i, variant] of variants.entries()) {
         const sounded = getVariantNotes(variant, DATA[instrument].tuning)
         const missing = [...getRequiredPitches(parsed)].filter((p) => !sounded.has(p))

--- a/libs/platform-api/src/lib/chord-diagrams.ts
+++ b/libs/platform-api/src/lib/chord-diagrams.ts
@@ -1,3 +1,6 @@
+import { parseNotePrefix } from './chord-symbol.js'
+import { pitchName } from './chord-theory.js'
+
 export type Instrument = 'guitar' | 'bass'
 
 export type ChordBarre = {
@@ -15,27 +18,20 @@ export type ChordVariant = {
 
 export type ChordDiagramMap = Record<string, ChordVariant[]>
 
-const FLAT_TO_SHARP: Record<string, string> = {
-  Bb: 'A#',
-  Db: 'C#',
-  Eb: 'D#',
-  Gb: 'F#',
-  Ab: 'G#',
-}
-
-/** Map a flat-spelled note prefix to its sharp equivalent ("Bb..." → "A#..."). */
-function sharpen(note: string): string {
-  const twoChar = note.slice(0, 2)
-  return FLAT_TO_SHARP[twoChar] ? FLAT_TO_SHARP[twoChar] + note.slice(2) : note
+/** Respell a token's leading note in sharps form ("Bbm7..." → "A#m7...").
+ *  Tokens that do not start with a note pass through unchanged. */
+function sharpenToken(token: string): string {
+  const note = parseNotePrefix(token)
+  return note === null ? token : pitchName(note.pitch) + note.rest
 }
 
 /** Normalize a chord name to the sharps-based key used in the JSON data.
- *  Keeps slash-bass notes and maps flat roots and bass notes to sharps
- *  (e.g. "Dm/Gb" → "Dm/F#"). */
+ *  Keeps slash-bass notes and respells roots and bass notes in sharps,
+ *  resolving any enharmonic spelling (e.g. "Dm/Gb" → "Dm/F#", "Cb" → "B"). */
 export function normalizeChordKey(chordName: string): string {
   const slashIdx = chordName.indexOf('/')
-  if (slashIdx === -1) return sharpen(chordName)
-  return `${sharpen(chordName.slice(0, slashIdx))}/${sharpen(chordName.slice(slashIdx + 1))}`
+  if (slashIdx === -1) return sharpenToken(chordName)
+  return `${sharpenToken(chordName.slice(0, slashIdx))}/${sharpenToken(chordName.slice(slashIdx + 1))}`
 }
 
 const cache = new Map<Instrument, ChordDiagramMap>()

--- a/libs/platform-api/src/lib/chord-diagrams.ts
+++ b/libs/platform-api/src/lib/chord-diagrams.ts
@@ -1,4 +1,4 @@
-import { parseNotePrefix } from './chord-symbol.js'
+import { canonicalSuffix, formatChordSymbol, parseChordSymbol, parseNotePrefix } from './chord-symbol.js'
 import { pitchName } from './chord-theory.js'
 
 export type Instrument = 'guitar' | 'bass'
@@ -26,9 +26,15 @@ function sharpenToken(token: string): string {
 }
 
 /** Normalize a chord name to the sharps-based key used in the JSON data.
- *  Keeps slash-bass notes and respells roots and bass notes in sharps,
- *  resolving any enharmonic spelling (e.g. "Dm/Gb" → "Dm/F#", "Cb" → "B"). */
+ *  Valid chord symbols get their root and bass respelled in sharps and their
+ *  quality canonicalized (e.g. "Dm/Gb" → "Dm/F#", "D-7" → "Dm7", "Cø" →
+ *  "Cm7b5", "CM7" → "Cmaj7"). Names the grammar rejects still get their note
+ *  prefixes respelled so near-miss lookups stay stable. */
 export function normalizeChordKey(chordName: string): string {
+  const parsed = parseChordSymbol(chordName)
+  if (parsed !== null) {
+    return formatChordSymbol({ ...parsed, suffix: canonicalSuffix(parsed.suffix) })
+  }
   const slashIdx = chordName.indexOf('/')
   if (slashIdx === -1) return sharpenToken(chordName)
   return `${sharpenToken(chordName.slice(0, slashIdx))}/${sharpenToken(chordName.slice(slashIdx + 1))}`

--- a/libs/platform-api/src/lib/chord-symbol.spec.ts
+++ b/libs/platform-api/src/lib/chord-symbol.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import fc from 'fast-check'
 import {
+  canonicalSuffix,
   formatChordSymbol,
   isChordSymbol,
   parseChordSymbol,
@@ -9,7 +10,7 @@ import {
   transposeChordSymbol,
   type ParsedChordSymbol,
 } from './chord-symbol.js'
-import { expectedChordKeys, parseChordKey, pitchName } from './chord-theory.js'
+import { CHORD_QUALITIES, expectedChordKeys, parseChordKey, pitchName } from './chord-theory.js'
 import { normalizeChordKey } from './chord-diagrams.js'
 
 // ── Legacy detection oracle ───────────────────────────────────────────────────
@@ -45,8 +46,9 @@ const ALLOWED_NUMBERS = new Set(['2', '4', '5', '6', '7', '9', '11', '13'])
 
 const stripRoot = (s: string) => s.replace(/^[A-G](?:##|bb|♭♭|#|b|♭)?/, '')
 
-/** New-only accepts must be one of the added forms. */
-const isApprovedAddition = (s: string) => /aug|6\/9|[#b♭]\d/.test(s)
+/** New-only accepts must be one of the added forms: aug, 6/9 (or 69),
+ *  altered tones, or the jazz symbols - + ° ø. */
+const isApprovedAddition = (s: string) => /aug|6\/9|69|[#b♭]\d|[-+°ø]/.test(s)
 
 /** Legacy-only accepts must be one of the dropped non-chord forms. */
 const isApprovedRemoval = (s: string) => {
@@ -60,9 +62,9 @@ const isApprovedRemoval = (s: string) => {
 
 const letterArb = fc.constantFrom('A', 'B', 'C', 'D', 'E', 'F', 'G')
 const accidentalArb = fc.constantFrom('', '#', '##', 'b', 'bb', '♭', '♭♭')
-const qualityArb = fc.constantFrom('', 'maj', 'min', 'm', 'M', 'dim', 'aug', 'sus', 'add')
+const qualityArb = fc.constantFrom('', 'maj', 'min', 'm', 'M', 'dim', 'aug', 'sus', 'add', '-', '+', '°', 'ø')
 const numberArb = fc.constantFrom('2', '4', '5', '6', '7', '9', '11', '13')
-const extensionArb = fc.constantFrom('', '2', '4', '5', '6', '6/9', '7', '9', '11', '13')
+const extensionArb = fc.constantFrom('', '2', '4', '5', '6', '69', '6/9', '7', '9', '11', '13')
 const tailArb = fc.oneof(
   fc.constant(''),
   fc
@@ -96,7 +98,7 @@ const parsedArb: fc.Arbitrary<ParsedChordSymbol> = fc
 /** Adversarial near-chord strings over a chord-flavoured alphabet. */
 const chordishStringArb = fc
   .array(
-    fc.constantFrom(...'ABCDEFGmajsudin#b♭/0123456789Mhe '.split('')),
+    fc.constantFrom(...'ABCDEFGmajsudin#b♭/0123456789Mhe-+°ø '.split('')),
     { maxLength: 10 },
   )
   .map((chars) => chars.join(''))
@@ -144,7 +146,9 @@ describe('parseChordSymbol grammar', () => {
     'Am', 'C#maj7', 'Dm7/G', 'Eb', 'B♭♭', 'Bsus4', 'Cadd9', 'Am7add9',
     'Cmaj13', 'C7sus4', 'Dmin7', 'CM7', 'Cmmaj7', 'C5', 'Cdim7',
     // forms the legacy grammar missed
-    'Caug', 'Am7b5', 'C6/9', 'E7#9', 'Fadd11', 'G7b9#5',
+    'Caug', 'Am7b5', 'C6/9', 'C69', 'E7#9', 'Fadd11', 'G7b9#5',
+    // jazz/lead-sheet symbol spellings
+    'C-', 'C-7', 'A-7/G', 'C+', 'C+5', 'C°', 'C°7', 'Cø', 'Cø7', 'C-7b5', 'C-maj7',
   ])('accepts %s', (chord) => {
     expect(parseChordSymbol(chord)).not.toBeNull()
   })
@@ -153,6 +157,8 @@ describe('parseChordSymbol grammar', () => {
     'hello', 'the', 'e', '', '/G', 'H7',
     // non-chords the legacy grammar accepted
     'Cmaj23', 'C8', 'C97', 'Cmin1', 'C7m7',
+    // malformed symbol spellings
+    'C--', 'C-+', 'C7-7', '+C', '-', 'ø',
   ])('rejects %s', (chord) => {
     expect(parseChordSymbol(chord)).toBeNull()
   })
@@ -284,15 +290,34 @@ describe('chord-symbol vs chord-theory on canonical keys', () => {
     )
   })
 
-  it('toTheoryChord bridges exactly the canonical qualities', () => {
+  it('normalizeChordKey resolves equivalent spellings to the diagram key', () => {
+    expect(normalizeChordKey('D-7')).toBe('Dm7')
+    expect(normalizeChordKey('Bb-')).toBe('A#m')
+    expect(normalizeChordKey('C+')).toBe('Caug')
+    expect(normalizeChordKey('Cø')).toBe('Cm7b5')
+    expect(normalizeChordKey('Eb°7')).toBe('D#dim7')
+    expect(normalizeChordKey('C6/9')).toBe('C69')
+    expect(normalizeChordKey('Dmin7/G')).toBe('Dm7/G')
+    expect(normalizeChordKey('CM7')).toBe('Cmaj7')
+  })
+
+  it('toTheoryChord bridges exactly the canonicalized qualities', () => {
     fc.assert(
       fc.property(knownKeyArb, (key) => {
         expect(toTheoryChord(parseChordSymbol(key)!)).toEqual(parseChordKey(key))
       }),
     )
-    // permissive-only suffixes do not bridge
-    expect(toTheoryChord(parseChordSymbol('Dmin7')!)).toBeNull()
-    expect(toTheoryChord(parseChordSymbol('Am7b5')!)).toBeNull()
+    // equivalent spellings bridge to the same theory chord
+    expect(toTheoryChord(parseChordSymbol('Dmin7')!)).toEqual(parseChordKey('Dm7'))
+    expect(toTheoryChord(parseChordSymbol('C-')!)).toEqual(parseChordKey('Cm'))
+    expect(toTheoryChord(parseChordSymbol('C+')!)).toEqual(parseChordKey('Caug'))
+    expect(toTheoryChord(parseChordSymbol('C°')!)).toEqual(parseChordKey('Cdim'))
+    expect(toTheoryChord(parseChordSymbol('Cø')!)).toEqual(parseChordKey('Cm7b5'))
+    expect(toTheoryChord(parseChordSymbol('C6/9')!)).toEqual(parseChordKey('C69'))
+    expect(toTheoryChord(parseChordSymbol('CM7')!)).toEqual(parseChordKey('Cmaj7'))
+    // suffixes naming no canonical quality do not bridge
+    expect(toTheoryChord(parseChordSymbol('C7sus4')!)).toBeNull()
+    expect(toTheoryChord(parseChordSymbol('Am7add9')!)).toBeNull()
   })
 
   it('formats every pitch class to its sharps-only name', () => {
@@ -301,5 +326,40 @@ describe('chord-symbol vs chord-theory on canonical keys', () => {
         expect(formatChordSymbol({ rootPitch: pitch, suffix: '' })).toBe(pitchName(pitch))
       }),
     )
+  })
+})
+
+// ── canonicalSuffix ───────────────────────────────────────────────────────────
+
+describe('canonicalSuffix', () => {
+  it('is idempotent on any string', () => {
+    fc.assert(
+      fc.property(fc.oneof(suffixArb, fc.string({ maxLength: 8 })), (suffix) => {
+        expect(canonicalSuffix(canonicalSuffix(suffix))).toBe(canonicalSuffix(suffix))
+      }),
+    )
+  })
+
+  it('is the identity on every canonical quality', () => {
+    for (const quality of CHORD_QUALITIES) {
+      expect(canonicalSuffix(quality), quality).toBe(quality)
+    }
+  })
+
+  it('rewrites equivalent spellings to the canonical quality', () => {
+    expect(canonicalSuffix('-')).toBe('m')
+    expect(canonicalSuffix('-7')).toBe('m7')
+    expect(canonicalSuffix('+')).toBe('aug')
+    expect(canonicalSuffix('°')).toBe('dim')
+    expect(canonicalSuffix('°7')).toBe('dim7')
+    expect(canonicalSuffix('ø')).toBe('m7b5')
+    expect(canonicalSuffix('ø7')).toBe('m7b5')
+    expect(canonicalSuffix('min')).toBe('m')
+    expect(canonicalSuffix('min7')).toBe('m7')
+    expect(canonicalSuffix('M')).toBe('')
+    expect(canonicalSuffix('maj')).toBe('')
+    expect(canonicalSuffix('M7')).toBe('maj7')
+    expect(canonicalSuffix('6/9')).toBe('69')
+    expect(canonicalSuffix('-7b5')).toBe('m7b5')
   })
 })

--- a/libs/platform-api/src/lib/chord-symbol.spec.ts
+++ b/libs/platform-api/src/lib/chord-symbol.spec.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import {
+  formatChordSymbol,
+  isChordSymbol,
+  parseChordSymbol,
+  parseNotePrefix,
+  toTheoryChord,
+  transposeChordSymbol,
+  type ParsedChordSymbol,
+} from './chord-symbol.js'
+import { expectedChordKeys, parseChordKey, pitchName } from './chord-theory.js'
+import { normalizeChordKey } from './chord-diagrams.js'
+
+// ── Legacy detection oracle ───────────────────────────────────────────────────
+//
+// The regex grammar that powered testChords before the chord-symbol layer,
+// copied verbatim. The new grammar deliberately diverges from it in two
+// approved directions (see the bounded-divergence property below):
+//   - it ADDS forms the old grammar missed: aug, altered tones (m7b5, 7#9),
+//     and the 6/9 extension;
+//   - it DROPS non-chords the old grammar accepted: extensions that name no
+//     chord tone (Cmaj23, C8) and m/M stacked as a second quality (C7m7).
+// Any divergence outside those two classes is a regression and fails here.
+
+const legacyNotePattern = '(?<note>[A-G])(?<accidentals>(?:bb|b|♭♭|♭)|(?:##|#))?'
+const legacyQuality = '(maj|[Mm]|min|sus|dim|add)?'
+const legacyQualityRequired = '(?:maj|[Mm]|min|sus|dim|add)'
+const legacyNumber = '(?:[1-9]|1[0-9]|2[0-3])?'
+const legacyNumberRequired = '(?:[1-9]|1[0-9]|2[0-3])'
+const legacyNoTriples = '^(?!.*(?:#{3}|b{3}|♭{3}))'
+const legacyChordsPattern =
+  `(?<chords>${legacyQuality}${legacyNumber}(?:${legacyQualityRequired}${legacyNumberRequired})?)?`
+const legacyBassPattern =
+  '(?:\\/(?<bass>(?<bassNote>[A-G])(?<bassAccidentals>(?:b|bb|♭|♭♭)|(?:#|##))?))?'
+const legacyMatcher = legacyNotePattern + legacyChordsPattern + legacyBassPattern
+
+const legacyTestChords = (string: string): boolean => {
+  const match = new RegExp(legacyNoTriples + legacyMatcher + '$').exec(string)
+  return match !== null && match[0] === string
+}
+
+/** Numbers the new grammar accepts as extensions/alterations. */
+const ALLOWED_NUMBERS = new Set(['2', '4', '5', '6', '7', '9', '11', '13'])
+
+const stripRoot = (s: string) => s.replace(/^[A-G](?:##|bb|♭♭|#|b|♭)?/, '')
+
+/** New-only accepts must be one of the added forms. */
+const isApprovedAddition = (s: string) => /aug|6\/9|[#b♭]\d/.test(s)
+
+/** Legacy-only accepts must be one of the dropped non-chord forms. */
+const isApprovedRemoval = (s: string) => {
+  const runs = s.match(/\d+/g) ?? []
+  if (runs.some((run) => !ALLOWED_NUMBERS.has(run))) return true
+  // m/M stacked after the start of the suffix, e.g. C7m7, Cmm7
+  return /[mM]/.test(stripRoot(s).slice(1))
+}
+
+// ── Arbitraries ───────────────────────────────────────────────────────────────
+
+const letterArb = fc.constantFrom('A', 'B', 'C', 'D', 'E', 'F', 'G')
+const accidentalArb = fc.constantFrom('', '#', '##', 'b', 'bb', '♭', '♭♭')
+const qualityArb = fc.constantFrom('', 'maj', 'min', 'm', 'M', 'dim', 'aug', 'sus', 'add')
+const numberArb = fc.constantFrom('2', '4', '5', '6', '7', '9', '11', '13')
+const extensionArb = fc.constantFrom('', '2', '4', '5', '6', '6/9', '7', '9', '11', '13')
+const tailArb = fc.oneof(
+  fc.constant(''),
+  fc
+    .tuple(fc.constantFrom('maj', 'min', 'sus', 'dim', 'add'), numberArb)
+    .map(([q, n]) => q + n),
+)
+const alterationArb = fc.array(
+  fc.tuple(fc.constantFrom('#', 'b', '♭'), numberArb).map(([a, n]) => a + n),
+  { maxLength: 2 },
+)
+
+/** Suffixes drawn from the new grammar. */
+const suffixArb = fc
+  .tuple(qualityArb, extensionArb, tailArb, alterationArb)
+  .map(([quality, extension, tail, alterations]) => quality + extension + tail + alterations.join(''))
+
+/** Well-formed chord strings (grammar-valid by construction). */
+const chordStringArb = fc
+  .tuple(letterArb, accidentalArb, suffixArb, fc.option(fc.tuple(letterArb, accidentalArb)))
+  .map(([letter, accidental, suffix, bass]) =>
+    bass === null ? letter + accidental + suffix : `${letter}${accidental}${suffix}/${bass[0]}${bass[1]}`,
+  )
+
+/** Parsed symbols with grammar-valid suffixes (the parser's output domain). */
+const parsedArb: fc.Arbitrary<ParsedChordSymbol> = fc
+  .tuple(fc.integer({ min: 0, max: 11 }), suffixArb, fc.option(fc.integer({ min: 0, max: 11 })))
+  .map(([rootPitch, suffix, bassPitch]) =>
+    bassPitch === null ? { rootPitch, suffix } : { rootPitch, suffix, bassPitch },
+  )
+
+/** Adversarial near-chord strings over a chord-flavoured alphabet. */
+const chordishStringArb = fc
+  .array(
+    fc.constantFrom(...'ABCDEFGmajsudin#b♭/0123456789Mhe '.split('')),
+    { maxLength: 10 },
+  )
+  .map((chars) => chars.join(''))
+
+const knownKeyArb = fc.constantFrom(...expectedChordKeys())
+
+// ── parseNotePrefix ───────────────────────────────────────────────────────────
+
+describe('parseNotePrefix', () => {
+  it('resolves every letter/accidental spelling and returns the remainder', () => {
+    fc.assert(
+      fc.property(letterArb, accidentalArb, fc.string({ maxLength: 5 }), (letter, accidental, rest) => {
+        const parsed = parseNotePrefix(letter + accidental + rest)
+        expect(parsed).not.toBeNull()
+        // Accidentals starting the rest get consumed by the prefix instead;
+        // only assert the round trip when the rest is not accidental-leading.
+        if (!/^[#b♭]/.test(rest) || accidental.length === 2) {
+          expect(parsed?.rest).toBe(rest)
+        }
+        expect(parsed?.pitch).toBeGreaterThanOrEqual(0)
+        expect(parsed?.pitch).toBeLessThanOrEqual(11)
+      }),
+    )
+  })
+
+  it('collapses enharmonic spellings to the same pitch class', () => {
+    expect(parseNotePrefix('Cb')?.pitch).toBe(parseNotePrefix('B')?.pitch)
+    expect(parseNotePrefix('B#')?.pitch).toBe(parseNotePrefix('C')?.pitch)
+    expect(parseNotePrefix('C##')?.pitch).toBe(parseNotePrefix('D')?.pitch)
+    expect(parseNotePrefix('D♭♭')?.pitch).toBe(parseNotePrefix('C')?.pitch)
+  })
+
+  it('rejects strings that do not start with a note letter', () => {
+    expect(parseNotePrefix('hello')).toBeNull()
+    expect(parseNotePrefix('e')).toBeNull()
+    expect(parseNotePrefix('')).toBeNull()
+    expect(parseNotePrefix('#C')).toBeNull()
+  })
+})
+
+// ── Grammar examples ──────────────────────────────────────────────────────────
+
+describe('parseChordSymbol grammar', () => {
+  it.each([
+    'Am', 'C#maj7', 'Dm7/G', 'Eb', 'B♭♭', 'Bsus4', 'Cadd9', 'Am7add9',
+    'Cmaj13', 'C7sus4', 'Dmin7', 'CM7', 'Cmmaj7', 'C5', 'Cdim7',
+    // forms the legacy grammar missed
+    'Caug', 'Am7b5', 'C6/9', 'E7#9', 'Fadd11', 'G7b9#5',
+  ])('accepts %s', (chord) => {
+    expect(parseChordSymbol(chord)).not.toBeNull()
+  })
+
+  it.each([
+    'hello', 'the', 'e', '', '/G', 'H7',
+    // non-chords the legacy grammar accepted
+    'Cmaj23', 'C8', 'C97', 'Cmin1', 'C7m7',
+  ])('rejects %s', (chord) => {
+    expect(parseChordSymbol(chord)).toBeNull()
+  })
+
+  it('keeps the suffix verbatim and the 6/9 extension out of the bass', () => {
+    expect(parseChordSymbol('Dmin7')).toEqual({ rootPitch: 2, suffix: 'min7' })
+    expect(parseChordSymbol('C6/9')).toEqual({ rootPitch: 0, suffix: '6/9' })
+    expect(parseChordSymbol('C6/9/E')).toEqual({ rootPitch: 0, suffix: '6/9', bassPitch: 4 })
+    expect(parseChordSymbol('Dm7/G')).toEqual({ rootPitch: 2, suffix: 'm7', bassPitch: 7 })
+  })
+})
+
+// ── Bounded legacy-divergence oracle ──────────────────────────────────────────
+
+describe('detection grammar vs legacy regex', () => {
+  const assertBoundedDivergence = (s: string) => {
+    const next = isChordSymbol(s)
+    const legacy = legacyTestChords(s)
+    if (next === legacy) return
+    if (next && !legacy) {
+      expect(isApprovedAddition(s), `unapproved new accept: "${s}"`).toBe(true)
+    } else {
+      expect(isApprovedRemoval(s), `unapproved removal: "${s}"`).toBe(true)
+    }
+  }
+
+  it('diverges only in the approved classes (adversarial alphabet)', () => {
+    fc.assert(fc.property(chordishStringArb, assertBoundedDivergence))
+  })
+
+  it('diverges only in the approved classes (arbitrary strings)', () => {
+    fc.assert(fc.property(fc.string({ maxLength: 12 }), assertBoundedDivergence))
+  })
+
+  it('accepts every grammar-built chord string', () => {
+    fc.assert(
+      fc.property(chordStringArb, (s) => {
+        expect(isChordSymbol(s)).toBe(true)
+      }),
+    )
+  })
+})
+
+// ── Round trips and normalization ─────────────────────────────────────────────
+
+describe('parse/format round trip', () => {
+  it('parseChordSymbol(formatChordSymbol(p)) recovers p exactly', () => {
+    fc.assert(
+      fc.property(parsedArb, (parsed) => {
+        expect(parseChordSymbol(formatChordSymbol(parsed))).toEqual(parsed)
+      }),
+    )
+  })
+
+  it('format∘parse is idempotent on parseable strings', () => {
+    fc.assert(
+      fc.property(chordStringArb, (s) => {
+        const once = formatChordSymbol(parseChordSymbol(s)!)
+        const twice = formatChordSymbol(parseChordSymbol(once)!)
+        expect(twice).toBe(once)
+      }),
+    )
+  })
+})
+
+// ── Transpose group laws ──────────────────────────────────────────────────────
+
+describe('transposeChordSymbol', () => {
+  it('transposing by 0 is the identity', () => {
+    fc.assert(
+      fc.property(parsedArb, (p) => {
+        expect(transposeChordSymbol(p, 0)).toEqual(p)
+      }),
+    )
+  })
+
+  it('composes additively: T_a ∘ T_b = T_(a+b)', () => {
+    fc.assert(
+      fc.property(parsedArb, fc.integer({ min: -50, max: 50 }), fc.integer({ min: -50, max: 50 }), (p, a, b) => {
+        expect(transposeChordSymbol(transposeChordSymbol(p, a), b)).toEqual(transposeChordSymbol(p, a + b))
+      }),
+    )
+  })
+
+  it('is periodic with period 12 and invertible', () => {
+    fc.assert(
+      fc.property(parsedArb, fc.integer({ min: -50, max: 50 }), (p, n) => {
+        expect(transposeChordSymbol(p, n + 12)).toEqual(transposeChordSymbol(p, n))
+        expect(transposeChordSymbol(transposeChordSymbol(p, n), -n)).toEqual(p)
+      }),
+    )
+  })
+
+  it('moves the root by exactly n semitones and never touches the suffix', () => {
+    fc.assert(
+      fc.property(parsedArb, fc.integer({ min: -50, max: 50 }), (p, n) => {
+        const moved = transposeChordSymbol(p, n)
+        expect(moved.rootPitch).toBe((((p.rootPitch + n) % 12) + 12) % 12)
+        expect(moved.suffix).toBe(p.suffix)
+        expect(moved.bassPitch === undefined).toBe(p.bassPitch === undefined)
+      }),
+    )
+  })
+})
+
+// ── Cross-system consistency (the unification contract) ──────────────────────
+
+describe('chord-symbol vs chord-theory on canonical keys', () => {
+  it('parses every expected chord key and agrees with parseChordKey', () => {
+    fc.assert(
+      fc.property(knownKeyArb, (key) => {
+        const symbol = parseChordSymbol(key)
+        const theory = parseChordKey(key)
+        expect(symbol).not.toBeNull()
+        expect(theory).not.toBeNull()
+        expect(symbol?.rootPitch).toBe(theory?.rootPitch)
+        expect(symbol?.suffix).toBe(theory?.quality)
+        expect(symbol?.bassPitch).toBe(theory?.bassPitch)
+      }),
+    )
+  })
+
+  it('canonical keys are fixpoints of format and normalizeChordKey', () => {
+    fc.assert(
+      fc.property(knownKeyArb, (key) => {
+        expect(formatChordSymbol(parseChordSymbol(key)!)).toBe(key)
+        expect(normalizeChordKey(key)).toBe(key)
+      }),
+    )
+  })
+
+  it('toTheoryChord bridges exactly the canonical qualities', () => {
+    fc.assert(
+      fc.property(knownKeyArb, (key) => {
+        expect(toTheoryChord(parseChordSymbol(key)!)).toEqual(parseChordKey(key))
+      }),
+    )
+    // permissive-only suffixes do not bridge
+    expect(toTheoryChord(parseChordSymbol('Dmin7')!)).toBeNull()
+    expect(toTheoryChord(parseChordSymbol('Am7b5')!)).toBeNull()
+  })
+
+  it('formats every pitch class to its sharps-only name', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 11 }), (pitch) => {
+        expect(formatChordSymbol({ rootPitch: pitch, suffix: '' })).toBe(pitchName(pitch))
+      }),
+    )
+  })
+})

--- a/libs/platform-api/src/lib/chord-symbol.ts
+++ b/libs/platform-api/src/lib/chord-symbol.ts
@@ -1,0 +1,140 @@
+import { CHORD_INTERVALS, NOTE_PITCH, pitchName, type ParsedChord } from './chord-theory.js'
+
+/**
+ * Permissive structured chord-symbol layer.
+ *
+ * This module is the single place where chord symbols written in tab text
+ * (`Am`, `Bbmaj7`, `Dm7/G`, `E7#9`, `C6/9`, ...) are interpreted. Root and
+ * bass notes are resolved to theory-grade pitch classes (C=0, shared with
+ * chord-theory.ts); the quality suffix is validated against a grammar but
+ * stored verbatim, so unconventional spellings like `Dmin7` survive a
+ * parse/format round trip unchanged.
+ */
+
+/**
+ * A chord symbol in parsed form.
+ *
+ * `suffix` is the verbatim quality text from the input (`''` for a plain
+ * major chord) and is always grammar-valid when produced by
+ * `parseChordSymbol`. It is *not* normalized: `Dmin7` keeps the suffix
+ * `min7`, it does not become `m7`.
+ */
+export type ParsedChordSymbol = {
+  /** Root pitch class, 0–11 with C=0. */
+  rootPitch: number
+  /** Verbatim quality suffix, e.g. `m7`, `maj7`, `7b5`; `''` = major. */
+  suffix: string
+  /** Slash-bass pitch class, 0–11 with C=0, when the symbol has one. */
+  bassPitch?: number
+}
+
+/** Signed semitone offset of each accidental spelling. */
+const ACCIDENTAL_OFFSET: Record<string, number> = {
+  '#': 1, '##': 2, b: -1, bb: -2, '♭': -1, '♭♭': -2,
+}
+
+const NOTE_PREFIX = /^(?<letter>[A-G])(?<accidental>##|bb|♭♭|#|b|♭)?/
+
+/**
+ * Splits a leading note token off a string and resolves it to a pitch class.
+ *
+ * Accepts a note letter A–G followed by at most a double accidental
+ * (`#`, `##`, `b`, `bb`, `♭`, `♭♭`). This is the only place in the codebase
+ * where accidentals are interpreted; enharmonic spellings collapse to the
+ * same pitch class (`Cb` → 11, same as `B`).
+ *
+ * @returns The pitch class and the unconsumed remainder, or `null` when the
+ *          string does not start with a note.
+ */
+export const parseNotePrefix = (string: string): { pitch: number; rest: string } | null => {
+  const match = NOTE_PREFIX.exec(string)
+  if (match === null || match.groups === undefined) return null
+  const offset = ACCIDENTAL_OFFSET[match.groups.accidental ?? ''] ?? 0
+  const pitch = (((NOTE_PITCH[match.groups.letter] + offset) % 12) + 12) % 12
+  return { pitch, rest: string.slice(match[0].length) }
+}
+
+// Quality suffix grammar: quality? extension? (quality extension)? alteration{0,2}
+//
+// Accepts the conventional chord vocabulary — m, maj7, sus4, dim, aug, 5,
+// add9, 7sus4, m7add9, 6/9, and altered tones like m7b5 or 7#9 — while
+// rejecting non-chords such as Cmaj23 or C97. Extensions are limited to the
+// numbers that name real chord tones.
+const QUALITY = '(?:maj|min|m|M|dim|aug|sus|add)'
+// Bare m/M cannot stack onto an extension (C7m7 is not a chord); spelled-out
+// qualities can (Cmmaj7, C7sus4, m7add9).
+const TAIL_QUALITY = '(?:maj|min|sus|dim|add)'
+const NUMBER = '(?:13|11|9|7|6|5|4|2)'
+const EXTENSION = '(?:13|11|9|7|6(?:\\/9)?|5|4|2)'
+const ALTERATION = `(?:[#b♭]${NUMBER})`
+const SUFFIX_MATCHER = new RegExp(`^${QUALITY}?${EXTENSION}?(?:${TAIL_QUALITY}${NUMBER})?${ALTERATION}{0,2}$`)
+
+/**
+ * Parses a whole token as a chord symbol.
+ *
+ * A chord symbol is a note (see `parseNotePrefix`), an optional quality
+ * suffix, and an optional `/bass` note. The bass split takes the last `/`
+ * whose remainder is exactly a note, so the `6/9` suffix is never mistaken
+ * for a slash bass (`C6/9` has no bass; `C6/9/E` does).
+ *
+ * @returns The parsed symbol, or `null` when the token is not a chord.
+ */
+export const parseChordSymbol = (token: string): ParsedChordSymbol | null => {
+  const root = parseNotePrefix(token)
+  if (root === null) return null
+
+  let suffix = root.rest
+  let bassPitch: number | undefined
+
+  const slashIndex = root.rest.lastIndexOf('/')
+  if (slashIndex !== -1) {
+    const bass = parseNotePrefix(root.rest.slice(slashIndex + 1))
+    if (bass !== null && bass.rest === '') {
+      suffix = root.rest.slice(0, slashIndex)
+      bassPitch = bass.pitch
+    }
+  }
+
+  if (!SUFFIX_MATCHER.test(suffix)) return null
+  return bassPitch === undefined
+    ? { rootPitch: root.pitch, suffix }
+    : { rootPitch: root.pitch, suffix, bassPitch }
+}
+
+/**
+ * Renders a parsed symbol back to a string in canonical sharps-only form
+ * (`{ rootPitch: 10, suffix: 'm7' }` → `A#m7`). Inverse of `parseChordSymbol`
+ * up to enharmonic spelling of the input.
+ */
+export const formatChordSymbol = (parsed: ParsedChordSymbol): string => {
+  const bass = parsed.bassPitch !== undefined ? `/${pitchName(parsed.bassPitch)}` : ''
+  return `${pitchName(parsed.rootPitch)}${parsed.suffix}${bass}`
+}
+
+/**
+ * Transposes a parsed symbol by `semitones` (any integer, wraps at 12).
+ * Root and bass move together; the suffix is untouched.
+ */
+export const transposeChordSymbol = (parsed: ParsedChordSymbol, semitones: number): ParsedChordSymbol => {
+  const shift = (pitch: number) => (((pitch + semitones) % 12) + 12) % 12
+  return {
+    ...parsed,
+    rootPitch: shift(parsed.rootPitch),
+    ...(parsed.bassPitch !== undefined ? { bassPitch: shift(parsed.bassPitch) } : {}),
+  }
+}
+
+/** Returns true if `token` is a chord symbol (see `parseChordSymbol`). */
+export const isChordSymbol = (token: string): boolean => parseChordSymbol(token) !== null
+
+/**
+ * Bridges the permissive symbol model to the strict theory model: succeeds
+ * exactly when the suffix is one of the canonical qualities in
+ * `CHORD_INTERVALS` (the qualities the chord-diagram data is generated for).
+ */
+export const toTheoryChord = (parsed: ParsedChordSymbol): ParsedChord | null => {
+  if (!(parsed.suffix in CHORD_INTERVALS)) return null
+  return parsed.bassPitch === undefined
+    ? { rootPitch: parsed.rootPitch, quality: parsed.suffix }
+    : { rootPitch: parsed.rootPitch, quality: parsed.suffix, bassPitch: parsed.bassPitch }
+}

--- a/libs/platform-api/src/lib/chord-symbol.ts
+++ b/libs/platform-api/src/lib/chord-symbol.ts
@@ -57,15 +57,16 @@ export const parseNotePrefix = (string: string): { pitch: number; rest: string }
 // Quality suffix grammar: quality? extension? (quality extension)? alteration{0,2}
 //
 // Accepts the conventional chord vocabulary — m, maj7, sus4, dim, aug, 5,
-// add9, 7sus4, m7add9, 6/9, and altered tones like m7b5 or 7#9 — while
-// rejecting non-chords such as Cmaj23 or C97. Extensions are limited to the
-// numbers that name real chord tones.
-const QUALITY = '(?:maj|min|m|M|dim|aug|sus|add)'
-// Bare m/M cannot stack onto an extension (C7m7 is not a chord); spelled-out
-// qualities can (Cmmaj7, C7sus4, m7add9).
+// add9, 7sus4, m7add9, 6/9, altered tones like m7b5 or 7#9, and the
+// jazz/lead-sheet symbols - (minor), + (augmented), ° (diminished) and
+// ø (half-diminished) — while rejecting non-chords such as Cmaj23 or C97.
+// Extensions are limited to the numbers that name real chord tones.
+const QUALITY = '(?:maj|min|m|M|dim|aug|sus|add|-|\\+|°|ø)'
+// Bare m/M and the single-symbol qualities cannot stack onto an extension
+// (C7m7 is not a chord); spelled-out qualities can (Cmmaj7, C7sus4, m7add9).
 const TAIL_QUALITY = '(?:maj|min|sus|dim|add)'
 const NUMBER = '(?:13|11|9|7|6|5|4|2)'
-const EXTENSION = '(?:13|11|9|7|6(?:\\/9)?|5|4|2)'
+const EXTENSION = '(?:13|11|9|7|69|6(?:\\/9)?|5|4|2)'
 const ALTERATION = `(?:[#b♭]${NUMBER})`
 const SUFFIX_MATCHER = new RegExp(`^${QUALITY}?${EXTENSION}?(?:${TAIL_QUALITY}${NUMBER})?${ALTERATION}{0,2}$`)
 
@@ -128,13 +129,33 @@ export const transposeChordSymbol = (parsed: ParsedChordSymbol, semitones: numbe
 export const isChordSymbol = (token: string): boolean => parseChordSymbol(token) !== null
 
 /**
+ * Rewrites equivalent quality spellings to the canonical form used by
+ * `CHORD_INTERVALS` and the chord-diagram JSON keys: `-` → `m`, `+` → `aug`,
+ * `°` → `dim`, `ø`/`ø7` → `m7b5`, `min` → `m`, `M`/`maj` → `maj`/`''`, and
+ * `6/9` → `69`. Spellings that are already canonical — or that name no
+ * canonical quality — pass through verbatim. Idempotent.
+ */
+export const canonicalSuffix = (suffix: string): string => {
+  if (suffix === 'ø' || suffix === 'ø7') return 'm7b5'
+  let result = suffix
+  if (result.startsWith('-')) result = 'm' + result.slice(1)
+  else if (result.startsWith('+')) result = 'aug' + result.slice(1)
+  else if (result.startsWith('°')) result = 'dim' + result.slice(1)
+  else if (result.startsWith('min')) result = 'm' + result.slice(3)
+  else if (result.startsWith('M') && !result.startsWith('Maj')) result = 'maj' + result.slice(1)
+  result = result.replace('6/9', '69')
+  return result === 'maj' ? '' : result
+}
+
+/**
  * Bridges the permissive symbol model to the strict theory model: succeeds
- * exactly when the suffix is one of the canonical qualities in
+ * exactly when the canonicalized suffix is one of the qualities in
  * `CHORD_INTERVALS` (the qualities the chord-diagram data is generated for).
  */
 export const toTheoryChord = (parsed: ParsedChordSymbol): ParsedChord | null => {
-  if (!(parsed.suffix in CHORD_INTERVALS)) return null
+  const quality = canonicalSuffix(parsed.suffix)
+  if (!(quality in CHORD_INTERVALS)) return null
   return parsed.bassPitch === undefined
-    ? { rootPitch: parsed.rootPitch, quality: parsed.suffix }
-    : { rootPitch: parsed.rootPitch, quality: parsed.suffix, bassPitch: parsed.bassPitch }
+    ? { rootPitch: parsed.rootPitch, quality }
+    : { rootPitch: parsed.rootPitch, quality, bassPitch: parsed.bassPitch }
 }

--- a/libs/platform-api/src/lib/chord-theory.spec.ts
+++ b/libs/platform-api/src/lib/chord-theory.spec.ts
@@ -5,6 +5,7 @@ import {
   CHORD_INTERVALS,
   CHORD_QUALITIES,
   CHORD_ROOTS,
+  OPTIONAL_INTERVALS,
   DIAGRAM_ROWS,
   INSTRUMENT_TUNING,
   MAX_FRET,
@@ -126,7 +127,7 @@ describe('parseChordKey', () => {
 // ── chord tone sets ───────────────────────────────────────────────────────────
 
 describe('getAllowedPitches / getRequiredPitches', () => {
-  it('for every shipped key: required ⊆ allowed, root and slash bass always required, only 7th chords may drop only the 5th', () => {
+  it('for every shipped key: required ⊆ allowed, root and slash bass always required, omissions follow OPTIONAL_INTERVALS', () => {
     fc.assert(
       fc.property(knownKeyArb, (key) => {
         const parsed = parseChordKey(key)!
@@ -141,13 +142,20 @@ describe('getAllowedPitches / getRequiredPitches', () => {
         }
 
         const optional = [...allowed].filter((p) => !required.has(p))
-        if (CHORD_INTERVALS[parsed.quality].length === 4) {
-          expect(optional).toEqual([(parsed.rootPitch + 7) % 12])
-        } else {
-          expect(optional).toEqual([])
-        }
+        const expectedOptional = (OPTIONAL_INTERVALS[parsed.quality] ?? [])
+          .map((interval) => (parsed.rootPitch + interval) % 12)
+          .filter((p) => !required.has(p)) // a slash bass can re-require an optional tone
+        expect(new Set(optional)).toEqual(new Set(expectedOptional))
       }),
     )
+  })
+
+  it('every optional interval is one of the quality\'s chord tones', () => {
+    for (const [quality, optional] of Object.entries(OPTIONAL_INTERVALS)) {
+      for (const interval of optional) {
+        expect(CHORD_INTERVALS[quality], quality).toContain(interval)
+      }
+    }
   })
 
   it('slash bass outside the chord joins both sets (C/B)', () => {
@@ -160,10 +168,10 @@ describe('getAllowedPitches / getRequiredPitches', () => {
 // ── expectedChordKeys ─────────────────────────────────────────────────────────
 
 describe('expectedChordKeys', () => {
-  it('returns 120 plain + 84 slash keys, unique, all parseable', () => {
+  it('returns 324 plain + 84 slash keys, unique, all parseable', () => {
     const keys = expectedChordKeys()
-    expect(keys).toHaveLength(204)
-    expect(new Set(keys).size).toBe(204)
+    expect(keys).toHaveLength(12 * CHORD_QUALITIES.length + 84)
+    expect(new Set(keys).size).toBe(keys.length)
     for (const key of keys) expect(parseChordKey(key), key).not.toBeNull()
   })
 

--- a/libs/platform-api/src/lib/chord-theory.ts
+++ b/libs/platform-api/src/lib/chord-theory.ts
@@ -25,11 +25,52 @@ export const CHORD_INTERVALS: Record<string, readonly number[]> = {
   dim: [0, 3, 6],          // diminished triad
   aug: [0, 4, 8],          // augmented triad
   '5': [0, 7],             // power chord
+  m7b5: [0, 3, 6, 10],     // half-diminished 7
+  dim7: [0, 3, 6, 9],      // diminished 7
+  '6': [0, 4, 7, 9],       // major 6
+  m6: [0, 3, 7, 9],        // minor 6
+  '69': [0, 4, 7, 9, 2],   // major 6 add 9 (written 6/9 in tabs)
+  add9: [0, 4, 7, 2],      // major add 9
+  '9': [0, 4, 7, 10, 2],   // dominant 9
+  m9: [0, 3, 7, 10, 2],    // minor 9
+  maj9: [0, 4, 7, 11, 2],  // major 9
+  '7b5': [0, 4, 6, 10],    // dominant 7 flat 5
+  '7#5': [0, 4, 8, 10],    // dominant 7 sharp 5
+  '7b9': [0, 4, 7, 10, 1], // dominant 7 flat 9
+  '7#9': [0, 4, 7, 10, 3], // dominant 7 sharp 9
+  '11': [0, 4, 7, 10, 2, 5],     // dominant 11
+  m11: [0, 3, 7, 10, 2, 5],      // minor 11
+  '13': [0, 4, 7, 10, 2, 5, 9],  // dominant 13
+  m13: [0, 3, 7, 10, 2, 5, 9],   // minor 13
+}
+
+/** Intervals a voicing may omit per quality, following common practice:
+ *  7th/9th chords drop the 5th; 11ths drop the 3rd (it clashes with the 11)
+ *  and the inner extensions; 13ths drop the 5th, 9th and 11th. Qualities not
+ *  listed require every chord tone. */
+export const OPTIONAL_INTERVALS: Record<string, readonly number[]> = {
+  '7': [7],
+  m7: [7],
+  maj7: [7],
+  '69': [7],
+  '9': [7],
+  m9: [7],
+  maj9: [7],
+  '7b9': [7],
+  '7#9': [7],
+  '11': [4, 7, 2],
+  m11: [7, 2],
+  '13': [7, 2, 5],
+  m13: [7, 2, 5],
 }
 
 /** Qualities in the order the chord JSON files enumerate them.
  *  (Object.keys(CHORD_INTERVALS) won't do: JS hoists integer-like keys like '5'.) */
-export const CHORD_QUALITIES = ['', 'm', '7', 'm7', 'maj7', 'sus2', 'sus4', 'dim', 'aug', '5'] as const
+export const CHORD_QUALITIES = [
+  '', 'm', '7', 'm7', 'maj7', 'sus2', 'sus4', 'dim', 'aug', '5',
+  'm7b5', 'dim7', '6', 'm6', '69', 'add9', '9', 'm9', 'maj9',
+  '7b5', '7#5', '7b9', '7#9', '11', 'm11', '13', 'm13',
+] as const
 
 /** Roots in the order the chord JSON files enumerate them.
  *  This is a file-ordering constant, not a pitch table — pitch arithmetic
@@ -89,14 +130,14 @@ export function getAllowedPitches(parsed: ParsedChord): Set<number> {
   return allowed
 }
 
-/** Pitch classes a variant must contain to be a complete chord.
- *  All chord tones are required; only 4-note qualities (7, m7, maj7) may omit the 5th. */
+/** Pitch classes a variant must contain to be a complete chord:
+ *  every chord tone except those `OPTIONAL_INTERVALS` allows the quality to
+ *  omit, plus the slash bass when there is one. */
 export function getRequiredPitches(parsed: ParsedChord): Set<number> {
-  const intervals = CHORD_INTERVALS[parsed.quality]
-  const fifthOptional = intervals.length === 4
+  const optional = new Set(OPTIONAL_INTERVALS[parsed.quality] ?? [])
   const required = new Set<number>()
-  for (const interval of intervals) {
-    if (fifthOptional && interval === 7) continue
+  for (const interval of CHORD_INTERVALS[parsed.quality]) {
+    if (optional.has(interval)) continue
     required.add((parsed.rootPitch + interval) % 12)
   }
   if (parsed.bassPitch !== undefined) required.add(parsed.bassPitch)
@@ -137,11 +178,19 @@ export function getInvalidNotes(
   return errors
 }
 
+/** Qualities that cannot be voiced in a single fretted position on a
+ *  4-string bass: a 13th needs both the b7 and the 13 — adjacent pitch
+ *  classes, which on adjacent bass strings always sit a full hand span
+ *  apart. Their keys are omitted from the bass data. */
+export const BASS_UNVOICEABLE_QUALITIES: readonly string[] = ['13', 'm13']
+
 /** Every chord key the JSON data files must define, in file order:
- *  plain keys grouped by quality, then slash keys grouped by root. */
-export function expectedChordKeys(): string[] {
+ *  plain keys grouped by quality, then slash keys grouped by root.
+ *  Without an instrument, returns the full (guitar) superset. */
+export function expectedChordKeys(instrument?: Instrument): string[] {
   const keys: string[] = []
   for (const quality of CHORD_QUALITIES) {
+    if (instrument === 'bass' && BASS_UNVOICEABLE_QUALITIES.includes(quality)) continue
     for (const root of CHORD_ROOTS) keys.push(root + quality)
   }
   for (const root of CHORD_ROOTS) {

--- a/libs/platform-api/src/lib/chord-theory.ts
+++ b/libs/platform-api/src/lib/chord-theory.ts
@@ -31,7 +31,9 @@ export const CHORD_INTERVALS: Record<string, readonly number[]> = {
  *  (Object.keys(CHORD_INTERVALS) won't do: JS hoists integer-like keys like '5'.) */
 export const CHORD_QUALITIES = ['', 'm', '7', 'm7', 'maj7', 'sus2', 'sus4', 'dim', 'aug', '5'] as const
 
-/** Roots in the order the chord JSON files enumerate them. */
+/** Roots in the order the chord JSON files enumerate them.
+ *  This is a file-ordering constant, not a pitch table — pitch arithmetic
+ *  uses NOTE_PITCH / pitchName (C=0). */
 export const CHORD_ROOTS = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'] as const
 
 /** Alternate-bass intervals shipped as slash-chord keys, per quality.
@@ -50,7 +52,8 @@ export const MAX_FRET = 15
 
 const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const
 
-const NOTE_PITCH: Record<string, number> = {
+/** Pitch class (C=0) of each natural and sharp note name. */
+export const NOTE_PITCH: Record<string, number> = {
   A: 9, 'A#': 10, B: 11, C: 0, 'C#': 1, D: 2, 'D#': 3, E: 4, F: 5, 'F#': 6, G: 7, 'G#': 8,
 }
 

--- a/libs/platform-api/src/lib/chords.spec.ts
+++ b/libs/platform-api/src/lib/chords.spec.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check'
 import {
   isTablatureLine,
   testHeader,
@@ -6,6 +7,7 @@ import {
   transposeChord,
   testTokenContext,
 } from './chords.js'
+import { formatChordSymbol, parseChordSymbol } from './chord-symbol.js'
 
 describe('isTablatureLine', () => {
   it('returns true for a standard E string tablature line', () => {
@@ -188,6 +190,32 @@ describe('transposeChord', () => {
 
   it('transposes A down by 1 semitone to G#', () => {
     expect(transposeChord('A', -1)).toBe('G#')
+  })
+
+  it('returns non-chord input unchanged for any transpose amount', () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 10 }), fc.integer({ min: -24, max: 24 }), (s, n) => {
+        fc.pre(parseChordSymbol(s) === null)
+        expect(transposeChord(s, n)).toBe(s)
+      }),
+    )
+  })
+
+  it('composes additively on canonical chord strings', () => {
+    const canonicalChordArb = fc
+      .tuple(
+        fc.integer({ min: 0, max: 11 }),
+        fc.constantFrom('', 'm', '7', 'm7', 'maj7', 'sus4', 'dim', 'aug', '5', 'm7b5', '6/9'),
+        fc.option(fc.integer({ min: 0, max: 11 })),
+      )
+      .map(([rootPitch, suffix, bassPitch]) =>
+        formatChordSymbol(bassPitch === null ? { rootPitch, suffix } : { rootPitch, suffix, bassPitch }),
+      )
+    fc.assert(
+      fc.property(canonicalChordArb, fc.integer({ min: -24, max: 24 }), fc.integer({ min: -24, max: 24 }), (chord, a, b) => {
+        expect(transposeChord(transposeChord(chord, a), b)).toBe(transposeChord(chord, a + b))
+      }),
+    )
   })
 })
 

--- a/libs/platform-api/src/lib/chords.ts
+++ b/libs/platform-api/src/lib/chords.ts
@@ -1,5 +1,9 @@
-/** The 12-note chromatic scale starting at A. Index is used for semitone arithmetic. */
-export const notes = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#']
+import { isChordSymbol, parseChordSymbol, formatChordSymbol, transposeChordSymbol } from './chord-symbol.js'
+import { pitchName } from './chord-theory.js'
+
+/** The 12-note chromatic scale starting at A, in the sharps-only spelling
+ *  shared with chord-theory (A = pitch class 9). */
+export const notes = Array.from({ length: 12 }, (_, i) => pitchName(9 + i))
 
 /** Splits a token stream on whitespace, pipe, parentheses, and common punctuation. */
 export const delimiterMatcher = /(?<whitespace>\s+|\||\(|\)|-|,|\*|%)/
@@ -12,32 +16,6 @@ export const delimiterMatcher = /(?<whitespace>\s+|\||\(|\)|-|,|\*|%)/
 export const isTablatureLine = (line: string): boolean =>
   /^[A-G][#b]?\|/.test(line) || /^e\|/.test(line)
 
-// Note pattern - captures the basic note and any accidentals
-const notePattern = "(?<note>[A-G])(?<accidentals>(?:bb|b|♭♭|♭)|(?:##|#))?"
-
-// Chord quality pattern - captures chord types and modifications
-const chordQualityPattern = '(maj|[Mm]|min|sus|dim|add)?'
-const chordQualityRequired = '(?:maj|[Mm]|min|sus|dim|add)'
-const chordNumberPattern = '(?:[1-9]|1[0-9]|2[0-3])?'
-const chordNumberRequiredPattern = '(?:[1-9]|1[0-9]|2[0-3])'
-
-// Rejects any chord containing three or more consecutive accidentals (### / bbb / ♭♭♭)
-const noTriples = '^(?!.*(?:#{3}|b{3}|♭{3}))'
-
-// Combines the chord components into the chords group (quality + extension, repeated at most twice)
-const chordsPattern =
-  `(?<chords>` +
-  chordQualityPattern +      // 1st quality
-  chordNumberPattern +       // 1st number
-  `(?:${chordQualityRequired}${chordNumberRequiredPattern})?` +  // 2nd quality+number
-  `)?`
-
-// Bass note pattern - captures the optional bass note after the slash (e.g. C/G)
-const bassPattern = "(?:\\/(?<bass>(?<bassNote>[A-G])(?<bassAccidentals>(?:b|bb|♭|♭♭)|(?:#|##))?))?";
-
-// Combine all patterns into the final chord matcher
-const chordMatcher = `${notePattern}${chordsPattern}${bassPattern}`
-
 /**
  * Returns true if the string looks like a section header, e.g. `[Verse]` or `[Chorus 1]`.
  */
@@ -46,79 +24,33 @@ export const testHeader = (string: string) => /\[[a-zA-Z0-9\s]+/.test(string)
 /**
  * Returns true if `string` is a valid chord symbol.
  *
- * Valid chords: root note (A–G) + optional accidental (#, ##, b, bb, ♭, ♭♭) +
- * optional quality (maj, m, M, min, sus, dim, add) + optional extension (1–23) +
- * optional slash bass note (e.g. `/G`). Rejects strings with triple accidentals.
+ * Thin wrapper over `isChordSymbol` — see chord-symbol.ts for the grammar.
+ * Prefer `parseChordSymbol` in new code when the parsed structure is needed.
  *
- * Examples: `Am`, `C#maj7`, `Dm7/G`, `Eb`, `Bsus4`.
+ * Examples: `Am`, `C#maj7`, `Dm7/G`, `Eb`, `Bsus4`, `Am7b5`, `C6/9`.
  */
-export const testChords = (string: string) => {
-  const match = (new RegExp(noTriples + chordMatcher + '$')).exec(string)
-
-  if (match === null || match.length === 0)
-    return false
-  if (match[0] === string)
-    return true
-
-  return false
-}
+export const testChords = (string: string) => isChordSymbol(string)
 
 /** Returns true if `string` contains only whitespace (or is empty). */
 export const testSpaces = (string: string) => /^\s*$/.test(string)
 
-/** Maps an accidentals string to a signed semitone offset (flats = negative, sharps = positive). */
-const getNoteOffset = (string: string | undefined) => {
-  if (string === undefined) {
-    return 0
-  }
-  const regex = /^(?<flats>bb|b|♭♭|♭)|(?<sharps>##|#)$/
-  const accidentals = regex.exec(string)
-
-  if (accidentals === null) {
-    return 0
-  } else if (["b", "bb", "♭", "♭♭"].includes(accidentals[0])) {
-    return string.length * -1
-  }
-  return string.length
-}
-
-/** Wraps a note index into the 0–11 range regardless of sign or magnitude. */
-const normalizeNoteIndex = (noteNumber: number): number => ((noteNumber % notes.length) + notes.length) % notes.length
-
-/** Parses a chord string into its named regex groups. */
-const matchChords = (string: string) => (new RegExp(chordMatcher).exec(string))
-
 /**
  * Transposes a chord symbol by `transpose` semitones.
  *
- * - Positive `transpose` shifts up; negative shifts down.
- * - Accidentals in the input are resolved to a semitone index before transposing,
- *   so `Bb` transposed +2 correctly yields `C` (not `B#`).
- * - Bass notes (e.g. the `G` in `C/G`) are transposed independently by the same amount.
- * - Returns `chord` unchanged when `transpose === 0`.
+ * - Positive `transpose` shifts up; negative shifts down; wraps at 12.
+ * - Accidentals are resolved to a pitch class before transposing, so `Bb`
+ *   transposed +2 correctly yields `C` (not `B#`). Output uses sharp notation.
+ * - Bass notes (e.g. the `G` in `C/G`) are transposed by the same amount.
+ * - Returns `chord` unchanged when `transpose === 0` or when `chord` is not
+ *   a valid chord symbol.
  *
- * @param chord     A valid chord symbol (see `testChords`).
- * @param transpose Semitone offset. May be any integer; wraps at 12.
- * @returns The transposed chord string using sharp notation for all output notes.
+ * Prefer `transposeChordSymbol` in new code when working with parsed chords.
  */
 export const transposeChord = (chord: string, transpose: number): string => {
-  const currentNote = matchChords(chord)?.groups
-  const matchedChords = currentNote?.chords
-
-  if (transpose !== 0) {
-    const noteIndex = notes.findIndex(sequenceNote => sequenceNote === currentNote?.note)
-    const bassNoteIndex = notes.findIndex(sequenceNote => sequenceNote === currentNote?.bassNote)
-
-    const transposedNoteIndex = normalizeNoteIndex(noteIndex + getNoteOffset(currentNote?.accidentals ?? '') + transpose)
-    const transposedBassNoteIndex = currentNote?.bassNote !== undefined ? normalizeNoteIndex(bassNoteIndex + getNoteOffset(currentNote.bassAccidentals) + transpose) : null
-
-    const bassChord = transposedBassNoteIndex !== null
-      ? `/${notes[transposedBassNoteIndex]}`
-      : '';
-
-    return `${notes[transposedNoteIndex]}${matchedChords ?? ''}${bassChord}`
-  }
-  return chord
+  if (transpose === 0) return chord
+  const parsed = parseChordSymbol(chord)
+  if (parsed === null) return chord
+  return formatChordSymbol(transposeChordSymbol(parsed, transpose))
 }
 
 /**

--- a/libs/platform-api/src/lib/sheet-lines.spec.ts
+++ b/libs/platform-api/src/lib/sheet-lines.spec.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import { classifySheetLine, type SheetLine } from './sheet-lines.js'
+import {
+  delimiterMatcher,
+  isTablatureLine,
+  testChords,
+  testHeader,
+  testSpaces,
+  testTokenContext,
+  transposeChord,
+} from './chords.js'
+
+// ── Legacy classification oracle ──────────────────────────────────────────────
+//
+// The decision logic of the old Sheet.tsx lineMatcher, reproduced without JSX
+// (including the `.replace('|', '')` it applied during detection, kept here
+// verbatim to prove it was dead code). classifySheetLine must classify every
+// line identically.
+
+type LegacyDecision =
+  | { kind: 'blank' }
+  | { kind: 'chord-line'; chordFlags: boolean[]; stringIndicatorIndex: number | null }
+  | { kind: 'header' }
+  | { kind: 'plain' }
+
+const legacyLineMatcher = (line: string): LegacyDecision => {
+  if (!line.trim()) return { kind: 'blank' }
+
+  const tokens = line.split(delimiterMatcher).filter((token) => token !== '')
+  const sanitizedTokens = tokens.filter((token) => !testSpaces(token))
+
+  const isTablature = isTablatureLine(line)
+  const hasValidChords = tokens.some(
+    (token) => testChords(token.replace('|', '')) || token === 'e',
+  )
+  const isMixedContent = hasValidChords && testTokenContext(sanitizedTokens)
+
+  if (hasValidChords && !isMixedContent) {
+    return {
+      kind: 'chord-line',
+      chordFlags: tokens.map((token) => testChords(token) || token === 'e'),
+      stringIndicatorIndex:
+        isTablature && (testChords(tokens[0]) || tokens[0] === 'e') ? 0 : null,
+    }
+  }
+
+  if (testHeader(line)) return { kind: 'header' }
+  return { kind: 'plain' }
+}
+
+// ── Arbitraries ───────────────────────────────────────────────────────────────
+
+const chordArb = fc.constantFrom('Am', 'C', 'G', 'Em', 'Dm7/G', 'Bb', 'C#maj7', 'Asus4', 'Caug', 'Am7b5', 'e')
+const wordArb = fc.constantFrom('the', 'quick', 'hello', 'la', 'darling', 'oo', 'Hm')
+const fragmentArb = fc.oneof(
+  chordArb,
+  wordArb,
+  fc.constantFrom('E|--0--2--', 'e|-3-', 'A#|--5--', '[Verse]', '[Chorus 1]', '(', ')', '|', '-', '*', '  ', '\t'),
+)
+
+/** Lines assembled from tab-flavoured fragments. */
+const sheetLineArb = fc
+  .array(fragmentArb, { maxLength: 8 })
+  .map((parts) => parts.join(' '))
+
+const anyLineArb = fc.oneof(sheetLineArb, fc.string({ maxLength: 30 }))
+const transposeArb = fc.integer({ min: -12, max: 12 })
+
+const chordLineTokens = (classified: SheetLine) =>
+  classified.kind === 'chord-line' ? classified.tokens : []
+
+// ── Properties ────────────────────────────────────────────────────────────────
+
+describe('classifySheetLine', () => {
+  it('never throws and always returns a known kind', () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), fc.integer(), (line, transpose) => {
+        const classified = classifySheetLine(line, transpose)
+        expect(['blank', 'chord-line', 'header', 'plain']).toContain(classified.kind)
+      }),
+    )
+  })
+
+  it('classifies a line as blank exactly when it has no visible characters', () => {
+    fc.assert(
+      fc.property(anyLineArb, transposeArb, (line, transpose) => {
+        expect(classifySheetLine(line, transpose).kind === 'blank').toBe(line.trim() === '')
+      }),
+    )
+  })
+
+  it('reconstructs chord lines losslessly from token raws', () => {
+    fc.assert(
+      fc.property(anyLineArb, transposeArb, (line, transpose) => {
+        const classified = classifySheetLine(line, transpose)
+        fc.pre(classified.kind === 'chord-line')
+        expect(chordLineTokens(classified).map((t) => t.raw).join('')).toBe(line)
+      }),
+    )
+  })
+
+  it('matches the legacy lineMatcher decision on every line', () => {
+    fc.assert(
+      fc.property(anyLineArb, transposeArb, (line, transpose) => {
+        const classified = classifySheetLine(line, transpose)
+        const legacy = legacyLineMatcher(line)
+        expect(classified.kind).toBe(legacy.kind)
+        if (classified.kind === 'chord-line' && legacy.kind === 'chord-line') {
+          const flags = classified.tokens.map((t) => t.kind !== 'text')
+          expect(flags).toEqual(legacy.chordFlags)
+          const indicator = classified.tokens.findIndex((t) => t.kind === 'string-indicator')
+          expect(indicator === -1 ? null : indicator).toBe(legacy.stringIndicatorIndex)
+        }
+      }),
+    )
+  })
+
+  it('places string indicators only at token 0 of tablature lines', () => {
+    fc.assert(
+      fc.property(anyLineArb, transposeArb, (line, transpose) => {
+        const tokens = chordLineTokens(classifySheetLine(line, transpose))
+        tokens.forEach((token, i) => {
+          if (token.kind === 'string-indicator') {
+            expect(i).toBe(0)
+            expect(isTablatureLine(line)).toBe(true)
+          }
+        })
+      }),
+    )
+  })
+
+  it('displays raw names at transpose 0, mapping a lone e to E', () => {
+    fc.assert(
+      fc.property(anyLineArb, (line) => {
+        for (const token of chordLineTokens(classifySheetLine(line, 0))) {
+          if (token.kind !== 'chord') continue
+          expect(token.display).toBe(token.raw === 'e' ? 'E' : token.raw)
+        }
+      }),
+    )
+  })
+
+  it('always produces chord displays that are themselves valid chords', () => {
+    fc.assert(
+      fc.property(anyLineArb, transposeArb, (line, transpose) => {
+        for (const token of chordLineTokens(classifySheetLine(line, transpose))) {
+          if (token.kind === 'chord') expect(testChords(token.display)).toBe(true)
+        }
+      }),
+    )
+  })
+
+  it('keeps token kinds independent of the transpose amount', () => {
+    fc.assert(
+      fc.property(anyLineArb, transposeArb, transposeArb, (line, a, b) => {
+        const kindsAt = (transpose: number) => {
+          const classified = classifySheetLine(line, transpose)
+          return classified.kind === 'chord-line'
+            ? classified.tokens.map((t) => t.kind)
+            : classified.kind
+        }
+        expect(kindsAt(a)).toEqual(kindsAt(b))
+      }),
+    )
+  })
+
+  it('transposes chord displays through transposeChord', () => {
+    fc.assert(
+      fc.property(anyLineArb, transposeArb, (line, transpose) => {
+        const tokens = chordLineTokens(classifySheetLine(line, transpose))
+        for (const token of tokens) {
+          if (token.kind !== 'chord') continue
+          expect(token.display).toBe(transposeChord(token.raw === 'e' ? 'E' : token.raw, transpose))
+        }
+      }),
+    )
+  })
+})
+
+// ── Examples pinning the renderer-facing contract ─────────────────────────────
+
+describe('classifySheetLine examples', () => {
+  it('classifies a pure chord line with transposed displays', () => {
+    expect(classifySheetLine('Am  C', 2)).toEqual({
+      kind: 'chord-line',
+      tokens: [
+        { kind: 'chord', raw: 'Am', display: 'Bm' },
+        { kind: 'text', raw: '  ' },
+        { kind: 'chord', raw: 'C', display: 'D' },
+      ],
+    })
+  })
+
+  it('keeps the tablature string label untransposed as a string indicator', () => {
+    const classified = classifySheetLine('e|--0--2--', 3)
+    expect(classified.kind).toBe('chord-line')
+    expect(chordLineTokens(classified)[0]).toEqual({ kind: 'string-indicator', raw: 'e' })
+  })
+
+  it('treats lyric lines with minority chords as plain text', () => {
+    expect(classifySheetLine('the Am quick C brown', 2)).toEqual({
+      kind: 'plain',
+      text: 'the Am quick C brown',
+    })
+  })
+
+  it('classifies headers after ruling out chord lines', () => {
+    expect(classifySheetLine('[Verse]', 0)).toEqual({ kind: 'header', text: '[Verse]' })
+    expect(classifySheetLine('[Chorus] Am G', 0).kind).toBe('chord-line')
+  })
+})

--- a/libs/platform-api/src/lib/sheet-lines.spec.ts
+++ b/libs/platform-api/src/lib/sheet-lines.spec.ts
@@ -51,8 +51,11 @@ const legacyLineMatcher = (line: string): LegacyDecision => {
 
 // ── Arbitraries ───────────────────────────────────────────────────────────────
 
-const chordArb = fc.constantFrom('Am', 'C', 'G', 'Em', 'Dm7/G', 'Bb', 'C#maj7', 'Asus4', 'Caug', 'Am7b5', 'e')
-const wordArb = fc.constantFrom('the', 'quick', 'hello', 'la', 'darling', 'oo', 'Hm')
+const chordArb = fc.constantFrom(
+  'Am', 'C', 'G', 'Em', 'Dm7/G', 'Bb', 'C#maj7', 'Asus4', 'Caug', 'Am7b5', 'e',
+  'C-', 'C-7', 'A-7/G', 'C+', 'C°7', 'Cø', 'C6/9',
+)
+const wordArb = fc.constantFrom('the', 'quick', 'hello', 'la', 'darling', 'oo', 'Hm', 'A-flat', 're-do')
 const fragmentArb = fc.oneof(
   chordArb,
   wordArb,
@@ -100,9 +103,24 @@ describe('classifySheetLine', () => {
     )
   })
 
-  it('matches the legacy lineMatcher decision on every line', () => {
+  it('matches the legacy lineMatcher decision on every line without a dash-merged chord', () => {
+    // A dash merge can occur where a token is followed by a single `-` and the
+    // pieces join into a chord — the one approved tokenization change.
+    const dashMergePossible = (line: string): boolean => {
+      if (isTablatureLine(line)) return false
+      const tokens = line.split(delimiterMatcher).filter((token) => token !== '')
+      return tokens.some(
+        (token, i) =>
+          tokens[i + 1] === '-' &&
+          tokens[i + 2] !== '-' &&
+          (testChords(`${token}-`) ||
+            (tokens[i + 2] !== undefined && testChords(`${token}-${tokens[i + 2]}`))),
+      )
+    }
+
     fc.assert(
       fc.property(anyLineArb, transposeArb, (line, transpose) => {
+        fc.pre(!dashMergePossible(line))
         const classified = classifySheetLine(line, transpose)
         const legacy = legacyLineMatcher(line)
         expect(classified.kind).toBe(legacy.kind)
@@ -208,5 +226,47 @@ describe('classifySheetLine examples', () => {
   it('classifies headers after ruling out chord lines', () => {
     expect(classifySheetLine('[Verse]', 0)).toEqual({ kind: 'header', text: '[Verse]' })
     expect(classifySheetLine('[Chorus] Am G', 0).kind).toBe('chord-line')
+  })
+
+  it('re-joins dash-spelled minor chords that the delimiter split apart', () => {
+    expect(classifySheetLine('C- G-', 0)).toEqual({
+      kind: 'chord-line',
+      tokens: [
+        { kind: 'chord', raw: 'C-', display: 'C-' },
+        { kind: 'text', raw: ' ' },
+        { kind: 'chord', raw: 'G-', display: 'G-' },
+      ],
+    })
+    expect(classifySheetLine('C-7  F-7', 2)).toEqual({
+      kind: 'chord-line',
+      tokens: [
+        { kind: 'chord', raw: 'C-7', display: 'D-7' },
+        { kind: 'text', raw: '  ' },
+        { kind: 'chord', raw: 'F-7', display: 'G-7' },
+      ],
+    })
+  })
+
+  it('never merges tablature dashes or lyric hyphens', () => {
+    const tab = classifySheetLine('E|--0--2--', 0)
+    expect(tab.kind).toBe('chord-line')
+    expect(chordLineTokens(tab).filter((t) => t.kind === 'chord')).toEqual([])
+    expect(classifySheetLine('the A-flat major scale', 0)).toEqual({
+      kind: 'plain',
+      text: 'the A-flat major scale',
+    })
+  })
+
+  it('classifies jazz symbol chords without dashes directly', () => {
+    expect(classifySheetLine('C+ Cø B°7', 0)).toEqual({
+      kind: 'chord-line',
+      tokens: [
+        { kind: 'chord', raw: 'C+', display: 'C+' },
+        { kind: 'text', raw: ' ' },
+        { kind: 'chord', raw: 'Cø', display: 'Cø' },
+        { kind: 'text', raw: ' ' },
+        { kind: 'chord', raw: 'B°7', display: 'B°7' },
+      ],
+    })
   })
 })

--- a/libs/platform-api/src/lib/sheet-lines.ts
+++ b/libs/platform-api/src/lib/sheet-lines.ts
@@ -1,0 +1,73 @@
+import {
+  delimiterMatcher,
+  isTablatureLine,
+  testChords,
+  testHeader,
+  testSpaces,
+  testTokenContext,
+  transposeChord,
+} from './chords.js'
+
+/**
+ * Pure classification of tab-sheet lines, extracted from the Sheet renderer
+ * so the decision logic is testable without React. The renderer maps the
+ * returned structure to markup one-to-one.
+ */
+
+export type SheetToken =
+  /** A chord to highlight; `display` is the transposed, sharps-spelled name. */
+  | { kind: 'chord'; raw: string; display: string }
+  /** The leading note label of a tablature line — styled like a chord but
+   *  never transposed and never given a diagram tooltip. */
+  | { kind: 'string-indicator'; raw: string }
+  /** Anything else, including whitespace and delimiters, verbatim. */
+  | { kind: 'text'; raw: string }
+
+export type SheetLine =
+  | { kind: 'blank' }
+  | { kind: 'chord-line'; tokens: SheetToken[] }
+  | { kind: 'header'; text: string }
+  | { kind: 'plain'; text: string }
+
+/**
+ * Classifies one line of tab text.
+ *
+ * - Blank lines are `blank`.
+ * - Lines whose tokens contain chords — unless chords are a minority among
+ *   words (a lyric line with chord annotations, kept as `plain`) — are
+ *   `chord-line`s; their chord tokens carry the transposed display name.
+ *   Tablature lines fall in here too: their leading note label becomes a
+ *   `string-indicator` token. A lone `e` token counts as the high-E chord.
+ * - Remaining lines are `header` (e.g. `[Verse]`) or `plain`.
+ *
+ * For chord-lines, concatenating `tokens[].raw` reproduces `line` exactly.
+ */
+export const classifySheetLine = (line: string, transpose: number): SheetLine => {
+  if (!line.trim()) return { kind: 'blank' }
+
+  const tokens = line.split(delimiterMatcher).filter((token) => token !== '')
+  const sanitizedTokens = tokens.filter((token) => !testSpaces(token))
+
+  const hasValidChords = tokens.some((token) => testChords(token) || token === 'e')
+  const isMixedContent = hasValidChords && testTokenContext(sanitizedTokens)
+
+  if (hasValidChords && !isMixedContent) {
+    const isTablature = isTablatureLine(line)
+    return {
+      kind: 'chord-line',
+      tokens: tokens.map((token, i): SheetToken => {
+        if (!testChords(token) && token !== 'e') return { kind: 'text', raw: token }
+        if (isTablature && i === 0) return { kind: 'string-indicator', raw: token }
+        return {
+          kind: 'chord',
+          raw: token,
+          display: transposeChord(token === 'e' ? 'E' : token, transpose),
+        }
+      }),
+    }
+  }
+
+  if (testHeader(line)) return { kind: 'header', text: line }
+
+  return { kind: 'plain', text: line }
+}

--- a/libs/platform-api/src/lib/sheet-lines.ts
+++ b/libs/platform-api/src/lib/sheet-lines.ts
@@ -30,6 +30,39 @@ export type SheetLine =
   | { kind: 'plain'; text: string }
 
 /**
+ * Re-joins minor-dash chords that the delimiter split tore apart: `-` is a
+ * delimiter (tablature dashes), so `C-7` tokenizes as `C`,`-`,`7`. A note
+ * token followed by a single `-` is merged back when the result is a chord —
+ * together with the next token when the three parse as one chord (`C-7`),
+ * or alone when the dash ends the chord and whitespace or the line end
+ * follows (so lyric hyphens like `A-flat` never merge). Dash runs (`--`)
+ * never merge. Callers must skip this pass on tablature lines.
+ */
+const mergeDashChords = (tokens: string[]): string[] => {
+  const merged: string[] = []
+  let i = 0
+  while (i < tokens.length) {
+    const token = tokens[i]
+    const next = tokens[i + 2]
+    if (tokens[i + 1] === '-' && next !== '-') {
+      if (next !== undefined && testChords(token + '-' + next)) {
+        merged.push(token + '-' + next)
+        i += 3
+        continue
+      }
+      if ((next === undefined || testSpaces(next)) && testChords(token + '-')) {
+        merged.push(token + '-')
+        i += 2
+        continue
+      }
+    }
+    merged.push(token)
+    i++
+  }
+  return merged
+}
+
+/**
  * Classifies one line of tab text.
  *
  * - Blank lines are `blank`.
@@ -45,7 +78,8 @@ export type SheetLine =
 export const classifySheetLine = (line: string, transpose: number): SheetLine => {
   if (!line.trim()) return { kind: 'blank' }
 
-  const tokens = line.split(delimiterMatcher).filter((token) => token !== '')
+  const splitTokens = line.split(delimiterMatcher).filter((token) => token !== '')
+  const tokens = isTablatureLine(line) ? splitTokens : mergeDashChords(splitTokens)
   const sanitizedTokens = tokens.filter((token) => !testSpaces(token))
 
   const hasValidChords = tokens.some((token) => testChords(token) || token === 'e')

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -1,81 +1,71 @@
 import React, { useEffect, useRef } from 'react'
 import styles from './sheet.module.css'
 import {
-  delimiterMatcher,
-  isTablatureLine,
-  testChords,
-  testHeader,
-  testSpaces,
-  testTokenContext,
-  transposeChord,
+  classifySheetLine,
   type Instrument,
 } from '@klank/platform-api'
 import { ChordDiagramTooltip } from '../chordDiagramTooltip/ChordDiagramTooltip.js'
 
-const lineMatcher = (
+const renderLine = (
   line: string,
   index: number,
   transpose: number,
   isScrolling: boolean,
   instrument?: Instrument
 ): React.ReactNode => {
-  if (!line.trim()) {
-    return <div key={index} className={styles.blankLine}>&nbsp;</div>
-  }
+  const classified = classifySheetLine(line, transpose)
 
-  const tokens = line.split(delimiterMatcher).filter((token) => token !== '')
-  const sanitizedTokens = tokens.filter((token) => !testSpaces(token))
+  switch (classified.kind) {
+    case 'blank':
+      return <div key={index} className={styles.blankLine}>&nbsp;</div>
 
-  const isTablature = isTablatureLine(line)
+    case 'header':
+      return <div key={index} className={styles.header}>{classified.text}</div>
 
-  const hasValidChords = tokens.some(
-    (token) => testChords(token.replace('|', '')) || token === 'e'
-  )
-  const isMixedContent = hasValidChords && testTokenContext(sanitizedTokens)
+    case 'plain':
+      return <div key={index}>{classified.text}</div>
 
-  if (hasValidChords && !isMixedContent) {
-    const processedChords = line
-      .split(delimiterMatcher)
-      .map((currentValue, i) => {
-        if (testChords(currentValue) || currentValue === 'e') {
-          const chordToTranspose = currentValue === 'e' ? 'E' : currentValue
-          const isStringIndicator = isTablature && i === 0
-          const displayChord = isStringIndicator
-            ? currentValue
-            : transposeChord(chordToTranspose, transpose)
-          const span = (
-            <span className={styles.chord} key={`${index}-${i}`}>
-              {displayChord}
-            </span>
-          )
-          if (instrument && !isStringIndicator) {
-            return (
-              <ChordDiagramTooltip
-                key={`${index}-${i}`}
-                chordName={displayChord}
-                instrument={instrument}
-                isScrolling={isScrolling}
-              >
-                {span}
-              </ChordDiagramTooltip>
+    case 'chord-line':
+      return (
+        <div key={index} className={styles.chordLine}>
+          {classified.tokens.map((token, i) => {
+            if (token.kind === 'text') {
+              return (
+                <React.Fragment key={`${index}-${i}`}>
+                  {token.raw}
+                </React.Fragment>
+              )
+            }
+            if (token.kind === 'string-indicator') {
+              return (
+                <span className={styles.chord} key={`${index}-${i}`}>
+                  {token.raw}
+                </span>
+              )
+            }
+            // token.kind === 'chord'
+            const span = (
+              <span className={styles.chord} key={`${index}-${i}`}>
+                {token.display}
+              </span>
             )
-          }
-          return span
-        }
-        return (
-          <React.Fragment key={`${index}-${i}`}>
-            {currentValue}
-          </React.Fragment>
-        )
-      })
-    return <div key={index} className={styles.chordLine}>{processedChords}</div>
+            if (instrument) {
+              return (
+                <ChordDiagramTooltip
+                  key={`${index}-${i}`}
+                  chordName={token.display}
+                  instrument={instrument}
+                  isScrolling={isScrolling}
+                >
+                  {span}
+                </ChordDiagramTooltip>
+              )
+            }
+            return span
+          })}
+        </div>
+      )
   }
-
-  if (testHeader(line)) {
-    return <div key={index} className={styles.header}>{line}</div>
-  }
-
-  return <div key={index}>{line}</div>
 }
 
 type SheetProps = {
@@ -207,7 +197,7 @@ export const Sheet: React.FC<SheetProps> = ({
   return (
     <pre ref={containerRef} className={styles.container} {...props}>
       <div ref={contentRef} className={styles.content}>
-        {lines.map((line, index) => lineMatcher(line, index, transpose, isScrolling, instrument))}
+        {lines.map((line, index) => renderLine(line, index, transpose, isScrolling, instrument))}
         <div ref={sentinelRef}>&nbsp;</div>
       </div>
     </pre>

--- a/tools/chord-data/generate-chord-data.ts
+++ b/tools/chord-data/generate-chord-data.ts
@@ -31,7 +31,7 @@ const VARIANT_COUNT: Record<Instrument, { plain: number; slash: number }> = {
 
 function buildMap(instrument: Instrument): ChordDiagramMap {
   const map: ChordDiagramMap = {}
-  for (const key of expectedChordKeys()) {
+  for (const key of expectedChordKeys(instrument)) {
     const counts = VARIANT_COUNT[instrument]
     const count = key.includes('/') ? counts.slash : counts.plain
 

--- a/tools/chord-data/project.json
+++ b/tools/chord-data/project.json
@@ -1,0 +1,4 @@
+{
+  "name": "@klank/chord-data-tool",
+  "root": "tools/chord-data"
+}


### PR DESCRIPTION
## Problem

Chord handling had grown into three parallel subsystems that disagreed with each other:

- **`chords.ts`** (tab-sheet detection/transposition) had its own A-start chromatic table and a regex grammar that accepted non-chords like `Cmaj23` while rejecting real ones like `Caug`, `Am7b5`, and `C6/9` — even though the chord-diagram engine and the shipped JSON fully support `aug`.
- **`chord-theory.ts`** (diagram generator engine) had its own C-start pitch model and strict parser.
- **`chord-diagrams.ts`** had a third, independent flat→sharp map.

Line classification (~65 lines) was also interleaved with JSX inside `Sheet.tsx`, untestable without rendering.

## Commit 1 — Unification

**New `chord-symbol.ts`** — the single place chord symbols are interpreted. `ParsedChordSymbol` resolves root/bass to the theory engine's pitch classes (C=0) and validates the quality suffix against a grammar while storing it verbatim. `toTheoryChord()` bridges into the strict `parseChordKey` model.

- `testChords` / `transposeChord` are thin wrappers; the regex apparatus and A-start `notes` arithmetic are gone.
- `normalizeChordKey` reuses the shared note parser — `Cb`→`B`, `B#`→`C`, doubles now resolve.
- **New `sheet-lines.ts`**: pure `classifySheetLine(line, transpose)`; `Sheet.tsx` is rendering-only with identical markup, keys, and classNames.
- Improved grammar (per discussion): accepts `Caug`, `Am7b5`, `E7#9`, `C6/9`, `Fadd11`; rejects `Cmaj23`, `C8`, `C97`, `C7m7`. `transposeChord` on non-chord input now returns it unchanged (previously garbage, unreachable in production).

## Commit 2 — Jazz spellings + diagram data for everything detectable

**Symbol spellings**: `C-` = C minor (lead-sheet convention; `C-7` = Cm7), `C+` = augmented, `C°` = diminished, `Cø`/`Cø7` = half-diminished. Since `-` is a tokenizer delimiter (tablature dashes), a chord-aware merge pass re-joins `C-7`-style tokens on non-tablature lines — lyric hyphens (`A-flat`) and fret dashes never merge. Displays stay verbatim (`C-7` +2 renders `D-7`).

**`canonicalSuffix()`** folds equivalent spellings (`-7`→`m7`, `min7`→`m7`, `M7`→`maj7`, `ø`→`m7b5`, `°7`→`dim7`, `6/9`→`69`) onto canonical qualities; `normalizeChordKey` and `toTheoryChord` use it, so `D-7`, `Dmin7`, and `DM7` all resolve to the `Dm7` diagram (the latter two previously showed empty tooltips).

**Diagram generation expanded by 17 qualities**: m7b5, dim7, 6, m6, 69, add9, 9, m9, maj9, 7b5, 7#5, 7b9, 7#9, 11, m11, 13, m13.
- The 4-note-chord fifth-omission heuristic became an explicit `OPTIONAL_INTERVALS` policy (11ths drop the clashing 3rd and inner extensions; 13ths drop 5th/9th/11th). It reproduces the old behavior exactly for the original qualities — **all 204 original keys regenerate byte-identically** (verified key-by-key).
- 13ths are omitted from the **bass** data on musical-physics grounds: the b7 and the 13 are adjacent pitch classes, which on adjacent bass strings always sit a full hand span apart — no single-position fretted voicing exists. `expectedChordKeys(instrument)` encodes this.
- Guitar: 408 keys / 1140 variants. Bass: 384 keys / 594 variants. Every variant passes the 21-rule validator.

## Property-based tests (fast-check)

- **Bounded-divergence oracle**: the legacy detection regex is frozen in the spec; differences outside the approved classes fail.
- **Legacy `lineMatcher` oracle**: classification must match the old Sheet.tsx decision on every line without a dash-merged chord.
- Parse/format round trips; transpose group laws; `canonicalSuffix` idempotence + identity on all canonical qualities; normalization idempotence.
- **Unification contract**: over every key from `expectedChordKeys()`, the permissive parser agrees with `parseChordKey`, formatting is a fixpoint, and `normalizeChordKey` is the identity.

## Verification

- All projects: tests (207 platform-api + UI), typecheck, lint, production build green.
- Old-key regeneration equality verified per key; generator's strict validator gates every shipped variant.

https://claude.ai/code/session_013xhJKqzbM2PSqVBKQRE2kM