### PR TITLE
Persist playlists to .klank-settings.json instead of localStorage

### DIFF
--- a/apps/klank/app/app.tsx
+++ b/apps/klank/app/app.tsx
@@ -26,6 +26,7 @@ export function App() {
   const fileService = useKlankStore().fileService
   const setFileService = useKlankStore().setFileService
   const setTabSettings = useKlankStore().setTabSettings
+  const setPlaylists = useKlankStore().setPlaylists
   const [tree, setTree] = useState<FileEntry[]>()
   const [needsUpdate, setNeedsUpdate] = useState(false)
   const containerRef = useRef<HTMLElement>(null)
@@ -49,9 +50,12 @@ export function App() {
           return // re-triggers effect once baseDirectory is in state
         }
 
-        // Load per-tab settings from the tab directory, then load the tree
+        // Load per-tab settings and playlists from the tab directory, then load the tree
         const savedSettings = await fileService.readTabSettings(dir)
         setTabSettings(savedSettings)
+
+        const savedPlaylists = await fileService.readPlaylists(dir)
+        setPlaylists(savedPlaylists)
 
         const data = await fileService.readDirectoryRecursively(
           dir,
@@ -65,7 +69,7 @@ export function App() {
     }
 
     initializeApp()
-  }, [baseDirectory, serverMode, setBaseDirectory, setFileService, setTabSettings])
+  }, [baseDirectory, serverMode, setBaseDirectory, setFileService, setTabSettings, setPlaylists])
 
   useEffect(() => {
     const container = containerRef.current

--- a/libs/platform-api/src/lib/fs.spec.ts
+++ b/libs/platform-api/src/lib/fs.spec.ts
@@ -31,6 +31,7 @@ import { createFileService } from './fs.js'
 const readTextFile = pluginFs.readTextFile as Mock
 const writeTextFile = pluginFs.writeTextFile as Mock
 const remove = pluginFs.remove as Mock
+const exists = pluginFs.exists as Mock
 
 // ── Helper to create a fresh FileService for every test ──────────────────────
 const getService = () => createFileService()
@@ -191,5 +192,238 @@ describe('deleteTabSetting', () => {
     const [, writtenContent] = (writeTextFile as Mock).mock.calls[0] as [string, string]
     const writtenKeys = Object.keys(JSON.parse(writtenContent) as Record<string, unknown>)
     expect(writtenKeys).toEqual([...writtenKeys].sort())
+  })
+})
+
+// ── Playlists in .klank-settings.json ─────────────────────────────────────────
+
+const makeStoredPlaylist = (overrides: Record<string, unknown> = {}) => ({
+  id: 'playlist-1',
+  name: 'Practice',
+  paths: [] as string[],
+  createdAt: 1718000000000,
+  ...overrides,
+})
+
+describe('readPlaylists', () => {
+  const baseDirectory = '/tabs'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an empty array when the settings file does not exist', async () => {
+    // Given: .klank-settings.json is missing
+    // When: readPlaylists is called
+    // Then: an empty array is returned without throwing
+    readTextFile.mockRejectedValue(new Error('No such file'))
+
+    const service = await getService()
+    await expect(service.readPlaylists(baseDirectory)).resolves.toEqual([])
+  })
+
+  it('returns an empty array when the file has no playlists key', async () => {
+    // Given: the file only contains per-tab entries
+    // When: readPlaylists is called
+    // Then: an empty array is returned
+    readTextFile.mockResolvedValue(JSON.stringify({
+      'Artist - Song.tab.txt': { fontSize: 14, transpose: 2, scrollSpeed: 3 },
+    }))
+
+    const service = await getService()
+    await expect(service.readPlaylists(baseDirectory)).resolves.toEqual([])
+  })
+
+  it('converts stored relative paths to absolute paths', async () => {
+    // Given: a stored playlist with forward-slash relative paths
+    // When: readPlaylists is called
+    // Then: paths are returned as absolute paths under baseDirectory
+    const stored = makeStoredPlaylist({
+      paths: ['Artist - Song.tab.txt', 'Sub/Other - Tune.tab.txt'],
+    })
+    readTextFile.mockResolvedValue(JSON.stringify({
+      'Artist - Song.tab.txt': { fontSize: 14, transpose: 2, scrollSpeed: 3 },
+      playlists: [stored],
+    }))
+
+    const service = await getService()
+    const playlists = await service.readPlaylists(baseDirectory)
+
+    expect(playlists).toHaveLength(1)
+    expect(playlists[0]).toEqual({
+      ...stored,
+      paths: ['/tabs/Artist - Song.tab.txt', '/tabs/Sub/Other - Tune.tab.txt'],
+    })
+  })
+
+  it('returns Windows-separated absolute paths for a backslash base directory', async () => {
+    // Given: a Windows base directory and forward-slash relative keys in the file
+    // When: readPlaylists is called
+    // Then: paths use the base directory separator
+    const winBase = 'C:\\Users\\foo\\tabs'
+    readTextFile.mockResolvedValue(JSON.stringify({
+      playlists: [makeStoredPlaylist({ paths: ['Sub/Artist - Song.tab.txt'] })],
+    }))
+
+    const service = await getService()
+    const playlists = await service.readPlaylists(winBase)
+
+    expect(playlists[0].paths).toEqual(['C:\\Users\\foo\\tabs\\Sub\\Artist - Song.tab.txt'])
+  })
+})
+
+describe('writePlaylists', () => {
+  const baseDirectory = '/tabs'
+  const settingsPath = '/tabs/.klank-settings.json'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('stores playlists under the reserved key with relative paths, preserving tab entries', async () => {
+    // Given: the file already contains per-tab entries
+    // When: writePlaylists is called with absolute playlist paths
+    // Then: tab entries survive and playlist paths are stored relative
+    const existing = {
+      'Artist - Song.tab.txt': { fontSize: 14, transpose: 2, scrollSpeed: 3 },
+    }
+    readTextFile.mockResolvedValue(JSON.stringify(existing))
+    writeTextFile.mockResolvedValue(undefined)
+
+    const service = await getService()
+    await service.writePlaylists(
+      [{ id: 'p1', name: 'Practice', paths: ['/tabs/Artist - Song.tab.txt', '/tabs/Sub/Other - Tune.tab.txt'], createdAt: 1 }],
+      baseDirectory
+    )
+
+    expect(writeTextFile).toHaveBeenCalledTimes(1)
+    const [writtenPath, writtenContent] = writeTextFile.mock.calls[0] as [string, string]
+    expect(writtenPath).toBe(settingsPath)
+    const written = JSON.parse(writtenContent) as Record<string, unknown>
+    expect(written['Artist - Song.tab.txt']).toEqual(existing['Artist - Song.tab.txt'])
+    expect(written['playlists']).toEqual([
+      { id: 'p1', name: 'Practice', paths: ['Artist - Song.tab.txt', 'Sub/Other - Tune.tab.txt'], createdAt: 1 },
+    ])
+  })
+
+  it('creates the settings file when it does not exist yet', async () => {
+    // Given: .klank-settings.json is missing
+    // When: writePlaylists is called
+    // Then: a new file containing only the playlists key is written
+    readTextFile.mockRejectedValue(new Error('No such file'))
+    writeTextFile.mockResolvedValue(undefined)
+
+    const service = await getService()
+    await service.writePlaylists([{ id: 'p1', name: 'Practice', paths: [], createdAt: 1 }], baseDirectory)
+
+    const [, writtenContent] = writeTextFile.mock.calls[0] as [string, string]
+    expect(JSON.parse(writtenContent)).toEqual({
+      playlists: [{ id: 'p1', name: 'Practice', paths: [], createdAt: 1 }],
+    })
+  })
+
+  it('replaces previously stored playlists instead of merging', async () => {
+    // Given: the file already contains a different playlist
+    // When: writePlaylists is called with a new list
+    // Then: only the new list remains under the playlists key
+    readTextFile.mockResolvedValue(JSON.stringify({
+      playlists: [makeStoredPlaylist({ id: 'old', name: 'Old' })],
+    }))
+    writeTextFile.mockResolvedValue(undefined)
+
+    const service = await getService()
+    await service.writePlaylists([{ id: 'new', name: 'New', paths: [], createdAt: 2 }], baseDirectory)
+
+    const [, writtenContent] = writeTextFile.mock.calls[0] as [string, string]
+    const written = JSON.parse(writtenContent) as { playlists: Array<{ id: string }> }
+    expect(written.playlists).toHaveLength(1)
+    expect(written.playlists[0].id).toBe('new')
+  })
+
+  it('normalises Windows backslash playlist paths to relative forward-slash keys', async () => {
+    // Given: a Windows base directory and backslash absolute paths
+    // When: writePlaylists is called
+    // Then: stored paths are relative and forward-slash separated
+    readTextFile.mockRejectedValue(new Error('No such file'))
+    writeTextFile.mockResolvedValue(undefined)
+
+    const service = await getService()
+    await service.writePlaylists(
+      [{ id: 'p1', name: 'Practice', paths: ['C:\\Users\\foo\\tabs\\Sub\\Artist - Song.tab.txt'], createdAt: 1 }],
+      'C:\\Users\\foo\\tabs'
+    )
+
+    const [, writtenContent] = writeTextFile.mock.calls[0] as [string, string]
+    const written = JSON.parse(writtenContent) as { playlists: Array<{ paths: string[] }> }
+    expect(written.playlists[0].paths).toEqual(['Sub/Artist - Song.tab.txt'])
+  })
+})
+
+describe('readTabSettings with playlists present', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    exists.mockResolvedValue(false) // no legacy .klankrc.json
+  })
+
+  it('skips the reserved playlists key and returns only tab entries', async () => {
+    // Given: the file contains both tab entries and playlists
+    // When: readTabSettings is called
+    // Then: only tab entries are returned, keyed by absolute path
+    readTextFile.mockResolvedValue(JSON.stringify({
+      'Artist - Song.tab.txt': { fontSize: 14, transpose: 2, scrollSpeed: 3 },
+      playlists: [makeStoredPlaylist()],
+    }))
+
+    const service = await getService()
+    const settings = await service.readTabSettings('/tabs')
+
+    expect(settings).toEqual({
+      '/tabs/Artist - Song.tab.txt': { fontSize: 14, transpose: 2, scrollSpeed: 3 },
+    })
+  })
+})
+
+describe('tab-setting writes preserve playlists', () => {
+  const baseDirectory = '/tabs'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('writeTabSetting keeps an existing playlists entry intact', async () => {
+    // Given: the file contains a playlists entry
+    // When: a tab setting is written
+    // Then: the playlists entry survives unchanged
+    const stored = makeStoredPlaylist({ paths: ['Artist - Song.tab.txt'] })
+    readTextFile.mockResolvedValue(JSON.stringify({ playlists: [stored] }))
+    writeTextFile.mockResolvedValue(undefined)
+
+    const service = await getService()
+    await service.writeTabSetting('/tabs/Artist - Song.tab.txt', { fontSize: 14, transpose: 2, scrollSpeed: 3 }, baseDirectory)
+
+    const [, writtenContent] = writeTextFile.mock.calls[0] as [string, string]
+    const written = JSON.parse(writtenContent) as Record<string, unknown>
+    expect(written['playlists']).toEqual([stored])
+    expect(written['Artist - Song.tab.txt']).toEqual({ fontSize: 14, transpose: 2, scrollSpeed: 3 })
+  })
+
+  it('deleteTabSetting keeps an existing playlists entry intact', async () => {
+    // Given: the file contains a playlists entry and a tab entry
+    // When: the tab entry is deleted
+    // Then: the playlists entry survives unchanged
+    const stored = makeStoredPlaylist({ paths: ['Artist - Song.tab.txt'] })
+    readTextFile.mockResolvedValue(JSON.stringify({
+      'Artist - Song.tab.txt': { fontSize: 14, transpose: 2, scrollSpeed: 3 },
+      playlists: [stored],
+    }))
+    writeTextFile.mockResolvedValue(undefined)
+
+    const service = await getService()
+    await service.deleteTabSetting('/tabs/Artist - Song.tab.txt', baseDirectory)
+
+    const [, writtenContent] = writeTextFile.mock.calls[0] as [string, string]
+    const written = JSON.parse(writtenContent) as Record<string, unknown>
+    expect(written).not.toHaveProperty('Artist - Song.tab.txt')
+    expect(written['playlists']).toEqual([stored])
   })
 })

