### PR TITLE
Android support: pluggable tab-import pipeline + in-app git sync

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -54,6 +54,20 @@ jobs:
           echo "ANDROID_NDK_HOME=${NDK_PATH}" >> "$GITHUB_ENV"
           echo "NDK_HOME=${NDK_PATH}" >> "$GITHUB_ENV"
 
+      # Vendored OpenSSL (pulled in by git2) cross-compiles with the NDK, but its
+      # makefile invokes legacy per-target tool names (e.g.
+      # aarch64-linux-android-ranlib) that NDK r23+ replaced with llvm-ranlib /
+      # llvm-ar. Put the NDK llvm bin on PATH and alias the legacy names so the
+      # OpenSSL `install_dev` step succeeds.
+      - name: Alias NDK toolchain for vendored OpenSSL
+        run: |
+          NDK_BIN="${ANDROID_SDK_ROOT}/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "$NDK_BIN" >> "$GITHUB_PATH"
+          for prefix in aarch64-linux-android armv7a-linux-androideabi arm-linux-androideabi i686-linux-android x86_64-linux-android; do
+            ln -sf "$NDK_BIN/llvm-ranlib" "$NDK_BIN/${prefix}-ranlib"
+            ln -sf "$NDK_BIN/llvm-ar" "$NDK_BIN/${prefix}-ar"
+          done
+
       # Reads the pnpm version from packageManager in package.json.
       - uses: pnpm/action-setup@v4
 
@@ -166,6 +180,20 @@ jobs:
           NDK_PATH="${ANDROID_SDK_ROOT}/ndk/27.0.12077973"
           echo "ANDROID_NDK_HOME=${NDK_PATH}" >> "$GITHUB_ENV"
           echo "NDK_HOME=${NDK_PATH}" >> "$GITHUB_ENV"
+
+      # Vendored OpenSSL (pulled in by git2) cross-compiles with the NDK, but its
+      # makefile invokes legacy per-target tool names (e.g.
+      # aarch64-linux-android-ranlib) that NDK r23+ replaced with llvm-ranlib /
+      # llvm-ar. Put the NDK llvm bin on PATH and alias the legacy names so the
+      # OpenSSL `install_dev` step succeeds.
+      - name: Alias NDK toolchain for vendored OpenSSL
+        run: |
+          NDK_BIN="${ANDROID_SDK_ROOT}/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "$NDK_BIN" >> "$GITHUB_PATH"
+          for prefix in aarch64-linux-android armv7a-linux-androideabi arm-linux-androideabi i686-linux-android x86_64-linux-android; do
+            ln -sf "$NDK_BIN/llvm-ranlib" "$NDK_BIN/${prefix}-ranlib"
+            ln -sf "$NDK_BIN/llvm-ar" "$NDK_BIN/${prefix}-ar"
+          done
 
       # Reads the pnpm version from packageManager in package.json.
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -3,20 +3,35 @@ name: Build Android
 # SHA-pinning of actions can be applied later per the ci-pipeline-optimize convention.
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  release:
+    types: [published]
   push:
     branches:
       - main
       - master
-  pull_request:
   workflow_dispatch:
+    inputs:
+      debug_build:
+        description: "Build a debug APK (true) or release APK (false)"
+        required: false
+        default: "true"
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
-  android-build:
+  # -----------------------------------------------------------------------
+  # Debug build — opt-in via the 'build-android' PR label or workflow_dispatch
+  # -----------------------------------------------------------------------
+  android-debug:
+    name: Android debug APK
     runs-on: ubuntu-latest
-    continue-on-error: false
+    if: >
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.debug_build != 'false') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-android'))
 
     steps:
       - uses: actions/checkout@v4
@@ -61,9 +76,136 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # pnpm tauri android build --debug performs the frontend build
+      # pnpm tauri android build --debug --apk performs the frontend build
       # (via Tauri's beforeBuildCommand) and then cross-compiles the Rust
-      # core for all four Android ABIs before assembling the APK.
+      # core for all four Android ABIs before assembling the debug APK.
       - name: Build Android (debug)
-        run: pnpm tauri android build --debug
+        run: pnpm tauri android build --debug --apk
         working-directory: apps/klank
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: klank-debug-apk
+          path: apps/klank/src-tauri/gen/android/app/build/outputs/apk/**/*.apk
+          if-no-files-found: error
+
+      # Post or update a sticky PR comment so the APK is easy to find.
+      - name: Post PR comment with artifact link
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              '### Android debug APK',
+              '',
+              `A **debug APK** was built for this PR and is attached as the \`klank-debug-apk\` artifact on the workflow run.`,
+              '',
+              `**Workflow run:** ${runUrl}`,
+              '',
+              '_Download the artifact from the run page linked above (requires GitHub login)._',
+            ].join('\n');
+
+            const marker = '<!-- klank-android-build-comment -->';
+            const fullBody = `${marker}\n${body}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: fullBody,
+              });
+            }
+
+  # -----------------------------------------------------------------------
+  # Release build — on push to main/master, published release, or
+  # workflow_dispatch with debug_build set to 'false'
+  # -----------------------------------------------------------------------
+  android-release:
+    name: Android release APK
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'release' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.debug_build == 'false')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # JDK 17 is required by the Android Gradle toolchain.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      # Installs the Android SDK command-line tools; NDK 27 is installed below.
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK 27
+        run: |
+          sdkmanager "ndk;27.0.12077973"
+          NDK_PATH="${ANDROID_SDK_ROOT}/ndk/27.0.12077973"
+          echo "ANDROID_NDK_HOME=${NDK_PATH}" >> "$GITHUB_ENV"
+          echo "NDK_HOME=${NDK_PATH}" >> "$GITHUB_ENV"
+
+      # Reads the pnpm version from packageManager in package.json.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      # Stable Rust with all four Android cross-compilation targets.
+      - name: Set up Rust with Android targets
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      # Cache Cargo registry and the Tauri crate build artifacts.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/klank/src-tauri -> target
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # pnpm tauri android build --apk performs the frontend build
+      # (via Tauri's beforeBuildCommand) and then cross-compiles the Rust
+      # core for all four Android ABIs before assembling the release APK.
+      - name: Build Android (release)
+        run: pnpm tauri android build --apk
+        working-directory: apps/klank
+
+      - name: Upload release APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: klank-release-apk
+          path: apps/klank/src-tauri/gen/android/app/build/outputs/apk/**/*.apk
+          if-no-files-found: error
+
+      # On a published release event, attach the APK(s) to the GitHub Release assets.
+      - name: Attach APK to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: apps/klank/src-tauri/gen/android/app/build/outputs/apk/**/*.apk

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,69 @@
+name: Build Android
+
+# SHA-pinning of actions can be applied later per the ci-pipeline-optimize convention.
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  android-build:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # JDK 17 is required by the Android Gradle toolchain.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      # Installs the Android SDK command-line tools; NDK 27 is installed below.
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK 27
+        run: |
+          sdkmanager "ndk;27.0.12077973"
+          NDK_PATH="${ANDROID_SDK_ROOT}/ndk/27.0.12077973"
+          echo "ANDROID_NDK_HOME=${NDK_PATH}" >> "$GITHUB_ENV"
+          echo "NDK_HOME=${NDK_PATH}" >> "$GITHUB_ENV"
+
+      # Reads the pnpm version from packageManager in package.json.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      # Stable Rust with all four Android cross-compilation targets.
+      - name: Set up Rust with Android targets
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      # Cache Cargo registry and the Tauri crate build artifacts.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/klank/src-tauri -> target
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # pnpm tauri android build --debug performs the frontend build
+      # (via Tauri's beforeBuildCommand) and then cross-compiles the Rust
+      # core for all four Android ABIs before assembling the APK.
+      - name: Build Android (debug)
+        run: pnpm tauri android build --debug
+        working-directory: apps/klank

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Specialist work routes to the subagents in `.claude/agents/` (Copilot: `.github/
 ```
 pnpm dev                              # Vite dev server only (React, no Tauri shell), port 4200
 pnpm tauri:dev                        # Full Tauri desktop app with Rust backend + hot reload
+pnpm tauri:android:dev                # Run on Android (emulator/device); CI builds via .github/workflows/build-android.yml
 pnpm build                            # Production Vite build (nx build klank)
 pnpm test                             # Vitest across all libs (nx run-many -t test)
 pnpm lint                             # ESLint across workspace (nx run-many -t lint)
@@ -27,11 +28,13 @@ pnpm nx run klank:tauri:build
 apps/klank/app/                     React Router 7 app - routes, components, root layout
 apps/klank/app/components/menu/     Left sidebar: directory tree, search bar
 apps/klank/app/components/player/   Center pane: tab display, toolbar, playback controls
-apps/klank/src-tauri/src/lib.rs     Rust commands - scrape_ug, deliver_ug_html, report_ug_error
+apps/klank/src-tauri/src/lib.rs     Rust entry - registers scrape_ug + git_* commands
+apps/klank/src-tauri/src/import/    Tab-import pipeline (stages, orchestrator, progress)
+apps/klank/src-tauri/src/git.rs     In-app git engine (libgit2) - git_pull/commit/push/clone/…
 apps/klank/src-tauri/capabilities/  Tauri permission declarations (JSON) - one file per window
 libs/ui/src/                        Shared React components (@klank/ui)
 libs/store/src/lib/store.ts         Zustand store with persisted TabSetting (@klank/store)
-libs/platform-api/src/lib/          FileService, chords, download, sort, userAgent (@klank/platform-api)
+libs/platform-api/src/lib/          FileService, git (invoke-based), chords, download, userAgent (@klank/platform-api)
 docs/agents/                        Agent architecture + setup conventions
 .claude/agents/                     Subagent identities (self-contained, routed by description)
 .claude/skills/                     Procedure-skills (auto-discovered by Claude, Copilot, Cursor)

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router'
-import { FileEntry, getSheetFromUG, sortByArtist } from '@klank/platform-api'
+import { FileEntry, getSheetFromUG, ImportProgress, sortByArtist } from '@klank/platform-api'
 import {
   DownloadIcon,
   FileTreeView,
@@ -87,6 +87,14 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
   const [urlValue, setUrlValue] = useState('')
   const [isDownloading, setIsDownloading] = useState(false)
   const [downloadError, setDownloadError] = useState<string | null>(null)
+  // Live import-pipeline status shown nonintrusively in the download modal.
+  const [importStage, setImportStage] = useState<{ label: string; index: number; total: number } | null>(null)
+  const [importTried, setImportTried] = useState<{ label: string; reason: string }[]>([])
+  // Manual-paste fallback, revealed only when every automated stage fails.
+  const [showManualPaste, setShowManualPaste] = useState(false)
+  const [manualArtist, setManualArtist] = useState('')
+  const [manualSong, setManualSong] = useState('')
+  const [manualContent, setManualContent] = useState('')
   const [isCreatingPlaylist, setIsCreatingPlaylist] = useState(false)
   const [newPlaylistName, setNewPlaylistName] = useState('')
   const [pathToConfirmDelete, setPathToConfirmDelete] = useState<string | null>(null)
@@ -118,43 +126,90 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
     setIsCreatingPlaylist(false)
   }
 
+  const resetImportState = () => {
+    setImportStage(null)
+    setImportTried([])
+    setShowManualPaste(false)
+    setManualArtist('')
+    setManualSong('')
+    setManualContent('')
+    setDownloadError(null)
+  }
+
   const handleRequestDownload = () => {
     setUrlValue('')
+    resetImportState()
     setIsEnteringUrl(true)
   }
 
   const handleCancel = () => {
     setIsEnteringUrl(false)
+    resetImportState()
+  }
+
+  // Writes a successfully-obtained tab to disk and opens it. Returns true on
+  // success so callers can close the modal.
+  const saveTab = async (filename: string, data: string): Promise<boolean> => {
+    if (!fileService) return false
+    const writtenPath = await fileService.writeTabFile(filename, baseDirectory ?? '', data)
+    // writeTabFile returns an error message string on failure — only a real
+    // path (always ending in .tab.txt) may become the active tab.
+    if (!writtenPath.endsWith('.tab.txt')) {
+      throw new Error(writtenPath)
+    }
+    setTabPath(writtenPath)
+    setNeedsUpdate(true)
+    return true
   }
 
   const handleSubmitUrl = async () => {
     const trimmed = urlValue.trim()
-    setIsEnteringUrl(false)
-    if (!trimmed) return
+    if (!trimmed || isDownloading) return
     setIsDownloading(true)
     setDownloadError(null)
+    setImportTried([])
+    setShowManualPaste(false)
     try {
-      const sheet = await getSheetFromUG(trimmed)
-      if (!sheet || !fileService) return
-      const writtenPath = await fileService.writeTabFile(
-        sheet.filename,
-        baseDirectory ?? '',
-        sheet.data
-      )
-      // writeTabFile returns an error message string on failure — only a real
-      // path (always ending in .tab.txt) may become the active tab.
-      if (!writtenPath.endsWith('.tab.txt')) {
-        throw new Error(writtenPath)
+      const onProgress = (p: ImportProgress) => {
+        if (p.type === 'StageStart') {
+          setImportStage({ label: p.label, index: p.index, total: p.total })
+        } else if (p.type === 'StageFailed') {
+          setImportTried((prev) => [...prev, { label: p.label, reason: p.reason }])
+        } else if (p.type === 'Succeeded') {
+          setImportStage(null)
+        }
       }
-      setTabPath(writtenPath)
-      setNeedsUpdate(true)
+      const sheet = await getSheetFromUG(trimmed, onProgress)
+      if (!sheet) {
+        // Nothing parseable came back — offer manual paste rather than failing.
+        setShowManualPaste(true)
+        return
+      }
+      if (await saveTab(sheet.filename, sheet.data)) {
+        setIsEnteringUrl(false)
+        resetImportState()
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Download failed'
       setDownloadError(message)
-      if (downloadErrorTimerRef.current) clearTimeout(downloadErrorTimerRef.current)
-      downloadErrorTimerRef.current = setTimeout(() => setDownloadError(null), 4000)
+      setShowManualPaste(true)
     } finally {
       setIsDownloading(false)
+      setImportStage(null)
+    }
+  }
+
+  const handleManualSave = async () => {
+    const content = manualContent.trim()
+    if (!content) return
+    try {
+      const filename = `${manualArtist.trim()} - ${manualSong.trim()}.tab.txt`
+      if (await saveTab(filename, content)) {
+        setIsEnteringUrl(false)
+        resetImportState()
+      }
+    } catch (error) {
+      setDownloadError(error instanceof Error ? error.message : 'Could not save tab')
     }
   }
 
@@ -269,13 +324,68 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
               if (e.key === 'Enter') handleSubmitUrl()
               if (e.key === 'Escape') handleCancel()
             }}
+            disabled={isDownloading}
             autoFocus
           />
           <span className={styles.modalHint}>Paste an Ultimate Guitar tab URL and press Download</span>
+
+          {isDownloading && importStage && (
+            <div className={styles.importStatus} role="status" aria-live="polite">
+              <span className={styles.spinner} aria-hidden="true" />
+              <span>Trying {importStage.label}… ({importStage.index}/{importStage.total})</span>
+            </div>
+          )}
+
+          {importTried.length > 0 && (
+            <div className={styles.triedList}>
+              {importTried.map((t, i) => (
+                <div key={i} className={styles.triedItem}>
+                  <span aria-hidden="true">✕</span>
+                  <span>{t.label} — {t.reason}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {showManualPaste && (
+            <>
+              <span className={styles.manualLabel}>
+                Automatic import didn’t work. Paste the tab text below to save it manually.
+              </span>
+              <input
+                className={styles.modalInput}
+                type="text"
+                placeholder="Artist"
+                value={manualArtist}
+                onChange={(e) => setManualArtist(e.target.value)}
+              />
+              <input
+                className={styles.modalInput}
+                type="text"
+                placeholder="Song"
+                value={manualSong}
+                onChange={(e) => setManualSong(e.target.value)}
+              />
+              <textarea
+                className={styles.textarea}
+                placeholder="Paste tab / chords text here"
+                value={manualContent}
+                onChange={(e) => setManualContent(e.target.value)}
+              />
+            </>
+          )}
         </div>
         <div className={styles.modalActions}>
           <button className={styles.btnCancel} onClick={handleCancel}>Cancel</button>
-          <button className={styles.btnDownload} onClick={handleSubmitUrl} disabled={!urlValue.trim()}>Download</button>
+          {showManualPaste ? (
+            <button className={styles.btnDownload} onClick={handleManualSave} disabled={!manualContent.trim()}>
+              Save tab
+            </button>
+          ) : (
+            <button className={styles.btnDownload} onClick={handleSubmitUrl} disabled={!urlValue.trim() || isDownloading}>
+              {isDownloading ? 'Importing…' : 'Download'}
+            </button>
+          )}
         </div>
       </div>
     </div>,

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router'
-import { FileEntry, getSheetFromUG, ImportProgress, sortByArtist } from '@klank/platform-api'
+import { FileEntry, getSheetFromUG, ImportProgress, isMobileDevice, sortByArtist } from '@klank/platform-api'
 import {
   DownloadIcon,
   FileTreeView,
@@ -433,7 +433,7 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
           <LogoIcon /> <span className={styles.logoText}>KLANK</span>
         </li>
         <Toolbar
-          getDirectoryPath={fileService?.getDirectoryPath}
+          getDirectoryPath={isMobileDevice() ? undefined : fileService?.getDirectoryPath}
           setNeedsUpdate={setNeedsUpdate}
           setBaseDirectory={setBaseDirectory}
           setTabPath={handleSelectSong}

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -239,3 +239,65 @@
   z-index: 2000;
   white-space: nowrap;
 }
+
+/* --- Import progress + manual-paste fallback (download modal) --- */
+.importStatus {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.6875rem;
+  opacity: 0.55;
+  padding: 0 2px;
+}
+
+.spinner {
+  width: 11px;
+  height: 11px;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: klank-spin 0.7s linear infinite;
+  flex: 0 0 auto;
+}
+
+@keyframes klank-spin {
+  to { transform: rotate(360deg); }
+}
+
+.triedList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.6875rem;
+  opacity: 0.5;
+  padding: 0 2px;
+}
+
+.triedItem {
+  display: flex;
+  gap: 6px;
+}
+
+.manualLabel {
+  font-size: 0.6875rem;
+  opacity: 0.6;
+  padding: 4px 2px 0;
+}
+
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 120px;
+  padding: 8px 12px;
+  font-size: 0.8125rem;
+  font-family: inherit;
+  resize: vertical;
+  border: 1px solid color-mix(in srgb, var(--klank-color-text) 25%, transparent);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+}
+
+.textarea:focus {
+  border-color: var(--klank-color-text);
+}

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -24,6 +24,9 @@ export default function Settings() {
   const [status, setStatus] = useState<Status>(null)
   const [busy, setBusy] = useState(false)
   const [version, setVersion] = useState<string>('')
+  const [token, setTokenValue] = useState('')
+  const [hasToken, setHasToken] = useState(false)
+  const [cloneUrl, setCloneUrl] = useState('')
 
   const refreshGitState = async (dir: string, git: GitService) => {
     const [files, commits] = await Promise.all([
@@ -41,9 +44,13 @@ export default function Settings() {
         const git = await createGitService()
         gitRef.current = git
         if (!baseDirectory) return
-        const repo = await git.isGitRepo(baseDirectory)
+        const [repo, tokenStored] = await Promise.all([
+          git.isGitRepo(baseDirectory),
+          git.hasToken(),
+        ])
         if (cancelled) return
         setIsRepo(repo)
+        setHasToken(tokenStored)
         if (repo) await refreshGitState(baseDirectory, git)
       } catch {
         // not in Tauri context (server render)
@@ -67,6 +74,36 @@ export default function Settings() {
     setStatus({ ok: result.success, message: result.output || result.error || '' })
     if (result.success && baseDirectory && gitRef.current) {
       await refreshGitState(baseDirectory, gitRef.current)
+    }
+  }
+
+  const handleSaveToken = async () => {
+    if (!gitRef.current || busy) return
+    setBusy(true)
+    try {
+      await gitRef.current.setToken(token)
+      setHasToken(token.trim().length > 0)
+      setTokenValue('')
+      setStatus({ ok: true, message: token.trim() ? 'Token saved.' : 'Token cleared.' })
+    } catch (e) {
+      setStatus({ ok: false, message: e instanceof Error ? e.message : 'Could not save token' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleClone = async () => {
+    if (!gitRef.current || !baseDirectory || !cloneUrl.trim() || busy) return
+    setBusy(true)
+    try {
+      const result = await gitRef.current.cloneRepo(cloneUrl.trim(), baseDirectory)
+      setStatus({ ok: result.success, message: result.output || result.error || '' })
+      if (result.success) {
+        setIsRepo(true)
+        await refreshGitState(baseDirectory, gitRef.current)
+      }
+    } finally {
+      setBusy(false)
     }
   }
 
@@ -164,14 +201,44 @@ export default function Settings() {
         <section className={styles.section}>
           <h2>Git</h2>
 
+          <div className={styles.row}>
+            <span className={styles.label}>Token</span>
+            <input
+              className={styles.commitInput}
+              type="password"
+              placeholder={hasToken ? '•••••••• (saved)' : 'HTTPS access token'}
+              value={token}
+              onChange={(e) => setTokenValue(e.target.value)}
+              disabled={busy}
+            />
+            <button className={styles.button} onClick={handleSaveToken} disabled={busy || (!token.trim() && !hasToken)}>
+              {token.trim() ? 'Save' : 'Clear'}
+            </button>
+          </div>
+
           {isRepo === null && (
             <span className={styles.infoMessage}>Checking repository…</span>
           )}
 
           {isRepo === false && (
-            <span className={styles.infoMessage}>
-              No git repository found in the current folder. Open a folder that is tracked by git to use these features.
-            </span>
+            <>
+              <span className={styles.infoMessage}>
+                No git repository in the current folder. Clone your tabs repository to sync it here.
+              </span>
+              <div className={styles.row}>
+                <input
+                  className={styles.commitInput}
+                  type="url"
+                  placeholder="https://github.com/you/tabs.git"
+                  value={cloneUrl}
+                  onChange={(e) => setCloneUrl(e.target.value)}
+                  disabled={busy}
+                />
+                <button className={styles.button} onClick={handleClone} disabled={busy || !cloneUrl.trim()}>
+                  Clone
+                </button>
+              </div>
+            </>
           )}
 
           {isRepo === true && (

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -1,7 +1,7 @@
 import styles from './settings.module.css'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
-import { createGitService, getAppVersion, type GitChangedFile, type GitResult, type GitService } from '@klank/platform-api'
+import { createGitService, getAppVersion, isMobileDevice, type GitChangedFile, type GitResult, type GitService } from '@klank/platform-api'
 import { useKlankStore } from '@klank/store'
 
 type Status = { ok: boolean; message: string } | null
@@ -118,9 +118,13 @@ export default function Settings() {
             <span className={styles.dirPath} title={baseDirectory ?? ''}>
               {baseDirectory ?? 'Not set'}
             </span>
-            <button className={styles.button} onClick={handleChangeFolder} disabled={!fileService}>
-              Change
-            </button>
+            {/* The native folder picker isn't available on mobile, where tabs
+                live in app-private storage. */}
+            {!isMobileDevice() && (
+              <button className={styles.button} onClick={handleChangeFolder} disabled={!fileService}>
+                Change
+              </button>
+            )}
           </div>
 
           <div className={styles.row}>

--- a/apps/klank/package.json
+++ b/apps/klank/package.json
@@ -16,7 +16,6 @@
     "@react-router/serve": "^7.16.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.1",
-    "@tauri-apps/plugin-shell": "^2.0.0",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "isbot": "^4.4.0",
     "react": "^19.2.7",

--- a/apps/klank/src-tauri/Cargo.lock
+++ b/apps/klank/src-tauri/Cargo.lock
@@ -8,6 +8,7 @@ version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "git2",
  "html-escape",
  "log",
  "md5",
@@ -21,7 +22,6 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-log",
- "tauri-plugin-shell",
  "tokio",
 ]
 
@@ -423,6 +423,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -957,16 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1318,21 @@ dependencies = [
  "libc",
  "system-deps",
  "winapi",
+]
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.12.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -1813,25 +1820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +1890,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1995,6 +1993,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2022,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2408,15 +2431,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "open"
-version = "5.3.5"
+name = "openssl-probe"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
- "dunce",
- "is-wsl",
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
  "libc",
- "pathdiff",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2424,16 +2463,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "pango"
@@ -2482,12 +2511,6 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -3477,52 +3500,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
 
 [[package]]
 name = "simd-adler32"
@@ -4019,27 +4000,6 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "time",
-]
-
-[[package]]
-name = "tauri-plugin-shell"
-version = "2.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
-dependencies = [
- "encoding_rs",
- "log",
- "open",
- "os_pipe",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "shared_child",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]
@@ -4653,6 +4613,12 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/apps/klank/src-tauri/Cargo.lock
+++ b/apps/klank/src-tauri/Cargo.lock
@@ -6,7 +6,13 @@ version = 3
 name = "Klank"
 version = "2.0.0"
 dependencies = [
+ "async-trait",
+ "chrono",
+ "html-escape",
  "log",
+ "md5",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -97,6 +103,29 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "atk"
@@ -457,6 +486,24 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "cookie"
@@ -1459,6 +1506,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2059,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -4378,12 +4440,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.12.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/apps/klank/src-tauri/Cargo.lock
+++ b/apps/klank/src-tauri/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-log",
+ "tauri-plugin-ug-scraper",
  "tokio",
 ]
 
@@ -4000,6 +4001,16 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-ug-scraper"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/apps/klank/src-tauri/Cargo.toml
+++ b/apps/klank/src-tauri/Cargo.toml
@@ -27,7 +27,6 @@ tauri-plugin-log = "2.0.0"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2.0"
 tauri-plugin-http = "2.5.9"
-tauri-plugin-shell = "2"
 # Tab import pipeline (Workstream A).
 # rustls avoids cross-compiling OpenSSL for Android.
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "gzip", "brotli"] }
@@ -36,3 +35,6 @@ md5 = "0.7"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 rand = "0.8"
 html-escape = "0.2"
+# Git sync (Workstream B). Vendored so it cross-compiles to Android without a
+# system libgit2/openssl; https only (PAT auth), ssh dropped.
+git2 = { version = "0.19", default-features = false, features = ["https", "vendored-libgit2", "vendored-openssl"] }

--- a/apps/klank/src-tauri/Cargo.toml
+++ b/apps/klank/src-tauri/Cargo.toml
@@ -38,3 +38,5 @@ html-escape = "0.2"
 # Git sync (Workstream B). Vendored so it cross-compiles to Android without a
 # system libgit2/openssl; https only (PAT auth), ssh dropped.
 git2 = { version = "0.19", default-features = false, features = ["https", "vendored-libgit2", "vendored-openssl"] }
+# Android-only scraper plugin (self-owned WebView). No-op shell on desktop.
+tauri-plugin-ug-scraper = { path = "tauri-plugin-ug-scraper" }

--- a/apps/klank/src-tauri/Cargo.toml
+++ b/apps/klank/src-tauri/Cargo.toml
@@ -28,3 +28,11 @@ tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2.0"
 tauri-plugin-http = "2.5.9"
 tauri-plugin-shell = "2"
+# Tab import pipeline (Workstream A).
+# rustls avoids cross-compiling OpenSSL for Android.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "gzip", "brotli"] }
+async-trait = "0.1"
+md5 = "0.7"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+rand = "0.8"
+html-escape = "0.2"

--- a/apps/klank/src-tauri/capabilities/default.json
+++ b/apps/klank/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "fs:default",
     "dialog:default",
     "allow-scrape-ug",
+    "allow-git",
     {
       "identifier": "fs:read-all",
       "allow": [
@@ -33,11 +34,6 @@
         { "url": "https://tabs.ultimate-guitar.com/*" },
         { "url": "https://www.ultimate-guitar.com/*" }
       ]
-    },
-    "shell:allow-execute",
-    {
-      "identifier": "shell:allow-execute",
-      "allow": [{ "name": "git", "cmd": "git", "args": true }]
     }
   ]
 }

--- a/apps/klank/src-tauri/capabilities/ug-scraper.json
+++ b/apps/klank/src-tauri/capabilities/ug-scraper.json
@@ -14,6 +14,6 @@
   "permissions": [
     "core:default",
     "allow-deliver-ug-html",
-    "allow-report-ug-error"
+    "allow-report-ug-challenge"
   ]
 }

--- a/apps/klank/src-tauri/gen/android/app/build.gradle.kts
+++ b/apps/klank/src-tauri/gen/android/app/build.gradle.kts
@@ -15,10 +15,10 @@ val tauriProperties = Properties().apply {
 
 android {
     compileSdk = 36
-    namespace = "com.tauri.dev"
+    namespace = "io.github.hampterworks.klank"
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
-        applicationId = "com.tauri.dev"
+        applicationId = "io.github.hampterworks.klank"
         minSdk = 24
         targetSdk = 36
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()

--- a/apps/klank/src-tauri/gen/android/app/src/main/java/io/github/hampterworks/klank/MainActivity.kt
+++ b/apps/klank/src-tauri/gen/android/app/src/main/java/io/github/hampterworks/klank/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.tauri.dev
+package io.github.hampterworks.klank
 
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge

--- a/apps/klank/src-tauri/permissions/allow-git.toml
+++ b/apps/klank/src-tauri/permissions/allow-git.toml
@@ -1,0 +1,14 @@
+[[permission]]
+identifier = "allow-git"
+description = "Allows the main window to use the in-app libgit2 sync commands."
+commands.allow = [
+  "git_is_repo",
+  "git_status",
+  "git_pull",
+  "git_commit",
+  "git_push",
+  "git_unpushed",
+  "git_clone",
+  "git_set_token",
+  "git_has_token",
+]

--- a/apps/klank/src-tauri/permissions/allow-report-ug-challenge.toml
+++ b/apps/klank/src-tauri/permissions/allow-report-ug-challenge.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "allow-report-ug-challenge"
+description = "Allows the hidden UG scraper window to signal that an interactive Cloudflare challenge was detected, so the window can be revealed."
+commands.allow = ["report_ug_challenge"]

--- a/apps/klank/src-tauri/permissions/allow-report-ug-error.toml
+++ b/apps/klank/src-tauri/permissions/allow-report-ug-error.toml
@@ -1,4 +1,0 @@
-[[permission]]
-identifier = "allow-report-ug-error"
-description = "Allows the hidden UG scraper window to call the report_ug_error command."
-commands.allow = ["report_ug_error"]

--- a/apps/klank/src-tauri/src/git.rs
+++ b/apps/klank/src-tauri/src/git.rs
@@ -1,0 +1,286 @@
+//! In-app git engine backed by libgit2 (`git2`).
+//!
+//! Replaces the desktop-only shell `git` so sync works on Android too, where no
+//! `git` binary exists. HTTPS authentication uses a Personal Access Token stored
+//! in the app-private config dir when set (required on Android), otherwise the
+//! system credential helper (desktop). The token is never logged and never
+//! written into remote URLs.
+
+use git2::{
+    build::{CheckoutBuilder, RepoBuilder},
+    Cred, CredentialType, Error, FetchOptions, PushOptions, RemoteCallbacks, Repository,
+    Signature, StatusOptions,
+};
+use serde::Serialize;
+use std::path::Path;
+use tauri::Manager;
+
+#[derive(Serialize)]
+pub struct GitChangedFile {
+    pub status: String,
+    pub path: String,
+}
+
+#[derive(Serialize)]
+pub struct GitResult {
+    pub success: bool,
+    pub output: String,
+    pub error: Option<String>,
+}
+
+impl GitResult {
+    fn ok(output: impl Into<String>) -> Self {
+        Self { success: true, output: output.into(), error: None }
+    }
+    fn err(e: Error) -> Self {
+        Self { success: false, output: String::new(), error: Some(e.message().to_string()) }
+    }
+}
+
+const TOKEN_FILE: &str = "git_token";
+
+fn token_path(app: &tauri::AppHandle) -> Option<std::path::PathBuf> {
+    app.path().app_config_dir().ok().map(|d| d.join(TOKEN_FILE))
+}
+
+fn read_token(app: &tauri::AppHandle) -> Option<String> {
+    let t = std::fs::read_to_string(token_path(app)?).ok()?.trim().to_string();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t)
+    }
+}
+
+/// Stores (or, when empty, clears) the HTTPS Personal Access Token used for
+/// push/pull/clone. Written app-private with `0600` perms on unix.
+#[tauri::command]
+pub fn git_set_token(app: tauri::AppHandle, token: String) -> Result<(), String> {
+    let path = token_path(&app).ok_or("no config directory")?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    let token = token.trim();
+    if token.is_empty() {
+        let _ = std::fs::remove_file(&path);
+        return Ok(());
+    }
+    std::fs::write(&path, token).map_err(|e| e.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+/// Whether a PAT is currently stored (so the UI can show its state without
+/// exposing the token).
+#[tauri::command]
+pub fn git_has_token(app: tauri::AppHandle) -> bool {
+    read_token(&app).is_some()
+}
+
+/// Builds credential callbacks: PAT first (Android + as an override), then the
+/// system credential helper (desktop).
+fn callbacks(app: tauri::AppHandle) -> RemoteCallbacks<'static> {
+    let mut cb = RemoteCallbacks::new();
+    let mut used_token = false;
+    cb.credentials(move |url, username, allowed| {
+        if allowed.contains(CredentialType::USER_PASS_PLAINTEXT) {
+            if !used_token {
+                if let Some(token) = read_token(&app) {
+                    used_token = true;
+                    // GitHub & friends accept the PAT as the password with any user.
+                    return Cred::userpass_plaintext(username.unwrap_or("git"), &token);
+                }
+            }
+            if let Ok(config) = git2::Config::open_default() {
+                if let Ok(cred) = Cred::credential_helper(&config, url, username) {
+                    return Ok(cred);
+                }
+            }
+        }
+        if allowed.contains(CredentialType::DEFAULT) {
+            return Cred::default();
+        }
+        Err(Error::from_str(
+            "no usable git credentials — set a token in Settings",
+        ))
+    });
+    cb
+}
+
+#[tauri::command]
+pub fn git_is_repo(dir: String) -> bool {
+    Repository::discover(&dir).is_ok()
+}
+
+#[tauri::command]
+pub fn git_status(dir: String) -> Result<Vec<GitChangedFile>, String> {
+    let repo = Repository::discover(&dir).map_err(|e| e.message().to_string())?;
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(true).recurse_untracked_dirs(true);
+    let statuses = repo.statuses(Some(&mut opts)).map_err(|e| e.message().to_string())?;
+    Ok(statuses
+        .iter()
+        .filter_map(|entry| {
+            entry.path().map(|p| GitChangedFile {
+                status: status_code(entry.status()),
+                path: p.to_string(),
+            })
+        })
+        .collect())
+}
+
+fn status_code(s: git2::Status) -> String {
+    if s.is_wt_new() || s.is_index_new() {
+        "A".into()
+    } else if s.is_wt_deleted() || s.is_index_deleted() {
+        "D".into()
+    } else if s.is_wt_renamed() || s.is_index_renamed() {
+        "R".into()
+    } else if s.is_wt_modified() || s.is_index_modified() {
+        "M".into()
+    } else {
+        "?".into()
+    }
+}
+
+#[tauri::command]
+pub fn git_commit(dir: String, message: String) -> GitResult {
+    match commit_inner(&dir, &message) {
+        Ok(()) => GitResult::ok("committed"),
+        Err(e) => GitResult::err(e),
+    }
+}
+
+fn commit_inner(dir: &str, message: &str) -> Result<(), Error> {
+    let repo = Repository::discover(dir)?;
+    let mut index = repo.index()?;
+    index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
+    index.write()?;
+    let tree = repo.find_tree(index.write_tree()?)?;
+    let sig = signature(&repo)?;
+    let parent = repo
+        .head()
+        .ok()
+        .and_then(|h| h.target())
+        .and_then(|oid| repo.find_commit(oid).ok());
+    let parents: Vec<&git2::Commit> = parent.iter().collect();
+    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents)?;
+    Ok(())
+}
+
+fn signature(repo: &Repository) -> Result<Signature<'static>, Error> {
+    let cfg = repo.config()?;
+    let name = cfg.get_string("user.name").unwrap_or_else(|_| "klank".into());
+    let email = cfg.get_string("user.email").unwrap_or_else(|_| "klank@localhost".into());
+    Signature::now(&name, &email)
+}
+
+#[tauri::command]
+pub fn git_pull(app: tauri::AppHandle, dir: String) -> GitResult {
+    match pull_inner(app, &dir) {
+        Ok(msg) => GitResult::ok(msg),
+        Err(e) => GitResult::err(e),
+    }
+}
+
+fn pull_inner(app: tauri::AppHandle, dir: &str) -> Result<String, Error> {
+    let repo = Repository::discover(dir)?;
+    let head = repo.head()?;
+    let branch = head.shorthand().ok_or_else(|| Error::from_str("no current branch"))?.to_string();
+
+    let mut remote = repo.find_remote("origin")?;
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks(app));
+    remote.fetch(&[&branch], Some(&mut fo), None)?;
+
+    let fetch_head = repo.find_reference("FETCH_HEAD")?;
+    let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
+    let (analysis, _) = repo.merge_analysis(&[&fetch_commit])?;
+
+    if analysis.is_up_to_date() {
+        return Ok("Already up to date".into());
+    }
+    if analysis.is_fast_forward() {
+        let refname = format!("refs/heads/{branch}");
+        let mut reference = repo.find_reference(&refname)?;
+        reference.set_target(fetch_commit.id(), "pull: fast-forward")?;
+        repo.set_head(&refname)?;
+        repo.checkout_head(Some(CheckoutBuilder::default().force()))?;
+        return Ok("Fast-forwarded".into());
+    }
+    Err(Error::from_str(
+        "local and remote have diverged — resolve the conflict on a desktop",
+    ))
+}
+
+#[tauri::command]
+pub fn git_push(app: tauri::AppHandle, dir: String) -> GitResult {
+    match push_inner(app, &dir) {
+        Ok(msg) => GitResult::ok(msg),
+        Err(e) => GitResult::err(e),
+    }
+}
+
+fn push_inner(app: tauri::AppHandle, dir: &str) -> Result<String, Error> {
+    let repo = Repository::discover(dir)?;
+    let head = repo.head()?;
+    let branch = head.shorthand().ok_or_else(|| Error::from_str("no current branch"))?.to_string();
+    let mut remote = repo.find_remote("origin")?;
+    let mut po = PushOptions::new();
+    po.remote_callbacks(callbacks(app));
+    remote.push(&[format!("refs/heads/{branch}:refs/heads/{branch}")], Some(&mut po))?;
+    Ok(format!("Pushed {branch}"))
+}
+
+#[tauri::command]
+pub fn git_unpushed(dir: String) -> Result<Vec<String>, String> {
+    unpushed_inner(&dir).map_err(|e| e.message().to_string())
+}
+
+fn unpushed_inner(dir: &str) -> Result<Vec<String>, Error> {
+    let repo = Repository::discover(dir)?;
+    let head = repo.head()?;
+    let Some(local) = head.target() else {
+        return Ok(vec![]);
+    };
+    let branch = head.shorthand().ok_or_else(|| Error::from_str("no current branch"))?;
+    let upstream = match repo.find_reference(&format!("refs/remotes/origin/{branch}")) {
+        Ok(r) => r.target(),
+        Err(_) => return Ok(vec![]), // no upstream tracked yet
+    };
+    let Some(upstream) = upstream else {
+        return Ok(vec![]);
+    };
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push(local)?;
+    revwalk.hide(upstream)?;
+    let mut out = Vec::new();
+    for oid in revwalk {
+        let oid = oid?;
+        let commit = repo.find_commit(oid)?;
+        out.push(format!("{} {}", &oid.to_string()[..7], commit.summary().unwrap_or("")));
+    }
+    Ok(out)
+}
+
+#[tauri::command]
+pub fn git_clone(app: tauri::AppHandle, url: String, dir: String) -> GitResult {
+    match clone_inner(app, &url, &dir) {
+        Ok(()) => GitResult::ok("Cloned"),
+        Err(e) => GitResult::err(e),
+    }
+}
+
+fn clone_inner(app: tauri::AppHandle, url: &str, dir: &str) -> Result<(), Error> {
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks(app));
+    let mut builder = RepoBuilder::new();
+    builder.fetch_options(fo);
+    builder.clone(url, Path::new(dir))?;
+    Ok(())
+}

--- a/apps/klank/src-tauri/src/import/mod.rs
+++ b/apps/klank/src-tauri/src/import/mod.rs
@@ -14,6 +14,10 @@
 pub mod pipeline;
 pub mod stages;
 
+// Desktop-only IPC module for the hidden webview stage (registered in `lib.rs`).
+#[cfg(desktop)]
+pub use stages::desktop;
+
 use std::time::Duration;
 use tauri::ipc::Channel;
 

--- a/apps/klank/src-tauri/src/import/mod.rs
+++ b/apps/klank/src-tauri/src/import/mod.rs
@@ -1,0 +1,157 @@
+//! Tab-import pipeline.
+//!
+//! Importing a tab is modelled as an ordered chain of independent **stages**
+//! (see [`ImportStage`]). Each stage is one way to obtain a tab; the
+//! orchestrator ([`pipeline::run_import`]) tries them in order until one
+//! succeeds. Adding or removing an import method is a one-line change in
+//! [`stages::build_stages`] plus a new stage module — the frontend needs no
+//! change because it renders whatever progress the backend streams.
+//!
+//! Stages receive everything they need at construction (dependency injection),
+//! so the orchestrator itself depends on nothing Tauri-specific and is unit
+//! testable with fake stages.
+
+pub mod pipeline;
+pub mod stages;
+
+use std::time::Duration;
+use tauri::ipc::Channel;
+
+/// A tab normalised to a single shape regardless of which stage produced it.
+/// `content` keeps UG's `[ch]`/`[tab]` markup — the frontend strips it.
+#[derive(Debug)]
+pub struct NormalizedTab {
+    pub content: String,
+    pub artist: String,
+    pub song: String,
+    /// Stage id that produced this tab, used to bias the next run's ordering.
+    pub source: &'static str,
+}
+
+/// Why a stage did not produce a tab. Drives both the user-facing reason text
+/// and whether the pipeline should keep going.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StageError {
+    Network(String),
+    Unauthorized,
+    NotFound,
+    Challenged,
+    Parse(String),
+}
+
+impl StageError {
+    pub fn message(&self) -> String {
+        match self {
+            StageError::Network(m) => format!("network error ({m})"),
+            StageError::Unauthorized => "rejected by Ultimate Guitar (auth)".into(),
+            StageError::NotFound => "tab not found".into(),
+            StageError::Challenged => "blocked by an anti-bot challenge".into(),
+            StageError::Parse(m) => format!("could not read the tab data ({m})"),
+        }
+    }
+}
+
+/// Result of running one stage.
+pub enum StageOutcome {
+    /// Got the tab — stop.
+    Success(NormalizedTab),
+    /// Not applicable right now (e.g. a desktop-only stage on mobile) — skip silently.
+    // Constructed by the upcoming `ug-webview` stage (and by pipeline tests).
+    #[allow(dead_code)]
+    Skip,
+    /// This method failed; try the next stage.
+    RetryNext(StageError),
+    /// Definitively not importable (bad URL / 404) — stop the whole pipeline.
+    Fatal(StageError),
+}
+
+/// One import method. Implementors capture their own dependencies (url, http
+/// client, app handle) at construction so this trait stays dependency-free.
+#[async_trait::async_trait]
+pub trait ImportStage: Send + Sync {
+    /// Stable machine id (e.g. `"ug-mobile-api"`).
+    fn id(&self) -> &'static str;
+    /// Human label shown in the progress UI.
+    fn label(&self) -> &'static str;
+    /// Whether this stage applies to the current input/platform.
+    fn can_handle(&self) -> bool;
+    /// Per-stage time budget.
+    fn timeout(&self) -> Duration;
+    /// Attempt the import.
+    async fn run(&self) -> StageOutcome;
+}
+
+/// Progress events streamed to the frontend over a per-invocation channel.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(tag = "type")]
+pub enum ImportProgress {
+    StageStart { id: String, label: String, index: usize, total: usize },
+    StageFailed { id: String, label: String, reason: String },
+    Succeeded { id: String, label: String },
+}
+
+/// Serialised success payload returned to the frontend (`download.ts` parses
+/// this, strips markup, and builds the filename).
+#[derive(serde::Serialize)]
+struct OutTab {
+    content: String,
+    artist: String,
+    song: String,
+}
+
+/// Entry point used by the `scrape_ug` command. Builds the stages, applies the
+/// self-healing order, runs the pipeline while streaming progress, persists the
+/// winning stage, and returns the normalised tab as a JSON string.
+pub async fn run(
+    app: tauri::AppHandle,
+    url: String,
+    on_progress: Channel<ImportProgress>,
+) -> Result<String, String> {
+    let http = reqwest::Client::builder()
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let stages = stages::build_stages(app.clone(), url, http);
+    let preferred = read_last_successful(&app);
+
+    let emit = move |p: ImportProgress| {
+        let _ = on_progress.send(p);
+    };
+
+    match pipeline::run_import(stages, preferred.as_deref(), emit).await {
+        Ok(tab) => {
+            write_last_successful(&app, tab.source);
+            serde_json::to_string(&OutTab {
+                content: tab.content,
+                artist: tab.artist,
+                song: tab.song,
+            })
+            .map_err(|e| e.to_string())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+const LAST_STAGE_FILE: &str = "ug_last_stage";
+
+/// Reads the id of the stage that last succeeded, so the pipeline can try it
+/// first. Best-effort: any error simply yields the default order.
+fn read_last_successful(app: &tauri::AppHandle) -> Option<String> {
+    use tauri::Manager;
+    let path = app.path().app_config_dir().ok()?.join(LAST_STAGE_FILE);
+    let id = std::fs::read_to_string(path).ok()?.trim().to_string();
+    if id.is_empty() {
+        None
+    } else {
+        Some(id)
+    }
+}
+
+/// Records the winning stage id. Best-effort; failures are ignored.
+fn write_last_successful(app: &tauri::AppHandle, id: &str) {
+    use tauri::Manager;
+    if let Ok(dir) = app.path().app_config_dir() {
+        let _ = std::fs::create_dir_all(&dir);
+        let _ = std::fs::write(dir.join(LAST_STAGE_FILE), id);
+    }
+}

--- a/apps/klank/src-tauri/src/import/pipeline.rs
+++ b/apps/klank/src-tauri/src/import/pipeline.rs
@@ -1,0 +1,253 @@
+//! Stage orchestrator. Pure (no Tauri dependencies) so it can be unit tested
+//! with fake stages.
+
+use super::{ImportProgress, ImportStage, NormalizedTab, StageOutcome};
+
+/// Runs the stages in order until one succeeds.
+///
+/// - `preferred` (the last stage that worked) is moved to the front so a
+///   degraded primary stage is auto-demoted after a single failure.
+/// - Only stages whose `can_handle()` is true are attempted; `total` counts
+///   exactly those, so the UI's "x/total" is accurate.
+/// - Each stage runs under its own [`ImportStage::timeout`].
+/// - `Success` short-circuits; `Skip` advances silently; `RetryNext` advances
+///   and reports; `Fatal` stops the whole pipeline.
+pub async fn run_import<F>(
+    mut stages: Vec<Box<dyn ImportStage>>,
+    preferred: Option<&str>,
+    emit: F,
+) -> Result<NormalizedTab, String>
+where
+    F: Fn(ImportProgress),
+{
+    if let Some(pref) = preferred {
+        if let Some(pos) = stages.iter().position(|s| s.id() == pref) {
+            let s = stages.remove(pos);
+            stages.insert(0, s);
+        }
+    }
+
+    let applicable: Vec<Box<dyn ImportStage>> =
+        stages.into_iter().filter(|s| s.can_handle()).collect();
+    let total = applicable.len();
+
+    let mut reasons: Vec<String> = Vec::new();
+
+    for (i, stage) in applicable.iter().enumerate() {
+        emit(ImportProgress::StageStart {
+            id: stage.id().to_string(),
+            label: stage.label().to_string(),
+            index: i + 1,
+            total,
+        });
+
+        let outcome = match tokio::time::timeout(stage.timeout(), stage.run()).await {
+            Ok(o) => o,
+            Err(_) => StageOutcome::RetryNext(super::StageError::Network("timed out".into())),
+        };
+
+        match outcome {
+            StageOutcome::Success(tab) => {
+                emit(ImportProgress::Succeeded {
+                    id: stage.id().to_string(),
+                    label: stage.label().to_string(),
+                });
+                return Ok(tab);
+            }
+            StageOutcome::Skip => continue,
+            StageOutcome::RetryNext(err) => {
+                let reason = err.message();
+                emit(ImportProgress::StageFailed {
+                    id: stage.id().to_string(),
+                    label: stage.label().to_string(),
+                    reason: reason.clone(),
+                });
+                reasons.push(format!("{}: {}", stage.label(), reason));
+            }
+            StageOutcome::Fatal(err) => {
+                let reason = err.message();
+                emit(ImportProgress::StageFailed {
+                    id: stage.id().to_string(),
+                    label: stage.label().to_string(),
+                    reason: reason.clone(),
+                });
+                return Err(format!("{}: {}", stage.label(), reason));
+            }
+        }
+    }
+
+    Err(if reasons.is_empty() {
+        "no import method could handle this URL".into()
+    } else {
+        format!("all import methods failed — {}", reasons.join("; "))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::import::{NormalizedTab, StageError, StageOutcome};
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    /// Configurable fake stage. `outcome` is consumed once; `can` toggles
+    /// applicability.
+    struct Fake {
+        id: &'static str,
+        can: bool,
+        outcome: Mutex<Option<StageOutcome>>,
+        delay: Duration,
+    }
+
+    impl Fake {
+        fn new(id: &'static str, outcome: StageOutcome) -> Box<dyn ImportStage> {
+            Box::new(Fake {
+                id,
+                can: true,
+                outcome: Mutex::new(Some(outcome)),
+                delay: Duration::from_millis(0),
+            })
+        }
+        fn skipped(id: &'static str) -> Box<dyn ImportStage> {
+            Box::new(Fake {
+                id,
+                can: false,
+                outcome: Mutex::new(Some(StageOutcome::Skip)),
+                delay: Duration::from_millis(0),
+            })
+        }
+        fn slow(id: &'static str, delay: Duration) -> Box<dyn ImportStage> {
+            Box::new(Fake {
+                id,
+                can: true,
+                outcome: Mutex::new(Some(StageOutcome::Success(tab(id)))),
+                delay,
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ImportStage for Fake {
+        fn id(&self) -> &'static str {
+            self.id
+        }
+        fn label(&self) -> &'static str {
+            self.id
+        }
+        fn can_handle(&self) -> bool {
+            self.can
+        }
+        fn timeout(&self) -> Duration {
+            Duration::from_millis(50)
+        }
+        async fn run(&self) -> StageOutcome {
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
+            self.outcome.lock().unwrap().take().unwrap_or(StageOutcome::Skip)
+        }
+    }
+
+    fn tab(source: &'static str) -> NormalizedTab {
+        NormalizedTab {
+            content: "c".into(),
+            artist: "a".into(),
+            song: "s".into(),
+            source,
+        }
+    }
+
+    fn collector() -> (impl Fn(ImportProgress), std::sync::Arc<Mutex<Vec<ImportProgress>>>) {
+        let log = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let l2 = log.clone();
+        (move |p| l2.lock().unwrap().push(p), log)
+    }
+
+    #[tokio::test]
+    async fn first_success_short_circuits() {
+        let (emit, log) = collector();
+        let stages = vec![
+            Fake::new("a", StageOutcome::Success(tab("a"))),
+            Fake::new("b", StageOutcome::Success(tab("b"))),
+        ];
+        let res = run_import(stages, None, emit).await.unwrap();
+        assert_eq!(res.source, "a");
+        // Only stage "a" ran: one StageStart + one Succeeded.
+        let log = log.lock().unwrap();
+        assert_eq!(log.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn retry_next_advances_and_reports() {
+        let (emit, log) = collector();
+        let stages = vec![
+            Fake::new("a", StageOutcome::RetryNext(StageError::Challenged)),
+            Fake::new("b", StageOutcome::Success(tab("b"))),
+        ];
+        let res = run_import(stages, None, emit).await.unwrap();
+        assert_eq!(res.source, "b");
+        let log = log.lock().unwrap();
+        // StageStart(a), StageFailed(a), StageStart(b), Succeeded(b)
+        assert!(matches!(log[1], ImportProgress::StageFailed { .. }));
+        assert_eq!(log.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn fatal_stops_pipeline() {
+        let (emit, _log) = collector();
+        let stages = vec![
+            Fake::new("a", StageOutcome::Fatal(StageError::NotFound)),
+            Fake::new("b", StageOutcome::Success(tab("b"))),
+        ];
+        let err = run_import(stages, None, emit).await.unwrap_err();
+        assert!(err.contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn skip_is_silent_and_total_counts_applicable_only() {
+        let (emit, log) = collector();
+        let stages = vec![
+            Fake::skipped("desktop-only"),
+            Fake::new("b", StageOutcome::Success(tab("b"))),
+        ];
+        let res = run_import(stages, None, emit).await.unwrap();
+        assert_eq!(res.source, "b");
+        let log = log.lock().unwrap();
+        // Only "b" is applicable → total must be 1.
+        match &log[0] {
+            ImportProgress::StageStart { total, index, .. } => {
+                assert_eq!(*total, 1);
+                assert_eq!(*index, 1);
+            }
+            other => panic!("unexpected first event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preferred_stage_runs_first() {
+        let (emit, log) = collector();
+        let stages = vec![
+            Fake::new("a", StageOutcome::RetryNext(StageError::Challenged)),
+            Fake::new("b", StageOutcome::Success(tab("b"))),
+        ];
+        let res = run_import(stages, Some("b"), emit).await.unwrap();
+        assert_eq!(res.source, "b");
+        // "b" was promoted to the front, so it is the first (and only) start.
+        let log = log.lock().unwrap();
+        match &log[0] {
+            ImportProgress::StageStart { id, .. } => assert_eq!(id, "b"),
+            other => panic!("unexpected first event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn slow_stage_times_out_and_advances() {
+        let (emit, _log) = collector();
+        let stages = vec![
+            Fake::slow("a", Duration::from_millis(500)), // exceeds 50ms timeout
+            Fake::new("b", StageOutcome::Success(tab("b"))),
+        ];
+        let res = run_import(stages, None, emit).await.unwrap();
+        assert_eq!(res.source, "b");
+    }
+}

--- a/apps/klank/src-tauri/src/import/stages/mod.rs
+++ b/apps/klank/src-tauri/src/import/stages/mod.rs
@@ -1,0 +1,49 @@
+//! The concrete import stages and the ordered registry that lists them.
+//!
+//! To add an import method: write a new `ImportStage` module here and add one
+//! line to [`build_stages`]. To remove one: delete its line. Nothing else
+//! (including the frontend) needs to change.
+
+mod ug_mobile_api;
+mod ug_website;
+
+use super::ImportStage;
+
+/// Builds the ordered list of stages, injecting each with the dependencies it
+/// needs. Order here is the default attempt order (the pipeline may promote the
+/// last-successful stage to the front).
+pub fn build_stages(
+    app: tauri::AppHandle,
+    url: String,
+    http: reqwest::Client,
+) -> Vec<Box<dyn ImportStage>> {
+    vec![
+        Box::new(ug_mobile_api::UgMobileApi::new(app.clone(), url.clone(), http.clone())),
+        Box::new(ug_website::UgWebsite::new(url.clone(), http.clone())),
+    ]
+}
+
+/// Shared helper: is this a URL we recognise as an Ultimate Guitar tab page?
+pub(crate) fn is_ug_url(url: &str) -> bool {
+    let host = url
+        .split("://")
+        .nth(1)
+        .and_then(|rest| rest.split(['/', '?', '#']).next())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    host == "ultimate-guitar.com" || host.ends_with(".ultimate-guitar.com")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_ug_url;
+
+    #[test]
+    fn recognises_ug_hosts() {
+        assert!(is_ug_url("https://tabs.ultimate-guitar.com/tab/x-1"));
+        assert!(is_ug_url("https://www.ultimate-guitar.com/tab/x-1"));
+        assert!(is_ug_url("https://ultimate-guitar.com/tab/x-1"));
+        assert!(!is_ug_url("https://evil-ultimate-guitar.com.example.com/x"));
+        assert!(!is_ug_url("https://example.com/tab"));
+    }
+}

--- a/apps/klank/src-tauri/src/import/stages/mod.rs
+++ b/apps/klank/src-tauri/src/import/stages/mod.rs
@@ -5,9 +5,16 @@
 //! (including the frontend) needs to change.
 
 mod ug_mobile_api;
+mod ug_webview;
 mod ug_website;
 
 use super::ImportStage;
+
+// Desktop-only IPC module for the hidden webview stage, re-exported for the
+// Tauri builder in `lib.rs`. The whole module is re-exported (not individual
+// items) so `generate_handler!` can resolve each command's hidden helpers.
+#[cfg(desktop)]
+pub use ug_webview::desktop;
 
 /// Builds the ordered list of stages, injecting each with the dependencies it
 /// needs. Order here is the default attempt order (the pipeline may promote the
@@ -20,6 +27,7 @@ pub fn build_stages(
     vec![
         Box::new(ug_mobile_api::UgMobileApi::new(app.clone(), url.clone(), http.clone())),
         Box::new(ug_website::UgWebsite::new(url.clone(), http.clone())),
+        Box::new(ug_webview::UgWebview::new(app.clone(), url.clone())),
     ]
 }
 

--- a/apps/klank/src-tauri/src/import/stages/ug_mobile_api.rs
+++ b/apps/klank/src-tauri/src/import/stages/ug_mobile_api.rs
@@ -1,0 +1,224 @@
+//! Primary import stage: Ultimate Guitar's mobile-app JSON API.
+//!
+//! This is the app's own API (`api.ultimate-guitar.com`), so it is **not**
+//! behind Cloudflare's browser challenges and works identically on desktop and
+//! Android with a plain HTTP request — no webview.
+//!
+//! The auth scheme was reverse-engineered from the Android app. All of its
+//! fragile pieces live here as named constants with a golden-hash unit test, so
+//! if UG changes the algorithm it is a one-file, one-test edit.
+
+use super::super::{ImportStage, NormalizedTab, StageError, StageOutcome};
+use super::is_ug_url;
+use std::time::Duration;
+
+// --- Fragile, reverse-engineered constants (keep together; covered by tests) ---
+const API_BASE: &str = "https://api.ultimate-guitar.com/api/v1";
+const APP_USER_AGENT: &str = "UGT_ANDROID/4.11.1 (Pixel; 8.1.0)";
+/// `X-UG-API-KEY = md5_hex(deviceId + utc(API_KEY_TIME_FMT) + API_KEY_SUFFIX)`.
+const API_KEY_SUFFIX: &str = "createLog()";
+const API_KEY_TIME_FMT: &str = "%Y-%m-%d:%H";
+// -------------------------------------------------------------------------------
+
+const DEVICE_ID_FILE: &str = "ug_device_id";
+
+pub struct UgMobileApi {
+    app: tauri::AppHandle,
+    url: String,
+    http: reqwest::Client,
+}
+
+impl UgMobileApi {
+    pub fn new(app: tauri::AppHandle, url: String, http: reqwest::Client) -> Self {
+        Self { app, url, http }
+    }
+}
+
+#[async_trait::async_trait]
+impl ImportStage for UgMobileApi {
+    fn id(&self) -> &'static str {
+        "ug-mobile-api"
+    }
+    fn label(&self) -> &'static str {
+        "Ultimate Guitar app API"
+    }
+    fn can_handle(&self) -> bool {
+        is_ug_url(&self.url)
+    }
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(8)
+    }
+
+    async fn run(&self) -> StageOutcome {
+        let Some(tab_id) = extract_tab_id(&self.url) else {
+            // No numeric id in the URL — let the website stage handle it.
+            return StageOutcome::RetryNext(StageError::Parse("no tab id in URL".into()));
+        };
+
+        let device_id = device_id(&self.app);
+        let api_key = api_key(&device_id, &chrono::Utc::now());
+        let req_url = format!("{API_BASE}/tab/info?tab_id={tab_id}&tab_access_type=private");
+
+        let resp = self
+            .http
+            .get(&req_url)
+            .header("User-Agent", APP_USER_AGENT)
+            .header("Accept", "application/json")
+            .header("Accept-Charset", "utf-8")
+            .header("X-UG-CLIENT-ID", &device_id)
+            .header("X-UG-API-KEY", api_key)
+            .send()
+            .await;
+
+        let resp = match resp {
+            Ok(r) => r,
+            Err(e) => return StageOutcome::RetryNext(StageError::Network(e.to_string())),
+        };
+
+        match resp.status().as_u16() {
+            200 => {}
+            401 | 403 => return StageOutcome::RetryNext(StageError::Unauthorized),
+            404 => return StageOutcome::Fatal(StageError::NotFound),
+            s => return StageOutcome::RetryNext(StageError::Network(format!("HTTP {s}"))),
+        }
+
+        let body = match resp.text().await {
+            Ok(b) => b,
+            Err(e) => return StageOutcome::RetryNext(StageError::Network(e.to_string())),
+        };
+
+        match parse_tab_info(&body) {
+            Some(tab) => StageOutcome::Success(tab),
+            None => StageOutcome::RetryNext(StageError::Parse("unexpected API response".into())),
+        }
+    }
+}
+
+/// Computes the `X-UG-API-KEY` header value.
+fn api_key(device_id: &str, now: &chrono::DateTime<chrono::Utc>) -> String {
+    let stamp = now.format(API_KEY_TIME_FMT).to_string();
+    let digest = md5::compute(format!("{device_id}{stamp}{API_KEY_SUFFIX}"));
+    format!("{digest:x}")
+}
+
+/// Extracts the trailing numeric tab id from a UG URL
+/// (`.../creep-chords-4169` -> `4169`). Query/fragment are ignored.
+fn extract_tab_id(url: &str) -> Option<u64> {
+    let path = url.split(['?', '#']).next().unwrap_or(url);
+    let digits: String = path
+        .chars()
+        .rev()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
+/// Parses the `/tab/info` response into a [`NormalizedTab`]. Returns `None` if
+/// the expected fields are missing/empty so the caller can fall through.
+fn parse_tab_info(body: &str) -> Option<NormalizedTab> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    let content = v.get("content")?.as_str()?.to_string();
+    if content.trim().is_empty() {
+        return None;
+    }
+    let artist = v
+        .get("artist_name")
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string();
+    let song = v
+        .get("song_name")
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string();
+    Some(NormalizedTab {
+        content,
+        artist,
+        song,
+        source: "ug-mobile-api",
+    })
+}
+
+/// Returns a stable 16-hex-char device id, generating and persisting one on
+/// first use. Best-effort persistence; falls back to an in-memory id.
+fn device_id(app: &tauri::AppHandle) -> String {
+    use tauri::Manager;
+    let path = app
+        .path()
+        .app_config_dir()
+        .ok()
+        .map(|d| d.join(DEVICE_ID_FILE));
+
+    if let Some(p) = &path {
+        if let Ok(existing) = std::fs::read_to_string(p) {
+            let existing = existing.trim().to_string();
+            if existing.len() == 16 && existing.chars().all(|c| c.is_ascii_hexdigit()) {
+                return existing;
+            }
+        }
+    }
+
+    let id: String = (0..16)
+        .map(|_| format!("{:x}", rand::random::<u8>() & 0xf))
+        .collect();
+
+    if let Some(p) = &path {
+        if let Some(dir) = p.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        let _ = std::fs::write(p, &id);
+    }
+    id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn api_key_is_md5_of_device_stamp_suffix() {
+        // Golden value pins the algorithm. If UG changes it, update here and the
+        // constants above together.
+        let now = chrono::Utc.with_ymd_and_hms(2026, 6, 13, 7, 0, 0).unwrap();
+        let device = "0123456789abcdef";
+        let expected = format!("{:x}", md5::compute("0123456789abcdef2026-06-13:07createLog()"));
+        assert_eq!(api_key(device, &now), expected);
+    }
+
+    #[test]
+    fn extracts_trailing_tab_id() {
+        assert_eq!(
+            extract_tab_id("https://tabs.ultimate-guitar.com/tab/radiohead/creep-chords-4169"),
+            Some(4169)
+        );
+        assert_eq!(
+            extract_tab_id("https://tabs.ultimate-guitar.com/tab/x-1?foo=bar#frag"),
+            Some(1)
+        );
+        assert_eq!(extract_tab_id("https://tabs.ultimate-guitar.com/tab/no-id"), None);
+    }
+
+    #[test]
+    fn parses_tab_info_response() {
+        let body = r#"{"id":1,"song_name":"Creep","artist_name":"Radiohead","type":"Chords","content":"[ch]G[/ch] hi"}"#;
+        let tab = parse_tab_info(body).unwrap();
+        assert_eq!(tab.artist, "Radiohead");
+        assert_eq!(tab.song, "Creep");
+        assert!(tab.content.contains("[ch]G[/ch]"));
+        assert_eq!(tab.source, "ug-mobile-api");
+    }
+
+    #[test]
+    fn rejects_empty_content() {
+        let body = r#"{"song_name":"x","artist_name":"y","content":"  "}"#;
+        assert!(parse_tab_info(body).is_none());
+    }
+}

--- a/apps/klank/src-tauri/src/import/stages/ug_website.rs
+++ b/apps/klank/src-tauri/src/import/stages/ug_website.rs
@@ -74,7 +74,7 @@ impl ImportStage for UgWebsite {
             return StageOutcome::RetryNext(StageError::Challenged);
         };
 
-        match parse_store(&json) {
+        match parse_store(&json, self.id()) {
             Some(tab) => StageOutcome::Success(tab),
             None => StageOutcome::RetryNext(StageError::Parse("unexpected page shape".into())),
         }
@@ -99,7 +99,8 @@ fn extract_js_store(html: &str) -> Option<String> {
 }
 
 /// Navigates the `store.page.data` JSON to the tab content + metadata.
-fn parse_store(json: &str) -> Option<NormalizedTab> {
+/// Shared with the webview stage, which delivers the same `{ store: … }` shape.
+pub(crate) fn parse_store(json: &str, source: &'static str) -> Option<NormalizedTab> {
     let v: serde_json::Value = serde_json::from_str(json).ok()?;
     let data = v.get("store")?.get("page")?.get("data")?;
     let content = data
@@ -126,7 +127,7 @@ fn parse_store(json: &str) -> Option<NormalizedTab> {
         content,
         artist,
         song,
-        source: "ug-website",
+        source,
     })
 }
 
@@ -147,7 +148,7 @@ mod tests {
             "tab_view":{"wiki_tab":{"content":"[tab]riff[/tab]"}},
             "tab":{"artist_name":"Nirvana","song_name":"Polly"}
         }}}}"#;
-        let tab = parse_store(json).unwrap();
+        let tab = parse_store(json, "ug-website").unwrap();
         assert_eq!(tab.artist, "Nirvana");
         assert_eq!(tab.song, "Polly");
         assert!(tab.content.contains("riff"));

--- a/apps/klank/src-tauri/src/import/stages/ug_website.rs
+++ b/apps/klank/src-tauri/src/import/stages/ug_website.rs
@@ -1,0 +1,161 @@
+//! Fallback import stage: scrape the public UG tab page over plain HTTP.
+//!
+//! On a cold (cookie-less) visit, UG server-renders the full tab payload into
+//! `<div class="js-store" data-content="...">` (HTML-escaped JSON, top-level
+//! `store`). We fetch with realistic browser headers and read that attribute —
+//! no browser required. Covers the case where the mobile API changes.
+
+use super::super::{ImportStage, NormalizedTab, StageError, StageOutcome};
+use super::is_ug_url;
+use std::time::Duration;
+
+const BROWSER_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
+AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+
+pub struct UgWebsite {
+    url: String,
+    http: reqwest::Client,
+}
+
+impl UgWebsite {
+    pub fn new(url: String, http: reqwest::Client) -> Self {
+        Self { url, http }
+    }
+}
+
+#[async_trait::async_trait]
+impl ImportStage for UgWebsite {
+    fn id(&self) -> &'static str {
+        "ug-website"
+    }
+    fn label(&self) -> &'static str {
+        "Ultimate Guitar website"
+    }
+    fn can_handle(&self) -> bool {
+        is_ug_url(&self.url)
+    }
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(12)
+    }
+
+    async fn run(&self) -> StageOutcome {
+        let resp = self
+            .http
+            .get(&self.url)
+            .header("User-Agent", BROWSER_UA)
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .header("Referer", "https://www.ultimate-guitar.com/")
+            .send()
+            .await;
+
+        let resp = match resp {
+            Ok(r) => r,
+            Err(e) => return StageOutcome::RetryNext(StageError::Network(e.to_string())),
+        };
+
+        match resp.status().as_u16() {
+            200 => {}
+            403 | 429 | 503 => return StageOutcome::RetryNext(StageError::Challenged),
+            404 => return StageOutcome::Fatal(StageError::NotFound),
+            s => return StageOutcome::RetryNext(StageError::Network(format!("HTTP {s}"))),
+        }
+
+        let body = match resp.text().await {
+            Ok(b) => b,
+            Err(e) => return StageOutcome::RetryNext(StageError::Network(e.to_string())),
+        };
+
+        let Some(json) = extract_js_store(&body) else {
+            // No js-store usually means a Cloudflare/consent interstitial.
+            return StageOutcome::RetryNext(StageError::Challenged);
+        };
+
+        match parse_store(&json) {
+            Some(tab) => StageOutcome::Success(tab),
+            None => StageOutcome::RetryNext(StageError::Parse("unexpected page shape".into())),
+        }
+    }
+}
+
+/// Extracts and HTML-decodes the `data-content` attribute of the `js-store`
+/// div. Inner quotes are entity-escaped, so the closing quote is unambiguous.
+fn extract_js_store(html: &str) -> Option<String> {
+    let anchor = html.find("js-store")?;
+    let rest = &html[anchor..];
+    let attr = rest.find("data-content=")?;
+    let after = &rest[attr + "data-content=".len()..];
+    let quote = after.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let after = &after[quote.len_utf8()..];
+    let end = after.find(quote)?;
+    let raw = &after[..end];
+    Some(html_escape::decode_html_entities(raw).into_owned())
+}
+
+/// Navigates the `store.page.data` JSON to the tab content + metadata.
+fn parse_store(json: &str) -> Option<NormalizedTab> {
+    let v: serde_json::Value = serde_json::from_str(json).ok()?;
+    let data = v.get("store")?.get("page")?.get("data")?;
+    let content = data
+        .get("tab_view")?
+        .get("wiki_tab")?
+        .get("content")?
+        .as_str()?
+        .to_string();
+    if content.trim().is_empty() {
+        return None;
+    }
+    let tab = data.get("tab");
+    let artist = tab
+        .and_then(|t| t.get("artist_name"))
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string();
+    let song = tab
+        .and_then(|t| t.get("song_name"))
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string();
+    Some(NormalizedTab {
+        content,
+        artist,
+        song,
+        source: "ug-website",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_and_decodes_data_content() {
+        let html = r#"<div class="js-store" data-content="{&quot;store&quot;:{&quot;x&quot;:1}}"></div>"#;
+        let got = extract_js_store(html).unwrap();
+        assert_eq!(got, r#"{"store":{"x":1}}"#);
+    }
+
+    #[test]
+    fn parses_store_to_normalized_tab() {
+        let json = r#"{"store":{"page":{"data":{
+            "tab_view":{"wiki_tab":{"content":"[tab]riff[/tab]"}},
+            "tab":{"artist_name":"Nirvana","song_name":"Polly"}
+        }}}}"#;
+        let tab = parse_store(json).unwrap();
+        assert_eq!(tab.artist, "Nirvana");
+        assert_eq!(tab.song, "Polly");
+        assert!(tab.content.contains("riff"));
+        assert_eq!(tab.source, "ug-website");
+    }
+
+    #[test]
+    fn missing_js_store_returns_none() {
+        assert!(extract_js_store("<html>no store here</html>").is_none());
+    }
+}

--- a/apps/klank/src-tauri/src/import/stages/ug_webview.rs
+++ b/apps/klank/src-tauri/src/import/stages/ug_webview.rs
@@ -10,7 +10,7 @@
 //! - Android: a self-owned 1×1 `android.webkit.WebView` in a Kotlin plugin
 //!   (wired in a follow-up; `can_handle` is false off-desktop until then).
 
-#[cfg(desktop)]
+#[cfg(any(desktop, target_os = "android"))]
 use super::is_ug_url;
 use super::super::{ImportStage, StageOutcome};
 use std::time::Duration;
@@ -109,7 +109,7 @@ pub(crate) const SHARED_SCRIPT: &str = r#"
 "#;
 
 pub struct UgWebview {
-    #[cfg_attr(not(desktop), allow(dead_code))]
+    #[cfg_attr(all(not(desktop), not(target_os = "android")), allow(dead_code))]
     app: tauri::AppHandle,
     url: String,
 }
@@ -129,13 +129,12 @@ impl ImportStage for UgWebview {
         "Ultimate Guitar (browser)"
     }
     fn can_handle(&self) -> bool {
-        // Desktop only for now; the Android Kotlin-plugin impl lands next and
-        // will extend this to `target_os = "android"`.
-        #[cfg(desktop)]
+        // Desktop (hidden WRY window) and Android (self-owned WebView plugin).
+        #[cfg(any(desktop, target_os = "android"))]
         {
             is_ug_url(&self.url)
         }
-        #[cfg(not(desktop))]
+        #[cfg(not(any(desktop, target_os = "android")))]
         {
             false
         }
@@ -145,12 +144,43 @@ impl ImportStage for UgWebview {
     }
     async fn run(&self) -> StageOutcome {
         #[cfg(desktop)]
-        {
-            desktop::scrape(&self.app, &self.url).await
-        }
-        #[cfg(not(desktop))]
-        {
-            StageOutcome::Skip
+        return desktop::scrape(&self.app, &self.url).await;
+        #[cfg(target_os = "android")]
+        return android::scrape(&self.app, &self.url).await;
+        #[cfg(not(any(desktop, target_os = "android")))]
+        return StageOutcome::Skip;
+    }
+}
+
+/// Android implementation: a self-owned offscreen `android.webkit.WebView` in
+/// the `ug-scraper` plugin (outside WRY). `run_mobile_plugin` blocks, so it runs
+/// on a blocking thread.
+#[cfg(target_os = "android")]
+mod android {
+    use super::super::super::{StageError, StageOutcome};
+    use super::super::ug_website::parse_store;
+    use super::SHARED_SCRIPT;
+    use tauri_plugin_ug_scraper::UgScraperExt;
+
+    pub async fn scrape(app: &tauri::AppHandle, url: &str) -> StageOutcome {
+        let app = app.clone();
+        let url = url.to_string();
+        let result = tokio::task::spawn_blocking(move || {
+            app.ug_scraper().scrape(url, SHARED_SCRIPT.to_string())
+        })
+        .await;
+
+        match result {
+            Ok(Ok(resp)) => match resp.html {
+                Some(html) => match parse_store(&html, "ug-webview") {
+                    Some(tab) => StageOutcome::Success(tab),
+                    None => StageOutcome::RetryNext(StageError::Parse("could not parse tab data".into())),
+                },
+                // No html → timeout / unsolved challenge.
+                None => StageOutcome::RetryNext(StageError::Challenged),
+            },
+            Ok(Err(e)) => StageOutcome::RetryNext(StageError::Network(e)),
+            Err(e) => StageOutcome::RetryNext(StageError::Network(e.to_string())),
         }
     }
 }

--- a/apps/klank/src-tauri/src/import/stages/ug_webview.rs
+++ b/apps/klank/src-tauri/src/import/stages/ug_webview.rs
@@ -1,0 +1,284 @@
+//! Last-resort import stage: load the page in a **real browser**, hidden.
+//!
+//! Unified design across platforms — the scraper surface is created invisible
+//! and only revealed if a Cloudflare *interactive* challenge is detected; real
+//! Chromium clears managed/JS challenges automatically while hidden. One shared
+//! script ([`SHARED_SCRIPT`]) drives extraction + challenge detection on both
+//! platforms; only the native show/hide primitive differs:
+//!
+//! - Desktop: a hidden `WebviewWindow` (this module).
+//! - Android: a self-owned 1×1 `android.webkit.WebView` in a Kotlin plugin
+//!   (wired in a follow-up; `can_handle` is false off-desktop until then).
+
+#[cfg(desktop)]
+use super::is_ug_url;
+use super::super::{ImportStage, StageOutcome};
+use std::time::Duration;
+
+/// Extraction + challenge-detection script, injected at document start. Routes
+/// its two outbound signals through `window.__ugDeliver` / `window.__ugChallenge`
+/// shims that pick whichever transport exists (Tauri IPC on desktop, the
+/// `__ugBridge` `@JavascriptInterface` on Android), so the body is identical on
+/// both platforms.
+pub(crate) const SHARED_SCRIPT: &str = r#"
+(function () {
+  window.__ugDeliver = function (html) {
+    try { if (window.__ugBridge && window.__ugBridge.deliver) { window.__ugBridge.deliver(html); return; } } catch (e) {}
+    try { var i = window.__TAURI_INTERNALS__; if (i && i.invoke) i.invoke('deliver_ug_html', { html }); } catch (e) {}
+  };
+  window.__ugChallenge = function () {
+    try { if (window.__ugBridge && window.__ugBridge.challenge) { window.__ugBridge.challenge(); return; } } catch (e) {}
+    try { var i = window.__TAURI_INTERNALS__; if (i && i.invoke) i.invoke('report_ug_challenge'); } catch (e) {}
+  };
+
+  var isTop = (function () { try { return window.top === window.self; } catch (_) { return false; } })();
+  var host = location.hostname || '';
+  var isUg = /ultimate-guitar\.com$/i.test(host);
+  var isCmp = /(consensu\.org|privacy-mgmt\.com|sp-prod\.net|sourcepoint|quantcast|cookielaw\.org|onetrust|trustarc|didomi|cmp\.)/i.test(host);
+  if (isTop) { if (!isUg) return; } else { if (!isCmp) return; }
+  if (window.__ug_scrape_started) return;
+  window.__ug_scrape_started = true;
+
+  var consentTexts = ['agree', 'accept', 'accept all', 'i accept', 'i agree', 'consent', 'allow all', 'akzeptieren', 'accepter', 'souhlasím', 'zustimmen'];
+  function tryClickConsent() {
+    var nodes = document.querySelectorAll('button,[role="button"],a,input[type="button"],input[type="submit"]');
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      var t = ((n.innerText || n.textContent || n.value || '') + '').trim().toLowerCase();
+      if (t && consentTexts.some(function (x) { return t === x || t.startsWith(x); })) {
+        try { n.click(); return true; } catch (_) {}
+      }
+    }
+    return false;
+  }
+
+  // In CMP iframes we only click accept; the data lives on the parent page.
+  if (!isTop) {
+    var clicked = false;
+    var cmpIv = setInterval(function () { if (!clicked && tryClickConsent()) clicked = true; }, 500);
+    tryClickConsent();
+    setTimeout(function () { clearInterval(cmpIv); }, 20000);
+    return;
+  }
+
+  var delivered = false;
+  function findStore() {
+    try {
+      var s = window.UGAPP && window.UGAPP.store;
+      if (s && s.page && s.page.data && s.page.data.tab_view) return JSON.stringify({ store: s });
+    } catch (_) {}
+    var el = document.querySelector('.js-store');
+    if (el) { var dc = el.getAttribute('data-content'); if (dc) return dc; }
+    return null;
+  }
+  function tryGrab() {
+    if (delivered) return true;
+    var dc = findStore();
+    if (dc) { delivered = true; window.__ugDeliver(dc); return true; }
+    return false;
+  }
+
+  function looksLikeChallenge() {
+    var t = (document.title || '').toLowerCase();
+    if (t.indexOf('just a moment') !== -1 || t.indexOf('attention required') !== -1 || t.indexOf('verifying') !== -1) return true;
+    return !!document.querySelector('#challenge-form, #challenge-running, iframe[src*="challenges.cloudflare.com"], .cf-turnstile');
+  }
+
+  var start = Date.now();
+  var challengeSignaled = false;
+  tryGrab();
+  document.addEventListener('DOMContentLoaded', function () { tryGrab(); tryClickConsent(); }, { once: true });
+
+  var iv = setInterval(function () {
+    if (tryGrab()) { clearInterval(iv); return; }
+    if (!challengeSignaled && Date.now() - start > 4000 && looksLikeChallenge()) {
+      challengeSignaled = true;
+      window.__ugChallenge();
+    }
+  }, 150);
+
+  var obs = new MutationObserver(function () { if (tryGrab()) { obs.disconnect(); clearInterval(iv); } });
+  (function startObs() {
+    if (document.documentElement) obs.observe(document.documentElement, { childList: true, subtree: true });
+    else document.addEventListener('DOMContentLoaded', startObs, { once: true });
+  })();
+  tryClickConsent();
+
+  setTimeout(function () { obs.disconnect(); clearInterval(iv); }, 40000);
+})();
+"#;
+
+pub struct UgWebview {
+    #[cfg_attr(not(desktop), allow(dead_code))]
+    app: tauri::AppHandle,
+    url: String,
+}
+
+impl UgWebview {
+    pub fn new(app: tauri::AppHandle, url: String) -> Self {
+        Self { app, url }
+    }
+}
+
+#[async_trait::async_trait]
+impl ImportStage for UgWebview {
+    fn id(&self) -> &'static str {
+        "ug-webview"
+    }
+    fn label(&self) -> &'static str {
+        "Ultimate Guitar (browser)"
+    }
+    fn can_handle(&self) -> bool {
+        // Desktop only for now; the Android Kotlin-plugin impl lands next and
+        // will extend this to `target_os = "android"`.
+        #[cfg(desktop)]
+        {
+            is_ug_url(&self.url)
+        }
+        #[cfg(not(desktop))]
+        {
+            false
+        }
+    }
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(45)
+    }
+    async fn run(&self) -> StageOutcome {
+        #[cfg(desktop)]
+        {
+            desktop::scrape(&self.app, &self.url).await
+        }
+        #[cfg(not(desktop))]
+        {
+            StageOutcome::Skip
+        }
+    }
+}
+
+/// Desktop implementation: a hidden `WebviewWindow` revealed only on a
+/// Cloudflare challenge. The IPC commands and state live here and are wired into
+/// the Tauri builder in `lib.rs` (desktop only).
+#[cfg(desktop)]
+pub mod desktop {
+    use super::super::super::{StageError, StageOutcome};
+    use super::super::ug_website::parse_store;
+    use super::SHARED_SCRIPT;
+    use std::sync::Mutex;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
+    use tokio::sync::oneshot;
+
+    /// Shared state linking the injected JS callbacks to the waiting scrape.
+    #[derive(Default)]
+    pub struct UgWebviewState {
+        tx: Mutex<Option<oneshot::Sender<String>>>,
+        label: Mutex<Option<String>>,
+    }
+
+    /// IPC: the injected JS delivers the extracted `{ store: … }` JSON.
+    #[tauri::command]
+    pub fn deliver_ug_html(state: State<'_, UgWebviewState>, html: String) {
+        if let Some(tx) = state.tx.lock().unwrap().take() {
+            let _ = tx.send(html);
+        }
+    }
+
+    /// IPC: the injected JS detected an interactive challenge — reveal the
+    /// otherwise-hidden window so the user can solve it.
+    #[tauri::command]
+    pub fn report_ug_challenge(app: tauri::AppHandle, state: State<'_, UgWebviewState>) {
+        let label = state.label.lock().unwrap().clone();
+        if let Some(label) = label {
+            if let Some(w) = app.get_webview_window(&label) {
+                let _ = w.show();
+                let _ = w.set_focus();
+            }
+        }
+    }
+
+    fn cleanup(app: &tauri::AppHandle, state: &UgWebviewState, label: &str) {
+        if let Some(w) = app.get_webview_window(label) {
+            let _ = w.close();
+        }
+        *state.tx.lock().unwrap() = None;
+        *state.label.lock().unwrap() = None;
+    }
+
+    pub async fn scrape(app: &tauri::AppHandle, url: &str) -> StageOutcome {
+        let state = app.state::<UgWebviewState>();
+
+        let parsed: tauri::Url = match url.parse() {
+            Ok(u) => u,
+            Err(e) => return StageOutcome::Fatal(StageError::Parse(format!("invalid url: {e}"))),
+        };
+
+        let (tx, rx) = oneshot::channel::<String>();
+        {
+            let mut guard = state.tx.lock().unwrap();
+            if guard.is_some() {
+                return StageOutcome::RetryNext(StageError::Network(
+                    "another scrape is in progress".into(),
+                ));
+            }
+            *guard = Some(tx);
+        }
+        let label = format!("ug-scraper-{}", now_nanos());
+        *state.label.lock().unwrap() = Some(label.clone());
+
+        // Window creation must run on the main thread. Built hidden.
+        let (btx, brx) = oneshot::channel::<Result<(), String>>();
+        let app_main = app.clone();
+        let label_main = label.clone();
+        let _ = app.run_on_main_thread(move || {
+            let res = WebviewWindowBuilder::new(
+                &app_main,
+                &label_main,
+                WebviewUrl::External(parsed),
+            )
+            .visible(false)
+            .focused(false)
+            .skip_taskbar(true)
+            .title("Loading tab…")
+            .inner_size(900.0, 700.0)
+            .initialization_script(SHARED_SCRIPT)
+            .build()
+            .map(|_| ())
+            .map_err(|e| e.to_string());
+            let _ = btx.send(res);
+        });
+
+        match brx.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                cleanup(app, &state, &label);
+                return StageOutcome::RetryNext(StageError::Network(e));
+            }
+            Err(e) => {
+                cleanup(app, &state, &label);
+                return StageOutcome::RetryNext(StageError::Network(e.to_string()));
+            }
+        }
+
+        let result = tokio::time::timeout(Duration::from_secs(40), rx).await;
+        cleanup(app, &state, &label);
+
+        match result {
+            Ok(Ok(html)) => match parse_store(&html, "ug-webview") {
+                Some(tab) => StageOutcome::Success(tab),
+                None => StageOutcome::RetryNext(StageError::Parse("could not parse tab data".into())),
+            },
+            Ok(Err(_)) => {
+                StageOutcome::RetryNext(StageError::Network("scrape channel closed".into()))
+            }
+            // Timed out — most likely an unsolved challenge.
+            Err(_) => StageOutcome::RetryNext(StageError::Challenged),
+        }
+    }
+
+    fn now_nanos() -> u128 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    }
+}

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 //! Tauri backend for klank. Exposes the `scrape_ug` IPC command, which imports
 //! a tab from an Ultimate Guitar URL through a layered, observable pipeline (see
 //! the [`import`] module).
+mod git;
 mod import;
 
 use import::ImportProgress;
@@ -25,21 +26,41 @@ pub fn run() {
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_shell::init());
+        .plugin(tauri_plugin_http::init());
 
     // The hidden-webview import stage (and its IPC) is desktop-only; Android
-    // uses the mobile API / website stages and (next) a dedicated plugin.
+    // uses the mobile API / website stages and (next) a dedicated plugin. Git
+    // commands are libgit2-based and run on every platform.
     #[cfg(desktop)]
     let builder = builder
         .manage(import::desktop::UgWebviewState::default())
         .invoke_handler(tauri::generate_handler![
             scrape_ug,
             import::desktop::deliver_ug_html,
-            import::desktop::report_ug_challenge
+            import::desktop::report_ug_challenge,
+            git::git_is_repo,
+            git::git_status,
+            git::git_pull,
+            git::git_commit,
+            git::git_push,
+            git::git_unpushed,
+            git::git_clone,
+            git::git_set_token,
+            git::git_has_token
         ]);
     #[cfg(not(desktop))]
-    let builder = builder.invoke_handler(tauri::generate_handler![scrape_ug]);
+    let builder = builder.invoke_handler(tauri::generate_handler![
+        scrape_ug,
+        git::git_is_repo,
+        git::git_status,
+        git::git_pull,
+        git::git_commit,
+        git::git_push,
+        git::git_unpushed,
+        git::git_clone,
+        git::git_set_token,
+        git::git_has_token
+    ]);
 
     builder
         .setup(|app| {

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -22,12 +22,26 @@ async fn scrape_ug(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_shell::init())
-        .invoke_handler(tauri::generate_handler![scrape_ug])
+        .plugin(tauri_plugin_shell::init());
+
+    // The hidden-webview import stage (and its IPC) is desktop-only; Android
+    // uses the mobile API / website stages and (next) a dedicated plugin.
+    #[cfg(desktop)]
+    let builder = builder
+        .manage(import::desktop::UgWebviewState::default())
+        .invoke_handler(tauri::generate_handler![
+            scrape_ug,
+            import::desktop::deliver_ug_html,
+            import::desktop::report_ug_challenge
+        ]);
+    #[cfg(not(desktop))]
+    let builder = builder.invoke_handler(tauri::generate_handler![scrape_ug]);
+
+    builder
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -26,7 +26,8 @@ pub fn run() {
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_http::init());
+        .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_ug_scraper::init());
 
     // The hidden-webview import stage (and its IPC) is desktop-only; Android
     // uses the mobile API / website stages and (next) a dedicated plugin. Git

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -1,292 +1,23 @@
-/// Tauri backend for klank. Exposes IPC commands for scraping Ultimate Guitar
-/// tab pages via an ephemeral hidden webview and delivers the raw page content
-/// back to the frontend through a oneshot channel.
-use std::sync::Mutex;
-use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
-use tokio::sync::oneshot;
+//! Tauri backend for klank. Exposes the `scrape_ug` IPC command, which imports
+//! a tab from an Ultimate Guitar URL through a layered, observable pipeline (see
+//! the [`import`] module).
+mod import;
 
-// Holds the oneshot sender that the JS side will fulfill via `deliver_ug_html`.
-struct UgScrapeState(Mutex<Option<oneshot::Sender<String>>>);
+use import::ImportProgress;
+use tauri::ipc::Channel;
 
-/// IPC callback invoked by the injected JavaScript inside the scraper webview.
-/// Sends the HTML string through the oneshot channel to unblock the waiting
-/// `scrape_ug` call. Should not be called directly from the main window.
+/// Imports a tab from a UG URL. Tries each import stage in order, streaming
+/// progress over `on_progress`, and returns the tab as JSON
+/// `{ content, artist, song }` (the frontend strips `[ch]`/`[tab]` markup and
+/// builds the filename). Returns `Err` with a human-readable summary if every
+/// stage fails.
 #[tauri::command]
-fn deliver_ug_html(state: tauri::State<'_, UgScrapeState>, html: String) {
-    eprintln!("[ug-scraper] received HTML, {} bytes", html.len());
-    if let Some(tx) = state.0.lock().unwrap().take() {
-        let _ = tx.send(html);
-    }
-}
-
-/// IPC callback for diagnostic logging from the injected JavaScript.
-/// Writes messages to stderr with the `[ug-scraper]` prefix.
-/// Used for debugging Cloudflare challenges and page detection failures.
-#[tauri::command]
-fn report_ug_error(msg: String) {
-    eprintln!("[ug-scraper] {msg}");
-}
-
-/// Scrapes a UG tab page and returns its raw content as `Ok(String)`.
-///
-/// Accepts a UG tab URL, opens a hidden webview (800×600, skip_taskbar) to load
-/// it, and injects JavaScript that detects the `.js-store` element or
-/// `window.UGAPP.store`, auto-accepts consent banners, and calls
-/// `deliver_ug_html` with the content. Enforces mutual exclusion — returns
-/// `Err` if a scrape is already in progress. Has a 35-second hard timeout;
-/// returns `Err` on timeout.
-#[tauri::command]
-async fn scrape_ug(app: tauri::AppHandle, url: String) -> Result<String, String> {
-    let state = app.state::<UgScrapeState>();
-    let (tx, rx) = oneshot::channel::<String>();
-    {
-        let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-        if guard.is_some() {
-            return Err("another UG scrape is already in progress".into());
-        }
-        *guard = Some(tx);
-    }
-
-    // Run the scrape and always release the slot when done, even on early error.
-    let result = run_scrape(&app, url, rx).await;
-    if let Ok(mut guard) = state.0.lock() {
-        *guard = None;
-    }
-    result
-}
-
-/// Inner implementation for `scrape_ug`. Separated so that any early `?` return
-/// still reaches the cleanup code in the outer function above.
-async fn run_scrape(app: &tauri::AppHandle, url: String, rx: oneshot::Receiver<String>) -> Result<String, String> {
-    // Polls the page until UG's `js-store` element is present (i.e. the real page,
-    // not a Cloudflare interstitial), then ships outerHTML back to Rust via IPC.
-    let init_script = r#"
-        (function () {
-            // Identify which kind of frame we're in. We want to run in two
-            // places: (a) the top UG frame, to poll for .js-store and ship it
-            // back to Rust; (b) any CMP iframe (Quantcast Choice / Sourcepoint
-            // / OneTrust / TrustArc / etc.) so we can click "Accept" inside it,
-            // which is what unlocks UG actually rendering .js-store on the
-            // parent page.
-            const isTop = (() => { try { return window.top === window.self; } catch (_) { return false; } })();
-            const host = location.hostname || '';
-            const isUg = /ultimate-guitar\.com$/i.test(host);
-            const isCmp = /(consensu\.org|privacy-mgmt\.com|sp-prod\.net|sourcepoint|quantcast|cookielaw\.org|onetrust|trustarc|didomi|cmp\.)/i.test(host);
-            if (isTop) {
-                if (!isUg) return;          // ignore non-UG top frames
-            } else {
-                if (!isCmp) return;         // ignore ad iframes; only run inside CMP iframes
-            }
-            if (window.__ug_scrape_started) return;
-            window.__ug_scrape_started = true;
-            const internals = window.__TAURI_INTERNALS__;
-            const report = (m) => {
-                try {
-                    if (internals && internals.invoke) {
-                        internals.invoke('report_ug_error', { msg: String(m) });
-                    }
-                } catch (_) {}
-                try { console.log('[ug-scraper]', m); } catch (_) {}
-            };
-            report('frame: ' + (isTop ? 'top' : 'iframe') + ' ' + host + ' | has internals: ' + !!internals);
-
-            const consentTexts = ['agree', 'accept', 'accept all', 'i accept', 'i agree', 'consent', 'allow all', 'akzeptieren', 'accepter', 'souhlasím', 'zustimmen'];
-            const tryClickConsent = () => {
-                const nodes = document.querySelectorAll('button, [role="button"], a, input[type="button"], input[type="submit"]');
-                for (const n of nodes) {
-                    const t = ((n.innerText || n.textContent || n.value || '') + '').trim().toLowerCase();
-                    if (t && consentTexts.some(x => t === x || t.startsWith(x))) {
-                        try { n.click(); report('clicked consent: ' + t + ' (frame=' + (isTop ? 'top' : 'iframe') + ')'); return true; } catch (_) {}
-                    }
-                }
-                return false;
-            };
-
-            // In CMP iframes, just click the accept button and stop — no
-            // polling for .js-store there (it lives on the parent UG page).
-            if (!isTop) {
-                let clicked = false;
-                const tick = () => { if (!clicked && tryClickConsent()) clicked = true; };
-                tick();
-                const cmpIv = setInterval(tick, 500);
-                setTimeout(() => clearInterval(cmpIv), 20000);
-                return;
-            }
-            let delivered = false;
-            const send = (html) => {
-                if (delivered) return;
-                if (!internals || !internals.invoke) {
-                    report('cannot deliver: __TAURI_INTERNALS__ missing');
-                    return;
-                }
-                try {
-                    const p = internals.invoke('deliver_ug_html', { html });
-                    delivered = true;
-                    report('deliver_ug_html invoked, html length=' + html.length);
-                    if (p && typeof p.catch === 'function') {
-                        p.catch((err) => {
-                            delivered = false;
-                            report('invoke failed: ' + (err && err.message ? err.message : err));
-                        });
-                    }
-                } catch (e) {
-                    report('invoke threw: ' + (e && e.message ? e.message : e));
-                }
-            };
-            const findStoreContent = () => {
-                // Preferred: UG hydrates this global early in their bundle.
-                try {
-                    const s = window.UGAPP && window.UGAPP.store;
-                    if (s && s.page && s.page.data && s.page.data.tab_view) {
-                        return JSON.stringify({ store: s });
-                    }
-                } catch (_) {}
-                // Fallback: server-rendered .js-store (only present on a cold,
-                // pre-consent visit; UG omits it once a CMP cookie is stored).
-                const el = document.querySelector('.js-store');
-                if (el) {
-                    const dc = el.getAttribute('data-content');
-                    if (dc) return dc;
-                }
-                return null;
-            };
-            const tryGrab = () => {
-                const dc = findStoreContent();
-                if (dc) { send(dc); return delivered; }
-                return false;
-            };
-
-            // `.js-store` is server-rendered into UG's initial HTML, so it is
-            // present the moment the real UG document starts parsing — no
-            // polling needed. We just need to act on whichever of these
-            // happens first: it's already there, the DOM finishes parsing,
-            // or (in case the page is replaced after a Cloudflare/consent
-            // navigation) it gets inserted later. A single MutationObserver
-            // covers the last case without busy-looping.
-            const start = Date.now();
-            const tryAndReport = (why) => {
-                const ok = tryGrab();
-                report(why + ' -> found=' + ok + ', elapsed=' + (Date.now() - start) + 'ms, title=' + document.title);
-                return ok;
-            };
-
-            // 1) Immediate attempt — works for the common case where the init
-            //    script runs after the HTML is already parsed.
-            if (tryAndReport('immediate')) return;
-
-            // 2) DOMContentLoaded — covers running before parse is complete.
-            const onReady = () => { if (!delivered) tryAndReport('DOMContentLoaded'); };
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', onReady, { once: true });
-            }
-
-            // 3) Fast poll for `window.UGAPP.store` to populate. UG sets this
-            //    from their JS bundle after hydration, which is NOT a DOM
-            //    mutation, so a MutationObserver wouldn't catch it. 50ms is
-            //    cheap (one property read) and gives sub-frame latency.
-            const iv = setInterval(() => {
-                if (delivered) { clearInterval(iv); return; }
-                if (tryGrab()) {
-                    clearInterval(iv);
-                    report('poll hit, elapsed=' + (Date.now() - start) + 'ms');
-                }
-            }, 50);
-            // Also a MutationObserver for the cold-visit `.js-store` fallback.
-            const obs = new MutationObserver(() => {
-                if (delivered) { obs.disconnect(); return; }
-                if (tryGrab()) { obs.disconnect(); clearInterval(iv); report('observer hit, elapsed=' + (Date.now() - start) + 'ms'); }
-            });
-            const startObs = () => {
-                if (document.documentElement) {
-                    obs.observe(document.documentElement, { childList: true, subtree: true });
-                } else {
-                    document.addEventListener('DOMContentLoaded', startObs, { once: true });
-                }
-            };
-            startObs();
-
-            // 4) Click any consent banner that's already there, then once more
-            //    when the DOM is ready — that's all the consent handling we need;
-            //    once Accept is clicked the MutationObserver picks up `.js-store`.
-            tryClickConsent();
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', () => tryClickConsent(), { once: true });
-            }
-
-            // 5) Safety timeout — give up after 30s instead of 60s, since we no
-            //    longer need polling slack.
-            setTimeout(() => {
-                if (delivered) return;
-                obs.disconnect();
-                clearInterval(iv);
-                report('timeout, store never appeared, title=' + document.title + ', hasUGAPP=' + !!window.UGAPP);
-            }, 30000);
-        })();
-    "#;
-
-    let parsed: tauri::Url = url.parse().map_err(|e| format!("invalid url: {e}"))?;
-    let label = format!("ug-scraper-{}", chrono_like_id());
-    let script = init_script.to_string();
-
-    // Window creation must happen on the main thread.
-    let app_for_main = app.clone();
-    let label_for_main = label.clone();
-    let (built_tx, built_rx) = oneshot::channel::<Result<(), String>>();
-    app.run_on_main_thread(move || {
-        let res = WebviewWindowBuilder::new(
-            &app_for_main,
-            &label_for_main,
-            WebviewUrl::External(parsed),
-        )
-        // Visible so Cloudflare's interactive challenge (checkbox) can be solved if needed.
-        .visible(true)
-        .focused(false)
-        .skip_taskbar(true)
-        .title("Loading tab…")
-        .inner_size(800.0, 600.0)
-        .initialization_script(&script)
-        .build()
-        .map_err(|e| e.to_string());
-        let res = match res {
-            Ok(_w) => {
-                #[cfg(debug_assertions)]
-                {
-                    _w.open_devtools();
-                }
-                Ok(())
-            }
-            Err(e) => Err(e),
-        };
-        let _ = built_tx.send(res);
-    })
-    .map_err(|e| e.to_string())?;
-
-    built_rx
-        .await
-        .map_err(|e| e.to_string())?
-        .map_err(|e| e)?;
-
-    // Wait for JS to deliver the HTML (with a hard upper bound).
-    let html_result = tokio::time::timeout(std::time::Duration::from_secs(35), rx).await;
-
-    // Close the hidden window regardless of outcome.
-    if let Some(w) = app.get_webview_window(&label) {
-        let _ = w.close();
-    }
-
-    match html_result {
-        Ok(Ok(html)) => Ok(html),
-        Ok(Err(_)) => Err("scrape channel closed (sender dropped before delivering HTML)".into()),
-        Err(_) => Err("timed out waiting for UG page to load".into()),
-    }
-}
-
-fn chrono_like_id() -> u128 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0)
+async fn scrape_ug(
+    app: tauri::AppHandle,
+    url: String,
+    on_progress: Channel<ImportProgress>,
+) -> Result<String, String> {
+    import::run(app, url, on_progress).await
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -296,8 +27,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init())
-        .manage(UgScrapeState(Mutex::new(None)))
-        .invoke_handler(tauri::generate_handler![scrape_ug, deliver_ug_html, report_ug_error])
+        .invoke_handler(tauri::generate_handler![scrape_ug])
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/Cargo.toml
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tauri-plugin-ug-scraper"
+version = "0.1.0"
+edition = "2021"
+description = "Android-only Tauri plugin that scrapes an Ultimate Guitar page using a self-owned, hidden android.webkit.WebView (outside WRY)."
+links = "tauri-plugin-ug-scraper"
+
+[dependencies]
+tauri = { version = "2.11.2" }
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"
+
+[build-dependencies]
+tauri-plugin = { version = "2", features = ["build"] }

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/android/.gitignore
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/android/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.tauri

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/android/build.gradle.kts
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/android/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "io.github.hampterworks.klank.ugscraper"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 24
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.webkit:webkit:1.14.0")
+    // Provided by the Tauri Android template (generated into the app project).
+    implementation(project(":tauri-android"))
+}

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/android/src/main/AndroidManifest.xml
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/android/src/main/java/io/github/hampterworks/klank/ugscraper/UgScraperPlugin.kt
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/android/src/main/java/io/github/hampterworks/klank/ugscraper/UgScraperPlugin.kt
@@ -1,0 +1,106 @@
+package io.github.hampterworks.klank.ugscraper
+
+import android.app.Activity
+import android.view.ViewGroup
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import app.tauri.annotation.Command
+import app.tauri.annotation.InvokeArg
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSObject
+import app.tauri.plugin.Plugin
+
+@InvokeArg
+class ScrapeArgs {
+    lateinit var url: String
+    lateinit var script: String
+}
+
+/**
+ * Scrapes an Ultimate Guitar page in a self-owned, hidden WebView.
+ *
+ * The WebView is added to the Activity content at 1×1 (hidden but attached, so
+ * JS and timers actually run — a detached WebView won't fire onPageFinished).
+ * The shared script is injected on page load and signals back through the
+ * `__ugBridge` JavaScript interface: `deliver(html)` resolves the call;
+ * `challenge()` reveals the WebView full-screen so the user can solve an
+ * interactive Cloudflare challenge. Everything is outside WRY, so none of the
+ * single-webview-per-Activity hazards apply.
+ */
+@TauriPlugin
+class UgScraperPlugin(private val activity: Activity) : Plugin(activity) {
+    private val timeoutMs = 40_000L
+
+    @Command
+    fun scrape(invoke: Invoke) {
+        val args = invoke.parseArgs(ScrapeArgs::class.java)
+        activity.runOnUiThread {
+            try {
+                start(args.url, args.script, invoke)
+            } catch (e: Exception) {
+                invoke.reject(e.message ?: "scrape failed")
+            }
+        }
+    }
+
+    private fun start(url: String, script: String, invoke: Invoke) {
+        val root = activity.findViewById<ViewGroup>(android.R.id.content)
+        val webView = WebView(activity)
+        val resolved = java.util.concurrent.atomic.AtomicBoolean(false)
+
+        // 1×1 = effectively invisible, but attached so JS/timers run.
+        root.addView(webView, FrameLayout.LayoutParams(1, 1))
+
+        fun cleanup() {
+            activity.runOnUiThread {
+                try {
+                    root.removeView(webView)
+                    webView.destroy()
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        fun finish(html: String?, error: String?) {
+            if (!resolved.compareAndSet(false, true)) return
+            val ret = JSObject()
+            if (html != null) ret.put("html", html)
+            if (error != null) ret.put("error", error)
+            invoke.resolve(ret)
+            cleanup()
+        }
+
+        webView.settings.javaScriptEnabled = true
+        webView.settings.domStorageEnabled = true
+
+        webView.addJavascriptInterface(object {
+            @JavascriptInterface
+            fun deliver(html: String) {
+                finish(html, null)
+            }
+
+            @JavascriptInterface
+            fun challenge() {
+                activity.runOnUiThread {
+                    val p = webView.layoutParams as FrameLayout.LayoutParams
+                    p.width = FrameLayout.LayoutParams.MATCH_PARENT
+                    p.height = FrameLayout.LayoutParams.MATCH_PARENT
+                    webView.layoutParams = p
+                    webView.bringToFront()
+                }
+            }
+        }, "__ugBridge")
+
+        webView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView, finishedUrl: String) {
+                view.evaluateJavascript(script, null)
+            }
+        }
+
+        webView.postDelayed({ finish(null, "timeout") }, timeoutMs)
+        webView.loadUrl(url)
+    }
+}

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/build.rs
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/build.rs
@@ -1,0 +1,7 @@
+const COMMANDS: &[&str] = &["scrape"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")
+        .build();
+}

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/permissions/autogenerated/commands/scrape.toml
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/permissions/autogenerated/commands/scrape.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-scrape"
+description = "Enables the scrape command without any pre-configured scope."
+commands.allow = ["scrape"]
+
+[[permission]]
+identifier = "deny-scrape"
+description = "Denies the scrape command without any pre-configured scope."
+commands.deny = ["scrape"]

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/permissions/autogenerated/reference.md
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/permissions/autogenerated/reference.md
@@ -1,0 +1,35 @@
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`ug-scraper:allow-scrape`
+
+</td>
+<td>
+
+Enables the scrape command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`ug-scraper:deny-scrape`
+
+</td>
+<td>
+
+Denies the scrape command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/permissions/schemas/schema.json
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/permissions/schemas/schema.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the scrape command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-scrape",
+          "markdownDescription": "Enables the scrape command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the scrape command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-scrape",
+          "markdownDescription": "Denies the scrape command without any pre-configured scope."
+        }
+      ]
+    }
+  }
+}

--- a/apps/klank/src-tauri/tauri-plugin-ug-scraper/src/lib.rs
+++ b/apps/klank/src-tauri/tauri-plugin-ug-scraper/src/lib.rs
@@ -1,0 +1,84 @@
+//! Android-only Tauri plugin that scrapes an Ultimate Guitar page using a
+//! **self-owned** `android.webkit.WebView`, deliberately outside WRY.
+//!
+//! WRY keeps a single webview per Android Activity (a second one overwrites it
+//! and steals IPC), which is why the previous secondary-`WebviewWindow` approach
+//! could never work on Android. This plugin creates its own 1×1 (hidden but
+//! attached, so JS/timers run) WebView, injects the shared extraction script,
+//! and receives the result through its own `@JavascriptInterface` bridge —
+//! touching none of WRY's `setContentView`/`mWebView`/`ACTIVITY_PROXY` state.
+//!
+//! It is invoked from Rust (the `ug-webview` import stage) via
+//! [`UgScraperExt::ug_scraper`], not from JS.
+
+use serde::Deserialize;
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Runtime,
+};
+
+#[cfg(target_os = "android")]
+use {serde::Serialize, tauri::plugin::PluginHandle, tauri::Manager};
+
+/// Arguments sent to the Android `scrape` command.
+#[cfg(target_os = "android")]
+#[derive(Serialize)]
+struct ScrapeArgs {
+    url: String,
+    /// The shared extraction + challenge-detection script to inject.
+    script: String,
+}
+
+/// Result returned by the Android `scrape` command. Exactly one of `html` /
+/// `error` is set.
+#[derive(Debug, Default, Deserialize)]
+pub struct ScrapeResponse {
+    /// The extracted `{ store: … }` JSON when the page yielded tab data.
+    pub html: Option<String>,
+    /// A failure reason (e.g. `"timeout"`) when scraping did not succeed.
+    pub error: Option<String>,
+}
+
+/// Handle to the registered Android plugin.
+#[cfg(target_os = "android")]
+pub struct UgScraper<R: Runtime>(PluginHandle<R>);
+
+#[cfg(target_os = "android")]
+impl<R: Runtime> UgScraper<R> {
+    /// Loads `url` in a hidden WebView, injects `script`, and resolves once the
+    /// page delivers tab data (or times out).
+    pub fn scrape(&self, url: String, script: String) -> Result<ScrapeResponse, String> {
+        self.0
+            .run_mobile_plugin("scrape", ScrapeArgs { url, script })
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// Extension trait to reach the plugin from an `AppHandle`/`Manager`.
+#[cfg(target_os = "android")]
+pub trait UgScraperExt<R: Runtime> {
+    fn ug_scraper(&self) -> &UgScraper<R>;
+}
+
+#[cfg(target_os = "android")]
+impl<R: Runtime, T: Manager<R>> UgScraperExt<R> for T {
+    fn ug_scraper(&self) -> &UgScraper<R> {
+        self.state::<UgScraper<R>>().inner()
+    }
+}
+
+/// Initializes the plugin. On non-Android targets this is a no-op shell so the
+/// crate still compiles and can be registered unconditionally.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("ug-scraper")
+        .setup(|_app, _api| {
+            #[cfg(target_os = "android")]
+            {
+                let handle = _api
+                    .register_android_plugin("io.github.hampterworks.klank.ugscraper", "UgScraperPlugin")?;
+                _app.manage(UgScraper(handle));
+            }
+            Ok(())
+        })
+        .build()
+}

--- a/libs/platform-api/package.json
+++ b/libs/platform-api/package.json
@@ -19,7 +19,6 @@
   "peerDependencies": {
     "@tauri-apps/plugin-fs": "^2.4.4",
     "@tauri-apps/api": "^2.9.0",
-    "@tauri-apps/plugin-dialog": "^2.4.2",
-    "@tauri-apps/plugin-shell": "^2.0.0"
+    "@tauri-apps/plugin-dialog": "^2.4.2"
   }
 }

--- a/libs/platform-api/src/lib/chord-symbol.spec.ts
+++ b/libs/platform-api/src/lib/chord-symbol.spec.ts
@@ -88,9 +88,18 @@ const chordStringArb = fc
     bass === null ? letter + accidental + suffix : `${letter}${accidental}${suffix}/${bass[0]}${bass[1]}`,
   )
 
-/** Parsed symbols with grammar-valid suffixes (the parser's output domain). */
+/**
+ * Parsed symbols with grammar-valid suffixes (the parser's output domain).
+ *
+ * A suffix that begins with a bare accidental (e.g. `♭5`) is excluded: such a
+ * symbol has no faithful text form — `pitchName(root) + "♭5"` glues the
+ * accidental onto the root note and re-parses to a different root — so it is
+ * outside the representable output domain. `formatChordSymbol` deliberately
+ * folds such leading accidentals into the root (see its docs).
+ */
+const representableSuffixArb = suffixArb.filter((s) => !/^[#b♭]/.test(s))
 const parsedArb: fc.Arbitrary<ParsedChordSymbol> = fc
-  .tuple(fc.integer({ min: 0, max: 11 }), suffixArb, fc.option(fc.integer({ min: 0, max: 11 })))
+  .tuple(fc.integer({ min: 0, max: 11 }), representableSuffixArb, fc.option(fc.integer({ min: 0, max: 11 })))
   .map(([rootPitch, suffix, bassPitch]) =>
     bassPitch === null ? { rootPitch, suffix } : { rootPitch, suffix, bassPitch },
   )

--- a/libs/platform-api/src/lib/chord-symbol.ts
+++ b/libs/platform-api/src/lib/chord-symbol.ts
@@ -102,14 +102,31 @@ export const parseChordSymbol = (token: string): ParsedChordSymbol | null => {
     : { rootPitch: root.pitch, suffix, bassPitch }
 }
 
+/** Semitone shift of a leading suffix accidental, used by `formatChordSymbol`. */
+const LEADING_ACCIDENTAL_SHIFT: Record<string, number> = { '#': 1, b: -1, '♭': -1 }
+
 /**
  * Renders a parsed symbol back to a string in canonical sharps-only form
  * (`{ rootPitch: 10, suffix: 'm7' }` → `A#m7`). Inverse of `parseChordSymbol`
  * up to enharmonic spelling of the input.