--- a/libs/platform-api/src/lib/fs.ts
+++ b/libs/platform-api/src/lib/fs.ts
@@ -35,12 +35,26 @@ export type FileEntry = {
 
 /**
  * The three user-adjustable settings saved per tab file.
- * Stored in `tab-settings.json` in the app's local data directory.
+ * Stored in `.klank-settings.json` in the active tab directory.
  */
 export type PerTabSettings = {
   fontSize: number
   transpose: number
   scrollSpeed: number
+}
+
+/**
+ * A named, ordered collection of tab files.
+ * Persisted under the reserved `"playlists"` key in `.klank-settings.json`;
+ * paths are stored relative to the base directory in the file, but the
+ * `FileService` API exposes them as absolute paths.
+ */
+export type Playlist = {
+  id: string
+  name: string
+  /** Ordered list of full file-system paths to .tab.txt files. */
+  paths: string[]
+  createdAt: number
 }
 
 /**
@@ -95,6 +109,20 @@ export type FileService = {
    * Silently succeeds when the file or the entry does not exist.
    */
   deleteTabSetting: (tabPath: string, baseDirectory: string) => Promise<void>
+  /**
+   * Reads the playlists stored under the reserved `"playlists"` key in
+   * `.klank-settings.json` in `baseDirectory`. Playlist paths are returned
+   * as absolute paths. Returns an empty array when the file or the key
+   * does not exist.
+   */
+  readPlaylists: (baseDirectory: string) => Promise<Playlist[]>
+  /**
+   * Persists all playlists under the reserved `"playlists"` key in
+   * `.klank-settings.json` in `baseDirectory`, leaving per-tab entries
+   * untouched. Playlist paths are stored relative to `baseDirectory`
+   * (forward-slash separated, portable).
+   */
+  writePlaylists: (playlists: Playlist[], baseDirectory: string) => Promise<void>
 }
 
 /**
@@ -131,6 +159,9 @@ export const mapTreeStructure = (
 
 const SETTINGS_FILE = '.klank-settings.json'
 const LEGACY_RC_FILE = '.klankrc.json'
+// Reserved top-level key in .klank-settings.json. Cannot collide with tab
+// entries because tab keys always end in `.tab.txt`.
+const PLAYLISTS_KEY = 'playlists'
 
 type LegacyKlankEntry = {
   fontSize: number
@@ -317,9 +348,12 @@ const createTauriFileService = async (): Promise<FileService> => {
 
         const content = await readTextFile(settingsPath)
         const raw = JSON.parse(content) as Record<string, PerTabSettings>
-        // Convert relative keys back to absolute paths
+        // Convert relative keys back to absolute paths, skipping the reserved
+        // playlists key (read via readPlaylists instead)
         return Object.fromEntries(
-          Object.entries(raw).map(([rel, val]) => [toAbsPath(rel, baseDirectory), val])
+          Object.entries(raw)
+            .filter(([rel]) => rel !== PLAYLISTS_KEY)
+            .map(([rel, val]) => [toAbsPath(rel, baseDirectory), val])
         )
       } catch {
         return {}
@@ -350,6 +384,46 @@ const createTauriFileService = async (): Promise<FileService> => {
 
     async deleteTabFile(path) {
       await remove(path)
+    },
+
+    async readPlaylists(baseDirectory) {
+      try {
+        const settingsPath = await join(baseDirectory, SETTINGS_FILE)
+        const content = await readTextFile(settingsPath)
+        const raw = JSON.parse(content) as Record<string, unknown>
+        const stored = raw[PLAYLISTS_KEY]
+        if (!Array.isArray(stored)) return []
+        return (stored as Playlist[]).map((playlist) => ({
+          ...playlist,
+          paths: playlist.paths.map((rel) => toAbsPath(rel, baseDirectory)),
+        }))
+      } catch {
+        return []
+      }
+    },
+
+    async writePlaylists(playlists, baseDirectory) {
+      try {
+        const settingsPath = await join(baseDirectory, SETTINGS_FILE)
+        // Read current file, replace the playlists key, sort keys, write back
+        let current: Record<string, unknown> = {}
+        try {
+          const content = await readTextFile(settingsPath)
+          current = JSON.parse(content) as Record<string, unknown>
+        } catch { /* file doesn't exist yet */ }
+
+        current[PLAYLISTS_KEY] = playlists.map((playlist) => ({
+          ...playlist,
+          paths: playlist.paths.map((abs) => toRelativeKey(abs, baseDirectory)),
+        }))
+
+        const sorted = Object.fromEntries(
+          Object.entries(current).sort(([a], [b]) => a.localeCompare(b))
+        )
+        await writeTextFile(settingsPath, JSON.stringify(sorted, null, 2))
+      } catch (error) {
+        console.error('Failed to write playlists:', error)
+      }
     },
 
     async deleteTabSetting(tabPath, baseDirectory) {

--- a/libs/store/src/lib/store-persistence.spec.ts
+++ b/libs/store/src/lib/store-persistence.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// This spec deliberately has NO static import of store.js: Vitest hoists
+// static imports above vi.stubGlobal, so the persist middleware would capture
+// an undefined localStorage at store creation and silently disable writes.
+// The dynamic import inside the tests runs after the stub is in place, so
+// hydration and writes go through the stubbed storage for real.
+
+const localStorageData: Record<string, string> = {}
+const localStorageStub = {
+  getItem: vi.fn((key: string) => localStorageData[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { localStorageData[key] = value }),
+  removeItem: vi.fn((key: string) => { delete localStorageData[key] }),
+  clear: vi.fn(() => { Object.keys(localStorageData).forEach((k) => delete localStorageData[k]) }),
+  length: 0,
+  key: vi.fn(() => null),
+}
+vi.stubGlobal('localStorage', localStorageStub)
+// zustand v5's default persist storage is `createJSONStorage(() => window.localStorage)`,
+// so a bare localStorage stub is not enough in the node test environment.
+vi.stubGlobal('window', { localStorage: localStorageStub })
+
+// Seed a v0 klank-storage entry (the old format that still carried playlists)
+// BEFORE the store module is first imported, so rehydration runs migrate.
+localStorageData['klank-storage'] = JSON.stringify({
+  version: 0,
+  state: {
+    theme: 'Dark',
+    playlists: [{ id: 'p1', name: 'Stale', paths: ['/tabs/A.tab.txt'], createdAt: 1 }],
+    activePlaylistId: 'p1',
+    activePlaylistIndex: 0,
+  },
+})
+
+describe('klank-storage migration and shape', () => {
+  it('migrate drops v0 playlists from localStorage but keeps the rest of the state', async () => {
+    const { useKlankStore } = await import('./store.js')
+
+    const state = useKlankStore.getState()
+    // Playlists now live in .klank-settings.json — stale localStorage copies are ignored
+    expect(state.playlists).toEqual([])
+    // Everything else survives the migration
+    expect(state.theme).toBe('Dark')
+    expect(state.activePlaylistId).toBe('p1')
+    expect(state.activePlaylistIndex).toBe(0)
+  })
+
+  it('no longer writes playlists to klank-storage, but keeps the active selection', async () => {
+    const { useKlankStore } = await import('./store.js')
+
+    useKlankStore.getState().createPlaylist('Practice')
+
+    const raw = localStorageData['klank-storage']
+    expect(raw).toBeDefined()
+    const parsed = JSON.parse(raw) as { version: number; state: Record<string, unknown> }
+    expect(parsed.version).toBe(1)
+    expect(parsed.state).not.toHaveProperty('playlists')
+    expect(parsed.state).toHaveProperty('activePlaylistId')
+    expect(parsed.state).toHaveProperty('activePlaylistIndex')
+  })
+})

--- a/libs/store/src/lib/store.spec.ts
+++ b/libs/store/src/lib/store.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import fc from 'fast-check'
 
 // Stub localStorage before store import — persist middleware reads it on init.
@@ -13,6 +13,7 @@ vi.stubGlobal('localStorage', {
   key: vi.fn(() => null),
 })
 
+import type { FileService } from '@klank/platform-api'
 import { useKlankStore, type Playlist } from './store.js'
 
 const makePlaylist = (overrides: Partial<Playlist> = {}): Playlist => ({
@@ -370,5 +371,140 @@ describe('deleteTab', () => {
     useKlankStore.getState().deleteTab(oldPath)
 
     expect(useKlankStore.getState().tabSettingByPath).not.toHaveProperty(oldPath)
+  })
+})
+
+// ── Playlists persisted to .klank-settings.json ────────────────────────────────
+
+describe('playlist write-through to the settings file', () => {
+  const baseDirectory = '/tabs'
+  let writePlaylists: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    writePlaylists = vi.fn()
+    resetPlaylists()
+    useKlankStore.setState({
+      baseDirectory,
+      fileService: { writePlaylists } as unknown as FileService,
+    })
+  })
+
+  afterEach(() => {
+    useKlankStore.setState({ baseDirectory: undefined, fileService: undefined })
+  })
+
+  it('createPlaylist writes the updated playlist list and base directory', () => {
+    useKlankStore.getState().createPlaylist('Practice')
+
+    expect(writePlaylists).toHaveBeenCalledTimes(1)
+    const [playlists, dir] = writePlaylists.mock.calls[0] as [Playlist[], string]
+    expect(dir).toBe(baseDirectory)
+    expect(playlists).toEqual(useKlankStore.getState().playlists)
+  })
+
+  it('deletePlaylist, renamePlaylist and reorderPlaylist write through', () => {
+    const playlist = makePlaylist({ paths: ['/tabs/A.tab.txt', '/tabs/B.tab.txt'] })
+    resetPlaylists([playlist])
+
+    useKlankStore.getState().renamePlaylist(playlist.id, 'Renamed')
+    useKlankStore.getState().reorderPlaylist(playlist.id, ['/tabs/B.tab.txt', '/tabs/A.tab.txt'])
+    useKlankStore.getState().deletePlaylist(playlist.id)
+
+    expect(writePlaylists).toHaveBeenCalledTimes(3)
+    const [finalPlaylists] = writePlaylists.mock.calls[2] as [Playlist[]]
+    expect(finalPlaylists).toEqual([])
+  })
+
+  it('addTabToPlaylist and removeTabFromPlaylist write through', () => {
+    const playlist = makePlaylist()
+    resetPlaylists([playlist])
+
+    useKlankStore.getState().addTabToPlaylist(playlist.id, '/tabs/A.tab.txt')
+    useKlankStore.getState().removeTabFromPlaylist(playlist.id, '/tabs/A.tab.txt')
+
+    expect(writePlaylists).toHaveBeenCalledTimes(2)
+    const [afterAdd] = writePlaylists.mock.calls[0] as [Playlist[]]
+    expect(afterAdd[0].paths).toEqual(['/tabs/A.tab.txt'])
+    const [afterRemove] = writePlaylists.mock.calls[1] as [Playlist[]]
+    expect(afterRemove[0].paths).toEqual([])
+  })
+
+  it('deleteTab writes through only when a playlist contained the path', () => {
+    const inPlaylist = '/tabs/Artist - In.tab.txt'
+    const notInPlaylist = '/tabs/Artist - Out.tab.txt'
+    resetPlaylists([makePlaylist({ paths: [inPlaylist] })])
+
+    useKlankStore.getState().deleteTab(notInPlaylist)
+    expect(writePlaylists).not.toHaveBeenCalled()
+
+    useKlankStore.getState().deleteTab(inPlaylist)
+    expect(writePlaylists).toHaveBeenCalledTimes(1)
+    const [playlists] = writePlaylists.mock.calls[0] as [Playlist[]]
+    expect(playlists[0].paths).toEqual([])
+  })
+
+  it('does not write when no base directory is set', () => {
+    useKlankStore.setState({ baseDirectory: undefined })
+
+    useKlankStore.getState().createPlaylist('Practice')
+
+    expect(writePlaylists).not.toHaveBeenCalled()
+  })
+
+  it('setPlaylists hydration does not write back to the settings file', () => {
+    useKlankStore.getState().setPlaylists([makePlaylist()])
+
+    expect(writePlaylists).not.toHaveBeenCalled()
+  })
+})
+
+describe('setPlaylists hydration', () => {
+  beforeEach(() => resetPlaylists())
+
+  it('replaces all playlists', () => {
+    resetPlaylists([makePlaylist({ name: 'Stale' })])
+    const fromFile = [makePlaylist({ name: 'FromFile' })]
+
+    useKlankStore.getState().setPlaylists(fromFile)
+
+    expect(useKlankStore.getState().playlists).toEqual(fromFile)
+  })
+
+  it('keeps the active selection when the active playlist still exists', () => {
+    const playlist = makePlaylist({ paths: ['/tabs/A.tab.txt', '/tabs/B.tab.txt'] })
+    useKlankStore.setState({ playlists: [], activePlaylistId: playlist.id, activePlaylistIndex: 1 })
+
+    useKlankStore.getState().setPlaylists([playlist])
+
+    expect(useKlankStore.getState().activePlaylistId).toBe(playlist.id)
+    expect(useKlankStore.getState().activePlaylistIndex).toBe(1)
+  })
+
+  it('clears the active selection when the active playlist is not in the loaded data', () => {
+    useKlankStore.setState({ playlists: [], activePlaylistId: 'gone', activePlaylistIndex: 0 })
+
+    useKlankStore.getState().setPlaylists([makePlaylist()])
+
+    expect(useKlankStore.getState().activePlaylistId).toBeNull()
+    expect(useKlankStore.getState().activePlaylistIndex).toBeNull()
+  })
+
+  it('clamps activePlaylistIndex when the loaded playlist is shorter', () => {
+    const playlist = makePlaylist({ paths: ['/tabs/A.tab.txt'] })
+    useKlankStore.setState({ playlists: [], activePlaylistId: playlist.id, activePlaylistIndex: 5 })
+
+    useKlankStore.getState().setPlaylists([playlist])
+
+    expect(useKlankStore.getState().activePlaylistIndex).toBe(0)
+  })
+
+  it('nulls activePlaylistIndex when the loaded active playlist is empty', () => {
+    const playlist = makePlaylist({ paths: [] })
+    useKlankStore.setState({ playlists: [], activePlaylistId: playlist.id, activePlaylistIndex: 2 })
+
+    useKlankStore.getState().setPlaylists([playlist])
+
+    expect(useKlankStore.getState().activePlaylistId).toBe(playlist.id)
+    expect(useKlankStore.getState().activePlaylistIndex).toBeNull()
   })
 })

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -1,23 +1,15 @@
 import {create} from 'zustand'
 import {devtools, persist} from 'zustand/middleware'
 import type {} from '@redux-devtools/extension'