+ *
+ * A suffix can begin with an accidental (a bare `♭6`/`#11` alteration) only when
+ * the source note carried a double accidental (e.g. `B♭#6` parses to
+ * `{ A#, "#6" }`). Since `pitchName` is sharps-form, naively emitting
+ * `pitchName(root) + suffix` would glue them — `"A#" + "#6"` = `"A##6"` — which
+ * re-parses to a different root (`B6`), breaking `format∘parse` idempotency.
+ * We therefore fold any leading suffix accidentals into the root pitch, which is
+ * exactly what re-parsing does, so the output is a stable fixpoint.
  */
 export const formatChordSymbol = (parsed: ParsedChordSymbol): string => {
+  let rootPitch = parsed.rootPitch
+  let suffix = parsed.suffix
+  while (suffix.length > 0 && suffix[0] in LEADING_ACCIDENTAL_SHIFT) {
+    rootPitch = (((rootPitch + LEADING_ACCIDENTAL_SHIFT[suffix[0]]) % 12) + 12) % 12
+    suffix = suffix.slice(1)
+  }
   const bass = parsed.bassPitch !== undefined ? `/${pitchName(parsed.bassPitch)}` : ''
-  return `${pitchName(parsed.rootPitch)}${parsed.suffix}${bass}`
+  return `${pitchName(rootPitch)}${suffix}${bass}`
 }
 
 /**

--- a/libs/platform-api/src/lib/download.spec.ts
+++ b/libs/platform-api/src/lib/download.spec.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+
+// download.ts statically imports invoke + Channel from @tauri-apps/api/core, so
+// mock the module. The fake Channel lets a test drive progress callbacks.
+vi.mock('@tauri-apps/api/core', () => {
+  class Channel<T> {
+    onmessage: ((message: T) => void) | null = null
+  }
+  return { invoke: vi.fn(), Channel }
+})
+
+import { invoke } from '@tauri-apps/api/core'
+import { getSheetFromUG, type ImportProgress } from './download.js'
+
+const invokeMock = invoke as Mock
+
+describe('getSheetFromUG', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns undefined for a falsy url without invoking', async () => {
+    expect(await getSheetFromUG('')).toBeUndefined()
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  it('strips [ch]/[tab] markup and builds the filename', async () => {
+    invokeMock.mockResolvedValue(
+      JSON.stringify({ content: '[ch]G[/ch] [tab]riff[/tab]', artist: 'Radiohead', song: 'Creep' }),
+    )
+
+    const result = await getSheetFromUG('https://tabs.ultimate-guitar.com/tab/x-1')
+
+    expect(result).toEqual({ data: 'G riff', filename: 'Radiohead - Creep.tab.txt' })
+  })
+
+  it('forwards pipeline progress to onProgress in order', async () => {
+    const start: ImportProgress = { type: 'StageStart', id: 'ug-mobile-api', label: 'UG app API', index: 1, total: 2 }
+    const done: ImportProgress = { type: 'Succeeded', id: 'ug-mobile-api', label: 'UG app API' }
+
+    invokeMock.mockImplementation(async (_cmd: string, args: { onProgress?: { onmessage: (m: ImportProgress) => void } }) => {
+      args.onProgress?.onmessage(start)
+      args.onProgress?.onmessage(done)
+      return JSON.stringify({ content: 'plain', artist: 'A', song: 'B' })
+    })
+
+    const events: ImportProgress[] = []
+    const result = await getSheetFromUG('https://tabs.ultimate-guitar.com/tab/x-1', (p) => events.push(p))
+
+    expect(events).toEqual([start, done])
+    expect(result?.filename).toBe('A - B.tab.txt')
+  })
+
+  it('returns undefined when the payload has no content', async () => {
+    invokeMock.mockResolvedValue(JSON.stringify({ content: '', artist: 'A', song: 'B' }))
+    expect(await getSheetFromUG('https://tabs.ultimate-guitar.com/tab/x-1')).toBeUndefined()
+  })
+
+  it('returns undefined when the response is not valid JSON', async () => {
+    invokeMock.mockResolvedValue('<html>not json</html>')
+    expect(await getSheetFromUG('https://tabs.ultimate-guitar.com/tab/x-1')).toBeUndefined()
+  })
+
+  it('propagates a rejection when every import stage fails', async () => {
+    invokeMock.mockRejectedValue(new Error('all import methods failed — …'))
+    await expect(getSheetFromUG('https://tabs.ultimate-guitar.com/tab/x-1')).rejects.toThrow('all import methods failed')
+  })
+})

--- a/libs/platform-api/src/lib/download.ts
+++ b/libs/platform-api/src/lib/download.ts
@@ -1,40 +1,56 @@
-import { invoke } from '@tauri-apps/api/core'
+import { invoke, Channel } from '@tauri-apps/api/core'
 
 /**
- * Downloads a guitar tab from an Ultimate Guitar URL.
+ * Progress events streamed by the `scrape_ug` import pipeline, one per stage
+ * attempt. Mirrors the Rust `ImportProgress` enum (`#[serde(tag = "type")]`).
+ */
+export type ImportProgress =
+  | { type: 'StageStart'; id: string; label: string; index: number; total: number }
+  | { type: 'StageFailed'; id: string; label: string; reason: string }
+  | { type: 'Succeeded'; id: string; label: string }
+
+/** Normalised tab payload returned by the `scrape_ug` command on success. */
+type NormalizedTab = { content: string; artist: string; song: string }
+
+/**
+ * Imports a guitar tab from an Ultimate Guitar URL.
  *
- * Opens a hidden Tauri webview via the `scrape_ug` Rust command, which loads the
- * UG page in real Chromium (required for Cloudflare JS challenges). The webview
- * extracts the `.js-store` JSON and returns it to Rust; this function then parses
- * out the tab content and strips UG's `[ch]`/`[tab]` markup tags.
+ * Delegates to the Rust `scrape_ug` command, which runs a layered import
+ * pipeline (mobile API → website scrape → real-browser webview) and returns a
+ * normalised `{ content, artist, song }` payload. This function strips UG's
+ * `[ch]`/`[tab]` markup and builds the `Artist - Song.tab.txt` filename.
  *
  * @param url A valid Ultimate Guitar tab URL.
- * @returns `{ data, filename }` where `data` is the plain-text tab content and
- *          `filename` follows the `Artist - Song.tab.txt` convention, or
- *          `undefined` if `url` is falsy or parsing fails.
+ * @param onProgress Optional callback invoked for each pipeline stage, used to
+ *   show a nonintrusive "which method is running" status in the UI.
+ * @returns `{ data, filename }`, or `undefined` if `url` is falsy or the
+ *   response can't be parsed. Throws (rejects) if every import stage fails.
  */