-import { FileService, PerTabSettings, type Instrument } from '@klank/platform-api'
+import { FileService, PerTabSettings, type Instrument, type Playlist } from '@klank/platform-api'
 
-export type { Instrument }
+export type { Instrument, Playlist }
 
 export type Mode = "Read" | "Edit"
 export type Theme = "Light" | "Dark"
 export type Ui = {
   isMenuExtended: boolean
   menuWidth: number
-}
-
-export type Playlist = {
-  id: string
-  name: string
-  /** Ordered list of full file-system paths to .tab.txt files. */
-  paths: string[]
-  createdAt: number
 }
 
 /**
@@ -73,12 +65,18 @@ type KlankState = {
   /** @persisted Instrument used for chord diagram tooltips. */
   instrument: Instrument
   setInstrument: (instrument: Instrument) => void
-  /** Named playlists — persisted to localStorage. */
+  /** Named playlists — persisted to `.klank-settings.json` in the tab directory. */
   playlists: Playlist[]
-  /** ID of the currently active playlist, or null when none is active. Persisted. */
+  /** ID of the currently active playlist, or null when none is active. Persisted to localStorage. */
   activePlaylistId: string | null
-  /** Index of the currently playing song within the active playlist. Persisted. */
+  /** Index of the currently playing song within the active playlist. Persisted to localStorage. */
   activePlaylistIndex: number | null