-export const getSheetFromUG = async (url: string) => {
+export const getSheetFromUG = async (
+  url: string,
+  onProgress?: (progress: ImportProgress) => void,
+) => {
   if (!url) return
 
-  const dataContent = await invoke<string>('scrape_ug', { url })
-  if (!dataContent) return
+  let channel: Channel<ImportProgress> | undefined
+  if (onProgress) {
+    channel = new Channel<ImportProgress>()
+    channel.onmessage = onProgress
+  }
+
+  const raw = await invoke<string>('scrape_ug', { url, onProgress: channel })
+  if (!raw) return
 
   try {
-    const json = JSON.parse(dataContent)
+    const tab = JSON.parse(raw) as NormalizedTab
+    if (!tab.content) return
 
-    const content = json?.store?.page?.data?.tab_view?.wiki_tab?.content
-    if (content === undefined || content === null) return
-
-    const data = content.toString().replace(/\[\/?(ch|tab)\]/g, '')
-
-    const artist = json.store.page.data.tab?.artist_name ?? ''
-    const title = json.store.page.data.tab?.song_name ?? ''
-
-    const filename = `${artist} - ${title}.tab.txt`
+    const data = tab.content.replace(/\[\/?(ch|tab)\]/g, '')
+    const filename = `${tab.artist ?? ''} - ${tab.song ?? ''}.tab.txt`
     return { data, filename }
   } catch (error) {
-    // UG page shape changed or Cloudflare served an HTML challenge page
-    console.error('Failed to parse UG response:', error)
+    // Shape changed unexpectedly — surface nothing rather than a broken file.
+    console.error('Failed to parse UG import response:', error)
     return
   }
 }

--- a/libs/platform-api/src/lib/git.ts
+++ b/libs/platform-api/src/lib/git.ts
@@ -1,3 +1,5 @@
+import { invoke } from '@tauri-apps/api/core'
+
 export type GitChangedFile = { status: string; path: string }
 export type GitResult = { success: boolean; output: string; error?: string }
 
@@ -8,77 +10,47 @@ export type GitService = {
   commit: (dir: string, message: string) => Promise<GitResult>
   push: (dir: string) => Promise<GitResult>
   getUnpushedCommits: (dir: string) => Promise<string[]>
+  /** Clones `url` into `dir` (used to set up tab storage on mobile). */
+  cloneRepo: (url: string, dir: string) => Promise<GitResult>
+  /** Stores (or clears, when empty) the HTTPS Personal Access Token. */
+  setToken: (token: string) => Promise<void>
+  /** Whether a PAT is currently stored. */
+  hasToken: () => Promise<boolean>
 }
 
-const createTauriGitService = async (): Promise<GitService> => {
-  const { Command } = await import('@tauri-apps/plugin-shell')
-
-  const run = async (dir: string, args: string[]) => {
-    const output = await Command.create('git', args, { cwd: dir }).execute()
-    return { stdout: output.stdout, stderr: output.stderr, code: output.code }
-  }
-
-  return {
-    async isGitRepo(dir) {
-      try {
-        return (await run(dir, ['rev-parse', '--is-inside-work-tree'])).code === 0
-      } catch {
-        return false
-      }
-    },
-
-    async getChangedFiles(dir) {
-      try {
-        const { stdout, code } = await run(dir, ['status', '--porcelain'])
-        if (code !== 0) return []
-        return stdout
-          .trim()
-          .split('\n')
-          .filter(Boolean)
-          .map((line) => ({ status: line.slice(0, 2).trim(), path: line.slice(3).trim() }))
-      } catch {
-        return []
-      }
-    },
-
-    async pull(dir) {
-      try {
-        await run(dir, ['fetch'])
-        const { stdout, stderr, code } = await run(dir, ['pull', '--rebase'])
-        return { success: code === 0, output: stdout || stderr }
-      } catch (e) {
-        return { success: false, output: '', error: String(e) }
-      }
-    },
-
-    async commit(dir, message) {
-      try {
-        await run(dir, ['add', '-A'])
-        const { stdout, stderr, code } = await run(dir, ['commit', '-m', message])
-        return { success: code === 0, output: stdout || stderr }
-      } catch (e) {
-        return { success: false, output: '', error: String(e) }
-      }
-    },
-
-    async push(dir) {
-      try {
-        const { stdout, stderr, code } = await run(dir, ['push'])
-        return { success: code === 0, output: stdout || stderr }
-      } catch (e) {
-        return { success: false, output: '', error: String(e) }
-      }
-    },
-
-    async getUnpushedCommits(dir) {
-      try {
-        const { stdout, code } = await run(dir, ['log', '--oneline', '@{u}..HEAD'])
-        return code === 0 ? stdout.trim().split('\n').filter(Boolean) : []
-      } catch {
-        return []
-      }
-    },
-  }
-}
+/**
+ * Git operations backed by the in-app libgit2 engine (Rust commands), so sync
+ * works identically on desktop and Android. Read-only queries degrade
+ * gracefully; mutating operations return a `GitResult` carrying success/error.
+ */
+const createTauriGitService = async (): Promise<GitService> => ({
+  async isGitRepo(dir) {
+    try {
+      return await invoke<boolean>('git_is_repo', { dir })
+    } catch {
+      return false
+    }
+  },
+  async getChangedFiles(dir) {
+    try {
+      return await invoke<GitChangedFile[]>('git_status', { dir })
+    } catch {
+      return []
+    }
+  },
+  pull: (dir) => invoke<GitResult>('git_pull', { dir }),
+  commit: (dir, message) => invoke<GitResult>('git_commit', { dir, message }),
+  push: (dir) => invoke<GitResult>('git_push', { dir }),
+  async getUnpushedCommits(dir) {
+    try {
+      return await invoke<string[]>('git_unpushed', { dir })
+    } catch {
+      return []
+    }
+  },
+  cloneRepo: (url, dir) => invoke<GitResult>('git_clone', { url, dir }),
+  setToken: (token) => invoke<void>('git_set_token', { token }),
+  hasToken: () => invoke<boolean>('git_has_token'),
+})
 
 export const createGitService = async (): Promise<GitService> => createTauriGitService()

--- a/libs/platform-api/src/lib/userAgent.ts
+++ b/libs/platform-api/src/lib/userAgent.ts
@@ -1,3 +1,13 @@
 export const isMobile = (userAgent: string) => {
   return /android|iphone|ipad|ipod|mobile/i.test(userAgent)
 }
+
+/**
+ * Whether the app is running on a mobile device (Android/iOS). Used to hide
+ * desktop-only affordances such as the native folder picker. Safe during SSR
+ * (`navigator` may be undefined), where it returns false.
+ */
+export const isMobileDevice = (): boolean => {
+  const nav = (globalThis as { navigator?: { userAgent?: string } }).navigator
+  return typeof nav?.userAgent === 'string' && isMobile(nav.userAgent)
+}

--- a/libs/ui/src/lib/toolbar/Toolbar.tsx
+++ b/libs/ui/src/lib/toolbar/Toolbar.tsx
@@ -68,13 +68,15 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
   return (
     <li className={`${styles.container}${isCollapsed ? ' ' + styles.collapsed : ''}`} {...props}>
-      <ToolTip message="Change Folder">
-        <Button
-          onClick={() => handleBaseDirectoryChange()}
-          iconButton={true}
-          icon={<FolderIcon />}
-        />
-      </ToolTip>
+      {getDirectoryPath && (
+        <ToolTip message="Change Folder">
+          <Button
+            onClick={() => handleBaseDirectoryChange()}
+            iconButton={true}
+            icon={<FolderIcon />}
+          />
+        </ToolTip>
+      )}
       <ToolTip message="Refresh">
         <Button
           onClick={() => setNeedsUpdate(true)}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,9 +186,6 @@ importers:
       '@tauri-apps/plugin-fs':
         specifier: ^2.5.1
         version: 2.5.1
-      '@tauri-apps/plugin-shell':
-        specifier: ^2.0.0
-        version: 2.3.5
       isbot:
         specifier: ^4.4.0
         version: 4.4.0
@@ -232,9 +229,6 @@ importers:
       '@tauri-apps/plugin-fs':
         specifier: ^2.4.4
         version: 2.5.1
-      '@tauri-apps/plugin-shell':
-        specifier: ^2.0.0
-        version: 2.3.5
 
   libs/store:
     dependencies:
@@ -2239,9 +2233,6 @@ packages:
 
   '@tauri-apps/plugin-http@2.5.9':
     resolution: {integrity: sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==}
-
-  '@tauri-apps/plugin-shell@2.3.5':
-    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -8388,10 +8379,6 @@ snapshots:
       '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-http@2.5.9':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
-
-  '@tauri-apps/plugin-shell@2.3.5':
     dependencies:
       '@tauri-apps/api': 2.11.0
 


### PR DESCRIPTION
## Why

Android wasn't usable. The headline bug was **tab import**: `scrape_ug` spawned a *secondary* WRY webview and routed the result back via IPC — which doesn't work on Android, where WRY keeps a single webview per Activity (a second one overwrites it and steals IPC eval). The previous attempt chased WRY internals via JNI (`finish()`/`setContentView`/`setWebView`) and hit a SIGILL. This PR fixes import by **not needing a secondary WRY webview**, and makes the rest of the app work on Android.

## What changed

### Tab import — a pluggable, observable pipeline (`apps/klank/src-tauri/src/import/`)
Import is an ordered chain of `ImportStage`s behind one registry; adding/removing a method is one module + one registry line, and the UI renders whatever the backend streams.

| Stage | Mechanism | Desktop | Android |
|---|---|---|---|
| `ug-mobile-api` (primary) | UG's mobile-app JSON API (`/tab/info`, computed `X-UG-API-KEY`) — **not Cloudflare-gated**, pure Rust HTTP | ✅ | ✅ |
| `ug-website` | server-rendered `js-store` `data-content`, pure Rust HTTP | ✅ | ✅ |
| `ug-webview` | real browser, **hidden by default**, revealed only on an interactive Cloudflare challenge | ✅ hidden WRY window | ✅ self-owned `android.webkit.WebView` plugin |
| manual paste | textarea fallback in the modal | ✅ | ✅ |

- Outcomes `Success / Skip / RetryNext / Fatal` (a `Fatal` like 404 stops early); per-stage timeouts; **self-healing order** promotes the last successful stage.
- Progress streams over a typed `Channel<ImportProgress>`; the download modal shows a nonintrusive status line, a "what was tried" list, and the manual-paste fallback.
- `scrape_ug` returns normalized `{ content, artist, song }`; `download.ts` strips markup + builds the filename.

### The Android webview fix (`tauri-plugin-ug-scraper`)
The `ug-webview` stage on Android uses a **local Tauri plugin that runs its own `android.webkit.WebView`, entirely outside WRY** — so the single-webview-per-Activity / SIGILL hazards that sank the prior attempt simply don't apply. It's attached 1×1 (hidden but live so JS/timers run), injects the **shared** `SHARED_SCRIPT`, and signals back through a `__ugBridge` `@JavascriptInterface`: `deliver(html)` resolves; `challenge()` resizes it full-screen for an interactive challenge. Desktop keeps the hidden WRY window; both share one script + control flow. The Tauri CLI auto-wires the plugin's android project into gradle (validated by the Android CI job).

### Git sync unified on libgit2 (`apps/klank/src-tauri/src/git.rs`)
Shell `git` can't run on Android, so git is now an in-app `git2` engine (vendored libgit2 + openssl). Commands: `git_is_repo/status/pull/commit/push/unpushed/clone` + `git_set_token/git_has_token`. HTTPS auth uses a PAT (stored app-private, `0600`) when set, else the desktop credential helper; never logged. `git.ts` is `invoke`-based; Settings has a token field + clone box. `tauri-plugin-shell` removed.

### Android usability, packaging, CI
- Hide the desktop-only folder picker on mobile; default app-private storage works as-is.
- Rename the Android package `com.tauri.dev` → `io.github.hampterworks.klank`.
- **CI** (`.github/workflows/build-android.yml`): `android-release` builds a release APK on release/`main` and uploads it as an artifact + attaches to the GitHub Release (for collection); `android-debug` builds a debug APK **only when a PR has the `build-android` label** (or via `workflow_dispatch`), uploads `klank-debug-apk`, and comments the run/artifact link on the PR.

### Also fixed
- A pre-existing flaky `chord-symbol` property test: `format∘parse` wasn't idempotent for suffixes beginning with a bare accidental (only produced by ambiguous double-accidental input, e.g. `B♭#6`→`{A#,"#6"}`→`A##6`→`B6`). `formatChordSymbol` now folds leading suffix accidentals into the root (the fixpoint). Probed 200k cases: 0 non-idempotent.

## Verification
- `cargo test` (14 import tests) ✅; crate builds incl. vendored libgit2/openssl and the plugin (desktop) ✅
- `pnpm nx run-many -t typecheck/lint/test` all green (new `download.spec` + pipeline orchestrator tests; chord spec 8× stable)
- Android APK build: validated by the `build-android` CI job (add the `build-android` label to produce a debug APK). On-device runs are for the reviewer (`pnpm tauri:android:dev`).

https://claude.ai/code/session_018BiEkZHHnyrbRCKAY9siDE