+  /**
+   * Replaces all playlists — used to hydrate from `.klank-settings.json` at
+   * startup. Clears or clamps the active selection when it no longer matches
+   * the loaded playlists. Does not write back to the settings file.
+   */
+  setPlaylists: (playlists: Playlist[]) => void
   createPlaylist: (name: string) => void
   deletePlaylist: (id: string) => void
   renamePlaylist: (id: string, name: string) => void
@@ -100,6 +98,20 @@ type KlankState = {
 /** All valid scroll speed levels (0–9, displayed as 1–10). */
 export const SCROLL_SPEEDS = [...new Array(10).keys()] as const
 export type ScrollSpeeds = typeof SCROLL_SPEEDS[number]
+
+/** The slice of KlankState saved to localStorage — must match what `partialize` returns. */
+type PersistedKlankState = Pick<
+  KlankState,
+  'tab' | 'theme' | 'ui' | 'baseDirectory' | 'activePlaylistId' | 'activePlaylistIndex'
+>
+
+/** Fire-and-forget write of all playlists to `.klank-settings.json`. No-op until a directory and FileService are set. */
+const persistPlaylists = (
+  state: Pick<KlankState, 'fileService' | 'baseDirectory'>,
+  playlists: Playlist[],
+) => {
+  if (state.baseDirectory) state.fileService?.writePlaylists(playlists, state.baseDirectory)
+}
 
 const clampFontSize = (size: number) => {
   if (size < 0) {
@@ -216,31 +228,53 @@ export const useKlankStore = create<KlankState>()(
         setTabDetails: (details) => set((state) => ({...state,tab: {...state.tab, details}})),
         setTabLink: (link) => set( state => ({...state, tab: {...state.tab, link}})),
         setServerMode: (serverMode) => set((state) => ({...state, serverMode})),
-        createPlaylist: (name) => set((state) => ({
-          ...state,
-          playlists: [
+        setPlaylists: (playlists) => set((state) => {
+          const active = playlists.find((p) => p.id === state.activePlaylistId)
+          let activePlaylistIndex = active ? state.activePlaylistIndex : null
+          if (active && activePlaylistIndex !== null) {
+            activePlaylistIndex = active.paths.length === 0
+              ? null
+              : Math.min(activePlaylistIndex, active.paths.length - 1)
+          }
+          return {
+            ...state,
+            playlists,
+            activePlaylistId: active ? state.activePlaylistId : null,
+            activePlaylistIndex,
+          }
+        }),
+        createPlaylist: (name) => set((state) => {
+          const playlists = [
             ...state.playlists,
             { id: crypto.randomUUID(), name, paths: [], createdAt: Date.now() },
-          ],
-        })),
-        deletePlaylist: (id) => set((state) => ({
-          ...state,
-          playlists: state.playlists.filter((p) => p.id !== id),
-          activePlaylistId: state.activePlaylistId === id ? null : state.activePlaylistId,
-          activePlaylistIndex: state.activePlaylistId === id ? null : state.activePlaylistIndex,
-        })),
-        renamePlaylist: (id, name) => set((state) => ({
-          ...state,
-          playlists: state.playlists.map((p) => p.id === id ? { ...p, name } : p),
-        })),
-        addTabToPlaylist: (id, path) => set((state) => ({
-          ...state,
-          playlists: state.playlists.map((p) =>
+          ]
+          persistPlaylists(state, playlists)
+          return { ...state, playlists }
+        }),
+        deletePlaylist: (id) => set((state) => {
+          const playlists = state.playlists.filter((p) => p.id !== id)
+          persistPlaylists(state, playlists)
+          return {
+            ...state,
+            playlists,
+            activePlaylistId: state.activePlaylistId === id ? null : state.activePlaylistId,
+            activePlaylistIndex: state.activePlaylistId === id ? null : state.activePlaylistIndex,
+          }
+        }),
+        renamePlaylist: (id, name) => set((state) => {
+          const playlists = state.playlists.map((p) => p.id === id ? { ...p, name } : p)
+          persistPlaylists(state, playlists)
+          return { ...state, playlists }
+        }),
+        addTabToPlaylist: (id, path) => set((state) => {
+          const playlists = state.playlists.map((p) =>
             p.id === id && !p.paths.includes(path)
               ? { ...p, paths: [...p.paths, path] }
               : p
-          ),
-        })),
+          )
+          persistPlaylists(state, playlists)
+          return { ...state, playlists }
+        }),
         removeTabFromPlaylist: (id, path) => set((state) => {
           const playlist = state.playlists.find((p) => p.id === id)
           const newPaths = playlist?.paths.filter((p) => p !== path) ?? []
@@ -250,16 +284,19 @@ export const useKlankStore = create<KlankState>()(
             if (removedIndex < newIndex) newIndex = newIndex - 1
             if (newIndex >= newPaths.length) newIndex = Math.max(0, newPaths.length - 1)
           }
+          const playlists = state.playlists.map((p) => p.id === id ? { ...p, paths: newPaths } : p)
+          persistPlaylists(state, playlists)
           return {
             ...state,
-            playlists: state.playlists.map((p) => p.id === id ? { ...p, paths: newPaths } : p),
+            playlists,
             activePlaylistIndex: newIndex,
           }
         }),
-        reorderPlaylist: (id, paths) => set((state) => ({
-          ...state,
-          playlists: state.playlists.map((p) => p.id === id ? { ...p, paths } : p),
-        })),
+        reorderPlaylist: (id, paths) => set((state) => {
+          const playlists = state.playlists.map((p) => p.id === id ? { ...p, paths } : p)
+          persistPlaylists(state, playlists)
+          return { ...state, playlists }
+        }),
         setActivePlaylist: (id) => set((state) => {
           if (id === null) return { ...state, activePlaylistId: null, activePlaylistIndex: null }
           const playlist = state.playlists.find((p) => p.id === id)
@@ -329,6 +366,7 @@ export const useKlankStore = create<KlankState>()(
             ? { ...state.tab, path: "", isScrolling: false }
             : state.tab
 
+          const playlistsChanged = state.playlists.some((p) => p.paths.includes(path))
           let activePlaylistIndex = state.activePlaylistIndex
           const playlists = state.playlists.map((p) => {
             const removedIndex = p.paths.indexOf(path)
@@ -344,18 +382,25 @@ export const useKlankStore = create<KlankState>()(
             }
             return { ...p, paths: newPaths }
           })
+          if (playlistsChanged) persistPlaylists(state, playlists)
 
           return { ...state, tab, tabSettingByPath, playlists, activePlaylistIndex }
         }),
       }),
       {
         name: 'klank-storage',
+        version: 1,
+        // v0 persisted playlists in localStorage; they now live in
+        // .klank-settings.json, so stale localStorage copies are dropped.
+        migrate: (persistedState) => {
+          const { playlists: _dropped, ...rest } = (persistedState ?? {}) as Record<string, unknown>
+          return rest as unknown as PersistedKlankState
+        },
         partialize: (state) => ({
           tab: { ...state.tab, isScrolling: false },
           theme: state.theme,
           ui: state.ui,
           baseDirectory: state.baseDirectory,
-          playlists: state.playlists,
           activePlaylistId: state.activePlaylistId,
           activePlaylistIndex: state.activePlaylistIndex,
         }),


### PR DESCRIPTION
## Summary

Playlists are now saved to the klank settings file (`.klank-settings.json` in the tab directory) instead of localStorage, so they live next to the tab files they reference and travel with the directory.

### File format

Playlists are stored under a reserved top-level `"playlists"` key alongside the existing per-tab entries. No collision is possible because tab keys always end in `.tab.txt`, and existing settings files stay valid with zero migration:

```json
{
  "Artist - Song.tab.txt": { "fontSize": 14, "transpose": 2, "scrollSpeed": 3 },
  "playlists": [
    { "id": "uuid", "name": "Practice", "paths": ["Artist - Song.tab.txt"], "createdAt": 1718000000000 }
  ]
}
```

Playlist paths are stored relative to the base directory (forward-slash separated, portable across Windows/Unix) and exposed as absolute paths by the `FileService` API, mirroring the per-tab settings behaviour.

### Changes

- **`@klank/platform-api`**: new `readPlaylists` / `writePlaylists` on `FileService`; `readTabSettings` skips the reserved key; `writeTabSetting` / `deleteTabSetting` preserve it. The `Playlist` type moved here (re-exported from `@klank/store`).
- **`@klank/store`**: every playlist mutation (create/delete/rename/add/remove/reorder and `deleteTab` cleanup) writes through to the settings file; new `setPlaylists` action hydrates from the file at startup and clears/clamps a stale active selection.
- **`apps/klank`**: `app.tsx` loads playlists from the settings file during initialization.
- **localStorage**: playlists are no longer persisted there (`klank-storage` bumped to v1 with a migrate step that drops stale v0 copies — old localStorage playlists are intentionally not migrated). The active playlist selection (`activePlaylistId` / `activePlaylistIndex`) stays device-local in localStorage.

### Tests

- `fs.spec.ts`: read/write playlists round-trip, relative⇄absolute path conversion (incl. Windows backslash paths), missing-file handling, and that tab-setting reads/writes skip/preserve the `playlists` key.
- `store.spec.ts`: write-through on every playlist mutation, `deleteTab` only writes when a playlist actually contained the path, `setPlaylists` hydration semantics.
- `store-persistence.spec.ts` (new): real persist-middleware coverage — the v0→v1 migration drops localStorage playlists, and new writes exclude them. (Discovered along the way: zustand v5's default storage is `window.localStorage`, so the existing localStorage-only stub never exercised persistence; this spec stubs `window` and uses a dynamic import.)

Verified: `nx run-many -t test`, `-t typecheck`, and `-t lint` all green across the workspace, plus a production build.

https://claude.ai/code/session_01APFuEBQRwphAawYdVfYNDi

---
_Generated by [Claude Code](https://claude.ai/code/session_01APFuEBQRwphAawYdVfYNDi)_