### PR TITLE
feat(mobile): polish mobile UI with safe areas, bottom toolbar, and keyboard handling

### DIFF
--- a/apps/klank/app/app.module.css
+++ b/apps/klank/app/app.module.css
@@ -31,3 +31,13 @@
     display: none;
   }
 }
+
+@media (max-width: 599px) {
+  .container {
+    display: flex !important;
+    flex-direction: column;
+    height: 100dvh;
+    /* The grid-template-columns inline style from app.tsx is overridden
+       because grid properties are inert when display is flex */
+  }
+}

--- a/apps/klank/app/app.module.css
+++ b/apps/klank/app/app.module.css
@@ -20,6 +20,8 @@
   cursor: col-resize;
   z-index: 10;
   transition: background 150ms;
+  /* Let pointer drags resize the menu instead of scrolling/panning on touch */
+  touch-action: none;
 }
 
 .resizeHandle:hover {

--- a/apps/klank/app/app.module.css
+++ b/apps/klank/app/app.module.css
@@ -37,7 +37,6 @@
     display: flex !important;
     flex-direction: column;
     height: 100dvh;
-    /* The grid-template-columns inline style from app.tsx is overridden
-       because grid properties are inert when display is flex */
+    overflow: clip;
   }
 }

--- a/apps/klank/app/app.tsx
+++ b/apps/klank/app/app.tsx
@@ -81,18 +81,26 @@ export function App() {
     return () => { cancelled = true }
   }, [baseDirectory, serverMode, setBaseDirectory, setFileService, setTabSettings, setPlaylists])
 
+  // Keep a ref so the ResizeObserver callback always reads the latest value
+  // without needing isMenuExtended in the effect's dependency array.
+  // If isMenuExtended were in deps, the effect would re-run every time the
+  // menu opens, the fresh ResizeObserver would fire immediately on .observe(),
+  // and it would close the menu before the drawer ever paints on mobile.
+  const isMenuExtendedRef = useRef(isMenuExtended)
+  isMenuExtendedRef.current = isMenuExtended
+
   useEffect(() => {
     const container = containerRef.current
     if (!container || typeof ResizeObserver === 'undefined') return
     const ro = new ResizeObserver(([entry]) => {
       if (entry.contentRect.width === 0) return
-      if (entry.contentRect.width < 600 && isMenuExtended) {
+      if (entry.contentRect.width < 600 && isMenuExtendedRef.current) {
         toggleMenu(false)
       }
     })
     ro.observe(container)
     return () => ro.disconnect()
-  }, [isMenuExtended, toggleMenu])
+  }, [toggleMenu])
 
   useEffect(() => {
     if (needsUpdate && baseDirectory) {

--- a/apps/klank/app/app.tsx
+++ b/apps/klank/app/app.tsx
@@ -120,17 +120,24 @@ export function App() {
     }
   }, [needsUpdate, baseDirectory, fileService])
 
-  const handleResizeStart = (e: React.MouseEvent) => {
+  // Pointer events unify mouse, touch, and pen so the same drag-to-resize works
+  // on desktop and on touch devices (tablets, fold phones) where the handle is
+  // still shown. touch-action:none on the handle (see CSS) stops the browser
+  // from hijacking the drag as a scroll/pan gesture.
+  const handleResizeStart = (e: React.PointerEvent) => {
     e.preventDefault()
     const container = containerRef.current
     const handle = handleRef.current
     if (!container || !handle) return
 
+    // Keep delivering pointer events to the handle even if the finger/cursor
+    // strays off it mid-drag.
+    handle.setPointerCapture(e.pointerId)
     container.classList.add(styles.resizing)
 
     let finalWidth = isMenuExtended ? menuWidth : 52
 
-    const onMove = (e: MouseEvent) => {
+    const onMove = (e: PointerEvent) => {
       const w = Math.min(MAX_WIDTH, Math.max(0, e.clientX))
       finalWidth = w
       const displayWidth = w < MIN_WIDTH ? 52 : w
@@ -146,12 +153,14 @@ export function App() {
         if (!isMenuExtended) toggleMenu(true)
         setMenuWidth(finalWidth)
       }
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
     }
 
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
   }
 
   const currentWidth = isMenuExtended ? menuWidth : 52
@@ -169,7 +178,7 @@ export function App() {
         ref={handleRef}
         className={styles.resizeHandle}
         style={{ left: currentWidth - 4 }}
-        onMouseDown={handleResizeStart}
+        onPointerDown={handleResizeStart}
       />
       <Player/>
     </main>

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -71,6 +71,17 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
   const navigate = useNavigate()
   const isMenuExtended = useKlankStore().ui.isMenuExtended
   const toggleMenu = useKlankStore().toggleMenu
+
+  // Width-based mobile detection — user-agent checks miss tablets and some
+  // Android WebViews that don't include "mobile" in their UA string.
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' && window.innerWidth <= 599
+  )
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth <= 599)
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
   const currentTabPath = useKlankStore().tab.path
   const setTabPath = useKlankStore().setTabPath
   const baseDirectory = useKlankStore().baseDirectory
@@ -475,7 +486,7 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
         <div className={styles.toastError}>{deleteError}</div>,
         document.body
       )}
-      {isMobileDevice() && isMenuExtended && createPortal(
+      {isMobile && isMenuExtended && createPortal(
         <div className={styles.mobileDrawer}>
           <div
             className={styles.mobileDrawerBackdrop}

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -454,12 +454,13 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
           setBaseDirectory={setBaseDirectory}
           setTabPath={handleSelectSong}
           tree={tree}
-          onRequestCreatePlaylist={handleRequestCreatePlaylist}
+          onRequestCreatePlaylist={isMobile ? undefined : handleRequestCreatePlaylist}
           onRequestDownload={handleRequestDownload}
           isDownloading={isDownloading}
           downloadError={downloadError}
           onSettingsClick={() => navigate('/settings')}
           isCollapsed={!isMenuExtended}
+          hideGoToTab={isMobile}
         />
         {!isMobile && isMenuExtended && (
           <>
@@ -517,6 +518,13 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
                   handleSelectSong(randomItem.path)
                   toggleMenu(false)
                 }}
+              />
+              <Button
+                iconButton
+                icon={<NewPlaylistIcon />}
+                title="New playlist"
+                aria-label="New playlist"
+                onClick={handleRequestCreatePlaylist}
               />
             </div>
             <div className={styles.mobileDrawerContent}>

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -475,6 +475,39 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
         <div className={styles.toastError}>{deleteError}</div>,
         document.body
       )}
+      {isMobileDevice() && isMenuExtended && createPortal(
+        <div className={styles.mobileDrawer}>
+          <div
+            className={styles.mobileDrawerBackdrop}
+            onClick={() => toggleMenu(false)}
+          />
+          <div className={styles.mobileDrawerSheet}>
+            <div className={styles.mobileDrawerContent}>
+              <PlaylistSection tree={tree} currentTabPath={currentTabPath} />
+              <div className={styles.treeWrapper}>
+                <FileTreeView
+                  currentTabPath={currentTabPath}
+                  setTabPath={handleSelectSong}
+                  searchFilter={searchFilter}
+                  tree={tree}
+                  onAddToPlaylist={activePlaylist ? (path) => addTabToPlaylist(activePlaylist.id, path) : undefined}
+                  activePlaylistPaths={activePlaylist?.paths}
+                  onDeleteTab={(path) => setPathToConfirmDelete(path)}
+                />
+              </div>
+            </div>
+            <div className={styles.mobileDrawerSearch}>
+              <Searchbar
+                toggleMenu={toggleMenu}
+                isMenuExtended={isMenuExtended}
+                searchFilter={searchFilter}
+                setSearchFilter={setSearchFilter}
+              />
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
     </>
   )
 }

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -456,7 +456,7 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
           onSettingsClick={() => navigate('/settings')}
           isCollapsed={!isMenuExtended}
         />
-        {isMenuExtended && (
+        {!isMobile && isMenuExtended && (
           <>
             <PlaylistSection tree={tree} currentTabPath={currentTabPath} />
             <div className={styles.treeWrapper}>

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -10,6 +10,7 @@ import {
   FileTreeView,
   LogoIcon,
   NewPlaylistIcon,
+  RefreshIcon,
   Searchbar,
   ShuffleIcon,
   TargetIcon,
@@ -455,12 +456,13 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
           setTabPath={handleSelectSong}
           tree={tree}
           onRequestCreatePlaylist={isMobile ? undefined : handleRequestCreatePlaylist}
-          onRequestDownload={handleRequestDownload}
+          onRequestDownload={isMobile ? undefined : handleRequestDownload}
           isDownloading={isDownloading}
           downloadError={downloadError}
           onSettingsClick={() => navigate('/settings')}
           isCollapsed={!isMenuExtended}
           hideGoToTab={isMobile}
+          hideRefresh={isMobile}
         />
         {!isMobile && isMenuExtended && (
           <>
@@ -500,32 +502,52 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
           />
           <div className={styles.mobileDrawerSheet}>
             <div className={styles.mobileDrawerActions}>
-              <Button
-                iconButton
-                icon={<TargetIcon />}
-                title="Go to current tab"
-                aria-label="Go to current tab"
-                onClick={() => document.getElementById('active')?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
-              />
-              <Button
-                iconButton
-                icon={<ShuffleIcon />}
-                title="Go to random tab"
-                aria-label="Go to random tab"
-                onClick={() => {
-                  if (!tree.length) return
-                  const randomItem = tree[Math.floor(Math.random() * tree.length)]
-                  handleSelectSong(randomItem.path)
-                  toggleMenu(false)
-                }}
-              />
-              <Button
-                iconButton
-                icon={<NewPlaylistIcon />}
-                title="New playlist"
-                aria-label="New playlist"
-                onClick={handleRequestCreatePlaylist}
-              />
+              {/* Utility — act on tree state, keep drawer open */}
+              <div className={styles.mobileDrawerActionsGroup}>
+                <Button
+                  iconButton
+                  icon={<TargetIcon />}
+                  title="Go to current tab"
+                  aria-label="Go to current tab"
+                  onClick={() => document.getElementById('active')?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
+                />
+                <Button
+                  iconButton
+                  icon={<RefreshIcon />}
+                  title="Refresh"
+                  aria-label="Refresh"
+                  onClick={() => setNeedsUpdate(true)}
+                />
+              </div>
+              {/* Creation / navigation — may close drawer or open a modal */}
+              <div className={styles.mobileDrawerActionsGroup}>
+                <Button
+                  iconButton
+                  icon={<ShuffleIcon />}
+                  title="Go to random tab"
+                  aria-label="Go to random tab"
+                  onClick={() => {
+                    if (!tree.length) return
+                    const randomItem = tree[Math.floor(Math.random() * tree.length)]
+                    handleSelectSong(randomItem.path)
+                    toggleMenu(false)
+                  }}
+                />
+                <Button
+                  iconButton
+                  icon={<NewPlaylistIcon />}
+                  title="New playlist"
+                  aria-label="New playlist"
+                  onClick={handleRequestCreatePlaylist}
+                />
+                <Button
+                  iconButton
+                  icon={<DownloadIcon />}
+                  title="Download tab"
+                  aria-label="Download tab"
+                  onClick={handleRequestDownload}
+                />
+              </div>
             </div>
             <div className={styles.mobileDrawerContent}>
               <PlaylistSection tree={tree} currentTabPath={currentTabPath} />

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -511,6 +511,7 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
             </div>
             <div className={styles.mobileDrawerSearch}>
               <Searchbar
+                inDrawer
                 toggleMenu={toggleMenu}
                 isMenuExtended={isMenuExtended}
                 searchFilter={searchFilter}

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -274,9 +274,11 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
 
   // Cleanup toast timers on unmount
   useEffect(() => {
+    const deleteTimer = deleteErrorTimerRef
+    const downloadTimer = downloadErrorTimerRef
     return () => {
-      if (deleteErrorTimerRef.current) clearTimeout(deleteErrorTimerRef.current)
-      if (downloadErrorTimerRef.current) clearTimeout(downloadErrorTimerRef.current)
+      if (deleteTimer.current) clearTimeout(deleteTimer.current)
+      if (downloadTimer.current) clearTimeout(downloadTimer.current)
     }
   }, [])
 

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -15,6 +15,7 @@ import {
   ShuffleIcon,
   TargetIcon,
   Toolbar,
+  ToolTip,
 } from '@klank/ui'
 import { useKlankStore } from '@klank/store'
 import { PlaylistSection } from './PlaylistSection'
@@ -504,49 +505,54 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
             <div className={styles.mobileDrawerActions}>
               {/* Utility — act on tree state, keep drawer open */}
               <div className={styles.mobileDrawerActionsGroup}>
-                <Button
-                  iconButton
-                  icon={<TargetIcon />}
-                  title="Go to current tab"
-                  aria-label="Go to current tab"
-                  onClick={() => document.getElementById('active')?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
-                />
-                <Button
-                  iconButton
-                  icon={<RefreshIcon />}
-                  title="Refresh"
-                  aria-label="Refresh"
-                  onClick={() => setNeedsUpdate(true)}
-                />
+                <ToolTip message="Go to Tab">
+                  <Button
+                    iconButton
+                    icon={<TargetIcon />}
+                    aria-label="Go to current tab"
+                    onClick={() => document.getElementById('active')?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
+                  />
+                </ToolTip>
+                <ToolTip message="Refresh">
+                  <Button
+                    iconButton
+                    icon={<RefreshIcon />}
+                    aria-label="Refresh"
+                    onClick={() => setNeedsUpdate(true)}
+                  />
+                </ToolTip>
               </div>
               {/* Creation / navigation — may close drawer or open a modal */}
               <div className={styles.mobileDrawerActionsGroup}>
-                <Button
-                  iconButton
-                  icon={<ShuffleIcon />}
-                  title="Go to random tab"
-                  aria-label="Go to random tab"
-                  onClick={() => {
-                    if (!tree.length) return
-                    const randomItem = tree[Math.floor(Math.random() * tree.length)]
-                    handleSelectSong(randomItem.path)
-                    toggleMenu(false)
-                  }}
-                />
-                <Button
-                  iconButton
-                  icon={<NewPlaylistIcon />}
-                  title="New playlist"
-                  aria-label="New playlist"
-                  onClick={handleRequestCreatePlaylist}
-                />
-                <Button
-                  iconButton
-                  icon={<DownloadIcon />}
-                  title="Download tab"
-                  aria-label="Download tab"
-                  onClick={handleRequestDownload}
-                />
+                <ToolTip message="Go to Random Tab">
+                  <Button
+                    iconButton
+                    icon={<ShuffleIcon />}
+                    aria-label="Go to random tab"
+                    onClick={() => {
+                      if (!tree.length) return
+                      const randomItem = tree[Math.floor(Math.random() * tree.length)]
+                      handleSelectSong(randomItem.path)
+                      toggleMenu(false)
+                    }}
+                  />
+                </ToolTip>
+                <ToolTip message="New Playlist">
+                  <Button
+                    iconButton
+                    icon={<NewPlaylistIcon />}
+                    aria-label="New playlist"
+                    onClick={handleRequestCreatePlaylist}
+                  />
+                </ToolTip>
+                <ToolTip message="Download Tab">
+                  <Button
+                    iconButton
+                    icon={<DownloadIcon />}
+                    aria-label="Download tab"
+                    onClick={handleRequestDownload}
+                  />
+                </ToolTip>
               </div>
             </div>
             <div className={styles.mobileDrawerContent}>

--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -5,11 +5,14 @@ import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router'
 import { FileEntry, getSheetFromUG, ImportProgress, isMobileDevice, sortByArtist } from '@klank/platform-api'
 import {
+  Button,
   DownloadIcon,
   FileTreeView,
   LogoIcon,
   NewPlaylistIcon,
   Searchbar,
+  ShuffleIcon,
+  TargetIcon,
   Toolbar,
 } from '@klank/ui'
 import { useKlankStore } from '@klank/store'
@@ -495,6 +498,27 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
             onClick={() => toggleMenu(false)}
           />
           <div className={styles.mobileDrawerSheet}>
+            <div className={styles.mobileDrawerActions}>
+              <Button
+                iconButton
+                icon={<TargetIcon />}
+                title="Go to current tab"
+                aria-label="Go to current tab"
+                onClick={() => document.getElementById('active')?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
+              />
+              <Button
+                iconButton
+                icon={<ShuffleIcon />}
+                title="Go to random tab"
+                aria-label="Go to random tab"
+                onClick={() => {
+                  if (!tree.length) return
+                  const randomItem = tree[Math.floor(Math.random() * tree.length)]
+                  handleSelectSong(randomItem.path)
+                  toggleMenu(false)
+                }}
+              />
+            </div>
             <div className={styles.mobileDrawerContent}>
               <PlaylistSection tree={tree} currentTabPath={currentTabPath} />
               <div className={styles.treeWrapper}>

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -303,6 +303,12 @@
 }
 
 @media (max-width: 599px) {
+  /* The first <li> (logo row) has a desktop border-bottom; on mobile the
+     container already draws border-bottom, so remove the inner one. */
+  .container > li:first-of-type {
+    border-bottom: none;
+  }
+
   /* ── Top bar (the <ul> / .container) ─────────────────────────── */
   .container {
     flex-direction: row !important;

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -304,9 +304,16 @@
 
 @media (max-width: 599px) {
   /* The first <li> (logo row) has a desktop border-bottom; on mobile the
-     container already draws border-bottom, so remove the inner one. */
+     container already draws border-bottom, so remove the inner one.
+     Height is also raised to 44px to match the Toolbar and Searchbar. */
   .container > li:first-of-type {
     border-bottom: none;
+    height: 44px;
+  }
+
+  /* KLANK text has no room in the horizontal top bar */
+  .logoText {
+    display: none;
   }
 
   /* ── Top bar (the <ul> / .container) ─────────────────────────── */
@@ -377,7 +384,14 @@
   /* ── Mobile drawer ─────────────────────────────────────────────── */
   .mobileDrawer {
     position: fixed;
-    inset: 0;
+    top: 0;
+    left: 0;
+    right: 0;
+    /* Use height:100dvh instead of inset:0 / bottom:0 so the drawer tracks
+       the visual viewport, which shrinks when the virtual keyboard opens.
+       Same pattern as .overlay above — keeps the sheet above the keyboard. */
+    bottom: auto;
+    height: 100dvh;
     z-index: 200;
     display: flex;
     flex-direction: column;

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -324,9 +324,10 @@
     background: var(--klank-color-background);
   }
 
-  /* Hide the tree and playlist sections from the top bar;
-     keep the Searchbar's toggle button visible so the drawer can be opened */
-  .treeWrapper,
+  /* Hide tree and playlist only from the top-bar <ul>.
+     .container .treeWrapper (not bare .treeWrapper) so the portal drawer's
+     treeWrapper is NOT hidden — unscoped .treeWrapper hides it everywhere. */
+  .container .treeWrapper,
   .container [class*="playlistSection"] {
     display: none !important;
   }
@@ -390,8 +391,10 @@
     border-radius: 12px 12px 0 0;
     display: flex;
     flex-direction: column;
-    max-height: calc(100dvh - 44px - var(--safe-top));
-    padding-bottom: calc(44px + var(--safe-bottom));
+    /* Fixed height so the file tree always has room; scrolls within */
+    height: 72dvh;
+    max-height: 85dvh;
+    padding-bottom: max(8px, var(--safe-bottom));
     overflow: hidden;
     z-index: 201;
   }
@@ -405,5 +408,6 @@
   .mobileDrawerSearch {
     flex-shrink: 0;
     border-top: 1px solid var(--klank-color-border);
+    padding: 4px 8px;
   }
 }

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -324,11 +324,10 @@
     background: var(--klank-color-background);
   }
 
-  /* Hide the tree, playlist and searchbar from the top bar */
+  /* Hide the tree and playlist sections from the top bar;
+     keep the Searchbar's toggle button visible so the drawer can be opened */
   .treeWrapper,
-  .container [class*="playlistSection"],
-  .container [class*="Searchbar"],
-  .container [class*="searchbar"] {
+  .container [class*="playlistSection"] {
     display: none !important;
   }
 

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -435,4 +435,22 @@
     border-top: 1px solid var(--klank-color-border);
     padding: 4px 8px;
   }
+
+  .mobileDrawerActions {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 4px;
+    border-bottom: 1px solid var(--klank-color-border);
+    padding: 4px 8px;
+  }
+
+  .mobileDrawerActions button {
+    min-width: 40px;
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -306,18 +306,22 @@
   /* ── Top bar (the <ul> / .container) ─────────────────────────── */
   .container {
     flex-direction: row !important;
-    align-items: center;
-    height: 44px;
-    min-height: 44px;
-    max-height: 44px;
+    /* align-items: flex-end keeps icons in the 44px zone below the status bar */
+    align-items: flex-end;
+    /* height: auto lets the container grow to accommodate safe-area-inset-top */
+    height: auto;
+    min-height: calc(44px + var(--safe-top));
+    max-height: none;
     border-right: none;
     border-bottom: 1px solid var(--klank-color-border);
     overflow: visible;
     width: 100%;
     flex-shrink: 0;
     padding-top: var(--safe-top);
+    padding-bottom: 0;
     padding-left: max(0px, var(--safe-left));
     padding-right: max(0px, var(--safe-right));
+    background: var(--klank-color-background);
   }
 
   /* Hide the tree, playlist and searchbar from the top bar */
@@ -330,8 +334,17 @@
 
   /* ── Download / New Tab overlay ────────────────────────────────── */
   .overlay {
+    /* Override inset:0 — use height:100dvh so the visual viewport (which
+       shrinks when the keyboard opens) determines how tall the overlay is.
+       The modal stays anchored just above the keyboard. */
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: auto;
+    height: 100dvh;
     align-items: flex-end;
     padding-bottom: var(--safe-bottom);
+    overflow: hidden;
   }
 
   .modal {

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -6,6 +6,11 @@
   font-size: 14px;
   color: var(--klank-color-text);
   height: 100dvh;
+  /* On desktop env() resolves to 0px — no visual change.
+     On Android (Fold, tablet) these protect against status/nav bars. */
+  padding-top: var(--safe-top);
+  padding-bottom: var(--safe-bottom);
+  padding-left: var(--safe-left);
 
   > li:first-of-type {
     display: flex;

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -301,3 +301,97 @@
 .textarea:focus {
   border-color: var(--klank-color-text);
 }
+
+@media (max-width: 599px) {
+  /* ── Top bar (the <ul> / .container) ─────────────────────────── */
+  .container {
+    flex-direction: row !important;
+    align-items: center;
+    height: 44px;
+    min-height: 44px;
+    max-height: 44px;
+    border-right: none;
+    border-bottom: 1px solid var(--klank-color-border);
+    overflow: visible;
+    width: 100%;
+    flex-shrink: 0;
+    padding-top: var(--safe-top);
+    padding-left: max(0px, var(--safe-left));
+    padding-right: max(0px, var(--safe-right));
+  }
+
+  /* Hide the tree, playlist and searchbar from the top bar */
+  .treeWrapper,
+  .container [class*="playlistSection"],
+  .container [class*="Searchbar"],
+  .container [class*="searchbar"] {
+    display: none !important;
+  }
+
+  /* ── Download / New Tab overlay ────────────────────────────────── */
+  .overlay {
+    align-items: flex-end;
+    padding-bottom: var(--safe-bottom);
+  }
+
+  .modal {
+    width: 100%;
+    max-width: 100%;
+    border-radius: 12px 12px 0 0;
+    max-height: 85dvh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* ── Textarea in manual-paste section ──────────────────────────── */
+  .textarea {
+    resize: none;
+    height: 100px;
+    min-height: unset;
+  }
+
+  /* ── Toast error sits above the bottom bar ─────────────────────── */
+  .toastError {
+    bottom: calc(1.5rem + var(--safe-bottom) + 44px);
+  }
+
+  /* ── Mobile drawer ─────────────────────────────────────────────── */
+  .mobileDrawer {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+
+  .mobileDrawerBackdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+  }
+
+  .mobileDrawerSheet {
+    position: relative;
+    background: var(--klank-color-background);
+    border-top: 1px solid var(--klank-color-border);
+    border-radius: 12px 12px 0 0;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100dvh - 44px - var(--safe-top));
+    padding-bottom: calc(44px + var(--safe-bottom));
+    overflow: hidden;
+    z-index: 201;
+  }
+
+  .mobileDrawerContent {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .mobileDrawerSearch {
+    flex-shrink: 0;
+    border-top: 1px solid var(--klank-color-border);
+  }
+}

--- a/apps/klank/app/components/menu/menu.module.css
+++ b/apps/klank/app/components/menu/menu.module.css
@@ -440,10 +440,15 @@
     flex-shrink: 0;
     display: flex;
     align-items: center;
-    justify-content: flex-end;
-    gap: 4px;
+    justify-content: space-between;
     border-bottom: 1px solid var(--klank-color-border);
     padding: 4px 8px;
+  }
+
+  .mobileDrawerActionsGroup {
+    display: flex;
+    align-items: center;
+    gap: 4px;
   }
 
   .mobileDrawerActions button {

--- a/apps/klank/app/components/player/Player.tsx
+++ b/apps/klank/app/components/player/Player.tsx
@@ -26,6 +26,9 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
   const instrument = useKlankStore().instrument
   const [tabData, setTabData] = useState<string | undefined>()
   const [editedContent, setEditedContent] = useState<string>('')
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' && window.innerWidth <= 599
+  )
 
   const activePlaylist = playlists.find((p) => p.id === activePlaylistId)
   const playlistNav = activePlaylist && activePlaylistIndex !== null ? {
@@ -34,6 +37,12 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
     onPrev: prevInPlaylist,
     onNext: nextInPlaylist,
   } : undefined
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth <= 599)
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
 
   useEffect(() => {
     if (!fileService?.readTabFile) return
@@ -92,6 +101,7 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
           tabData={tabData ?? ''}
           transpose={transpose}
           instrument={instrument}
+          isMobile={isMobile}
           style={{ fontSize: `${fontSize}px` }}
         />
       )}

--- a/apps/klank/app/components/player/player.module.css
+++ b/apps/klank/app/components/player/player.module.css
@@ -2,6 +2,13 @@
   display: grid;
   grid-template-rows: auto 1fr;
   height: 100vh;
+  /* On desktop env() = 0px — no visual change.
+     On Android tablets/folds these inset the SheetToolbar top away from the
+     status bar, the right edge away from the screen edge, and the sheet
+     bottom above the gesture nav bar. */
+  padding-top: var(--safe-top);
+  padding-right: var(--safe-right);
+  padding-bottom: var(--safe-bottom);
 
   > div {
     position: relative;
@@ -35,6 +42,11 @@
        clipping overflow, and never creates a fixed-positioning containing block */
     overflow: clip;
     height: auto;
+    /* Safe areas are handled by the menu top bar (top) and SheetToolbar
+       mobile padding (bottom/sides) — reset the desktop container padding. */
+    padding-top: 0;
+    padding-right: 0;
+    padding-bottom: 0;
   }
 
   /* Cancel the desktop z-index:2 on the SheetToolbar (direct div child).

--- a/apps/klank/app/components/player/player.module.css
+++ b/apps/klank/app/components/player/player.module.css
@@ -31,7 +31,9 @@
     grid-template-rows: unset;
     flex: 1;
     min-height: 0;
-    overflow: hidden;
+    /* overflow:clip instead of hidden — prevents scroll-trapping while still
+       clipping overflow, and never creates a fixed-positioning containing block */
+    overflow: clip;
     height: auto;
   }
 }

--- a/apps/klank/app/components/player/player.module.css
+++ b/apps/klank/app/components/player/player.module.css
@@ -23,3 +23,15 @@
   padding: 8px;
   box-sizing: border-box;
 }
+
+@media (max-width: 599px) {
+  .container {
+    display: flex !important;
+    flex-direction: column;
+    grid-template-rows: unset;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    height: auto;
+  }
+}

--- a/apps/klank/app/components/player/player.module.css
+++ b/apps/klank/app/components/player/player.module.css
@@ -36,4 +36,12 @@
     overflow: clip;
     height: auto;
   }
+
+  /* Cancel the desktop z-index:2 on the SheetToolbar (direct div child).
+     Without this, SheetToolbar creates a stacking context that can paint
+     above the mobile drawer overlay (z-index: 200). */
+  .container > div {
+    position: static;
+    z-index: auto;
+  }
 }

--- a/apps/klank/app/root.tsx
+++ b/apps/klank/app/root.tsx
@@ -54,7 +54,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-visual" />
         <Meta />
         <Links />
       </head>

--- a/apps/klank/app/root.tsx
+++ b/apps/klank/app/root.tsx
@@ -12,6 +12,7 @@ import '../styles.css';
 import { ThemeProvider } from '@klank/ui';
 import { useKlankStore } from '@klank/store'
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { useEffect } from 'react';
 
 export const meta: MetaFunction = () => [
   {
@@ -49,12 +50,24 @@ export function HydrateFallback() {
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const activeTheme = useKlankStore().theme
+  const themeColor = activeTheme === 'Dark' ? '#020202' : '#fdfdfd'
+
+  useEffect(() => {
+    let tag = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+    if (!tag) {
+      tag = document.createElement('meta')
+      tag.name = 'theme-color'
+      document.head.appendChild(tag)
+    }
+    tag.content = themeColor
+  }, [themeColor])
 
   return (
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-visual" />
+        <meta name="theme-color" content={themeColor} />
         <Meta />
         <Links />
       </head>

--- a/apps/klank/app/routes/settings.module.css
+++ b/apps/klank/app/routes/settings.module.css
@@ -180,3 +180,10 @@
   opacity: 0.65;
   font-style: italic;
 }
+
+@media (max-width: 599px) {
+  .page {
+    padding-top: var(--safe-top);
+    padding-bottom: calc(var(--safe-bottom) + 1rem);
+  }
+}

--- a/apps/klank/src-tauri/capabilities/default.json
+++ b/apps/klank/src-tauri/capabilities/default.json
@@ -14,12 +14,14 @@
     {
       "identifier": "fs:read-all",
       "allow": [
+        { "path": "$APPLOCALDATA/**" },
         { "path": "**" }
       ]
     },
     {
       "identifier": "fs:write-all",
       "allow": [
+        { "path": "$APPLOCALDATA/**" },
         { "path": "**" }
       ]
     },

--- a/apps/klank/styles.css
+++ b/apps/klank/styles.css
@@ -98,6 +98,13 @@ meter {
 :where(dialog:modal) {
   all: revert;
 }
+:root {
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+}
+
 html {
   height: 100%;
   width: 100%;

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -149,7 +149,7 @@ export const useKlankStore = create<KlankState>()(
         },
         tabSettingByPath: {},
         mode: "Read",
-        theme: "Light",
+        theme: (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'Dark' : 'Light',
         instrument: "guitar" as Instrument,
         playlists: [],
         activePlaylistId: null,

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -149,7 +149,7 @@ export const useKlankStore = create<KlankState>()(
         },
         tabSettingByPath: {},
         mode: "Read",
-        theme: (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'Dark' : 'Light',
+        theme: (typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'Dark' : 'Light',
         instrument: "guitar" as Instrument,
         playlists: [],
         activePlaylistId: null,
@@ -393,8 +393,9 @@ export const useKlankStore = create<KlankState>()(
         // v0 persisted playlists in localStorage; they now live in
         // .klank-settings.json, so stale localStorage copies are dropped.
         migrate: (persistedState) => {
-          const { playlists: _dropped, ...rest } = (persistedState ?? {}) as Record<string, unknown>
-          return rest as unknown as PersistedKlankState
+          const state = { ...((persistedState ?? {}) as Record<string, unknown>) }
+          delete state['playlists']
+          return state as unknown as PersistedKlankState
         },
         partialize: (state) => ({
           tab: { ...state.tab, isScrolling: false },

--- a/libs/ui/src/lib/fileTreeView/FileTreeView.tsx
+++ b/libs/ui/src/lib/fileTreeView/FileTreeView.tsx
@@ -72,6 +72,7 @@ const renderTreeStructure = (opts: RenderTreeOptions) => {
               const alreadyInPlaylist = activePlaylistPaths?.includes(item.path)
               return (
                 <li
+                  id={currentTabPath === item.path ? 'active' : undefined}
                   className={currentTabPath === item.path ? styles.active : ''}
                   key={item.path}
                 >

--- a/libs/ui/src/lib/searchbar/Searchbar.tsx
+++ b/libs/ui/src/lib/searchbar/Searchbar.tsx
@@ -11,6 +11,8 @@ type SearchbarProps = {
   toggleMenu: (isMenuExtended: boolean) => void
   searchFilter: string
   setSearchFilter: (filter: string) => void
+  /** When true (drawer context on mobile), shows the search Input instead of hiding it. */
+  inDrawer?: boolean
 } & React.ComponentPropsWithRef<'li'>
 
 export const Searchbar: React.FC<SearchbarProps> = ({
@@ -18,10 +20,11 @@ export const Searchbar: React.FC<SearchbarProps> = ({
   toggleMenu,
   searchFilter,
   setSearchFilter,
+  inDrawer,
   ...props
 }) => {
   return (
-    <li className={`${styles.container}${!isMenuExtended ? ' ' + styles.collapsed : ''}`} {...props}>
+    <li className={`${styles.container}${!isMenuExtended ? ' ' + styles.collapsed : ''}${inDrawer ? ' ' + styles.inDrawer : ''}`} {...props}>
       {isMenuExtended && (
         <Input
           value={searchFilter}

--- a/libs/ui/src/lib/searchbar/searchbar.module.css
+++ b/libs/ui/src/lib/searchbar/searchbar.module.css
@@ -29,3 +29,17 @@
   justify-content: center;
   margin-top: auto;
 }
+
+@media (max-width: 599px) {
+  /* In the mobile top bar the Searchbar only shows its toggle button */
+  .container,
+  .container.collapsed {
+    box-shadow: none;
+    margin-top: 0;
+    padding: 0;
+    height: 44px;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+}

--- a/libs/ui/src/lib/searchbar/searchbar.module.css
+++ b/libs/ui/src/lib/searchbar/searchbar.module.css
@@ -44,7 +44,14 @@
   }
 
   /* Never show the search Input in the top bar — it lives in the drawer only */
-  .container > div {
+  .container:not(.inDrawer) > div {
     display: none !important;
+  }
+
+  /* In the drawer the Input must be fully visible and fill available width */
+  .container.inDrawer {
+    height: auto;
+    padding: 0;
+    justify-content: flex-start;
   }
 }

--- a/libs/ui/src/lib/searchbar/searchbar.module.css
+++ b/libs/ui/src/lib/searchbar/searchbar.module.css
@@ -42,4 +42,9 @@
     justify-content: center;
     flex-shrink: 0;
   }
+
+  /* Never show the search Input in the top bar — it lives in the drawer only */
+  .container > div {
+    display: none !important;
+  }
 }

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import styles from './sheet.module.css'
 import {
   classifySheetLine,
@@ -142,6 +142,58 @@ const renderChordLyricPair = (
   )
 }
 
+/**
+ * Reflow a tablature block (consecutive string lines) into stacked "systems"
+ * that fit `cols` characters wide, so the tab reads top-to-bottom and stays
+ * playable under vertical auto-scroll instead of overflowing sideways. Each
+ * line keeps its string-label prefix (everything up to and including the first
+ * `|`); the body is split in sync across all strings, preferring a measure-bar
+ * (`|`) boundary and otherwise a column that is blank on every string so a fret
+ * number is never cut in half.
+ */
+const reflowTablature = (rawLines: string[], cols: number): string[][] => {
+  if (!Number.isFinite(cols) || cols <= 0 || rawLines.length === 0) return [rawLines]
+
+  const prefixes = rawLines.map(l => {
+    const bar = l.indexOf('|')
+    return bar >= 0 ? l.slice(0, bar + 1) : ''
+  })
+  const bodies = rawLines.map((l, i) => l.slice(prefixes[i].length))
+  const prefixLen = Math.max(0, ...prefixes.map(p => p.length))
+  const bodyCols = Math.max(4, cols - prefixLen)
+  const bodyMax = Math.max(0, ...bodies.map(b => b.length))
+  if (bodyMax <= bodyCols) return [rawLines]
+
+  const isClean = (k: number) =>
+    bodies.every(b => { const ch = b[k]; return ch === undefined || ch === '-' || ch === ' ' })
+  const barCount = (k: number) => bodies.reduce((n, b) => n + (b[k] === '|' ? 1 : 0), 0)
+
+  const systems: string[][] = []
+  let pos = 0
+  while (pos < bodyMax) {
+    const hardEnd = Math.min(pos + bodyCols, bodyMax)
+    let end = hardEnd
+    if (hardEnd < bodyMax) {
+      const need = Math.ceil(rawLines.length / 2)
+      let cut = -1
+      // Prefer cutting just after a measure bar shared by most strings.
+      for (let k = hardEnd - 1; k > pos + 3; k--) {
+        if (barCount(k) >= need) { cut = k + 1; break }
+      }
+      // Otherwise snap back to a column blank on every string.
+      if (cut < 0) {
+        for (let k = hardEnd; k > pos + 3; k--) {
+          if (isClean(k)) { cut = k; break }
+        }
+      }
+      if (cut > pos) end = cut
+    }
+    systems.push(rawLines.map((l, i) => prefixes[i] + bodies[i].slice(pos, end)))
+    pos = end
+  }
+  return systems
+}
+
 type SheetProps = {
   tabData: string
   transpose: number
@@ -168,6 +220,30 @@ export const Sheet: React.FC<SheetProps> = ({
   const contentRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
   const virtualY = useRef(0)
+  const measureRef = useRef<HTMLSpanElement>(null)
+  // How many monospace characters fit across the sheet, used to reflow tab.
+  const [colsPerRow, setColsPerRow] = useState<number>(Number.POSITIVE_INFINITY)
+
+  useEffect(() => {
+    const container = containerRef.current
+    const measure = measureRef.current
+    if (!container || !measure) return
+    const recompute = () => {
+      const charWidth = measure.getBoundingClientRect().width / 100
+      const cs = getComputedStyle(container)
+      const padX = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight)
+      const avail = container.clientWidth - (Number.isFinite(padX) ? padX : 0)
+      if (charWidth > 0 && avail > 0) {
+        // Leave ~1 char of slack so nothing kisses the right edge.
+        setColsPerRow(Math.max(8, Math.floor(avail / charWidth) - 1))
+      }
+    }
+    recompute()
+    const ro = new ResizeObserver(recompute)
+    ro.observe(container)
+    ro.observe(measure)
+    return () => ro.disconnect()
+  }, [])
 
   useEffect(() => {
     const container = containerRef.current
@@ -293,21 +369,27 @@ export const Sheet: React.FC<SheetProps> = ({
         const isTablature = classified.tokens.some(t => t.kind === 'string-indicator')
 
         if (isTablature) {
-          // Tablature is fixed-width ASCII art that must not wrap. Group the run
-          // of consecutive tab lines into one horizontally-scrollable block so
-          // every string stays column-aligned and the block scrolls as a unit.
-          const block: React.ReactNode[] = []
+          // Tablature is fixed-width ASCII art. Collect the run of consecutive
+          // tab lines, then reflow it into stacked systems that fit the screen
+          // so it reads top-to-bottom and stays playable under vertical
+          // auto-scroll instead of overflowing sideways.
+          const rawBlock: string[] = []
           let j = i
           while (j < lines.length) {
             const c = classifySheetLine(lines[j], transpose)
             const tab = c.kind === 'chord-line' && c.tokens.some(t => t.kind === 'string-indicator')
             if (!tab) break
-            block.push(renderLine(lines[j], j, transpose, isScrolling, instrument))
+            rawBlock.push(lines[j])
             j++
           }
+          const systems = reflowTablature(rawBlock, colsPerRow)
           result.push(
             <div key={`tab-${i}`} className={styles.tablatureBlock}>
-              {block}
+              {systems.map((sys, s) => (
+                <div key={s} className={styles.tablatureSystem}>
+                  {sys.map((ln, k) => renderLine(ln, k, transpose, isScrolling, instrument))}
+                </div>
+              ))}
             </div>
           )
           i = j
@@ -328,10 +410,24 @@ export const Sheet: React.FC<SheetProps> = ({
       i++
     }
     return result
-  }, [tabData, transpose, isScrolling, instrument, isMobile])
+  }, [tabData, transpose, isScrolling, instrument, isMobile, colsPerRow])
 
   return (
     <pre ref={containerRef} className={styles.container} {...props}>
+      <span
+        ref={measureRef}
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          visibility: 'hidden',
+          whiteSpace: 'pre',
+          pointerEvents: 'none',
+        }}
+      >
+        {'0'.repeat(100)}
+      </span>
       <div ref={contentRef} className={styles.content}>
         {renderedLines}
         <div ref={sentinelRef}>&nbsp;</div>

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -3,6 +3,7 @@ import styles from './sheet.module.css'
 import {
   classifySheetLine,
   type Instrument,
+  type SheetLine,
 } from '@klank/platform-api'
 import { ChordDiagramTooltip } from '../chordDiagramTooltip/ChordDiagramTooltip.js'
 
@@ -68,6 +69,68 @@ const renderLine = (
   }
 }
 
+/**
+ * Mobile-only: renders a chord-line + following plain-line as a flex row
+ * of segments so the whole unit wraps while keeping each chord above the
+ * lyric characters it annotates.
+ */
+const renderChordLyricPair = (
+  chordLine: Extract<SheetLine, { kind: 'chord-line' }>,
+  lyricText: string,
+  index: number,
+): React.ReactNode => {
+  // Compute character position of each chord token by summing preceding raw lengths
+  let charPos = 0
+  const chords: Array<{ pos: number; display: string }> = []
+
+  for (const token of chordLine.tokens) {
+    if (token.kind === 'chord') {
+      chords.push({ pos: charPos, display: token.display })
+    }
+    charPos += token.raw.length
+  }
+
+  type Segment = { chordDisplay?: string; text: string }
+  const segments: Segment[] = []
+
+  if (chords.length === 0) {
+    // No chords — treat like a plain pair
+    segments.push({ text: lyricText })
+  } else {
+    // Text before the first chord (if the first chord isn't at position 0)
+    if (chords[0].pos > 0) {
+      segments.push({ text: lyricText.slice(0, chords[0].pos) })
+    }
+    // Each chord followed by the lyric characters up to the next chord (or end)
+    for (let i = 0; i < chords.length; i++) {
+      const start = chords[i].pos
+      const end = chords[i + 1]?.pos ?? lyricText.length
+      segments.push({
+        chordDisplay: chords[i].display,
+        text: lyricText.slice(start, end),
+      })
+    }
+  }
+
+  return (
+    <div key={index} className={styles.chordLyricPair}>
+      {segments.map((seg, i) => (
+        <span key={i} className={styles.chordLyricSegment}>
+          {/* Invisible placeholder keeps lyric baseline aligned when no chord */}
+          <span
+            className={styles.chord}
+            style={{ visibility: seg.chordDisplay ? 'visible' : 'hidden' }}
+            aria-hidden={!seg.chordDisplay}
+          >
+            {seg.chordDisplay ?? ' '}
+          </span>
+          <span className={styles.lyricText}>{seg.text || ' '}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
 type SheetProps = {
   tabData: string
   transpose: number
@@ -75,6 +138,9 @@ type SheetProps = {
   isScrolling: boolean
   setTabIsScrolling: (isScrolling: boolean) => void
   instrument?: Instrument
+  /** When true, chord-line + lyric-line pairs are rendered as wrappable
+   *  inline segments instead of two separate block lines. */
+  isMobile?: boolean
 } & React.ComponentPropsWithRef<'pre'>
 
 export const Sheet: React.FC<SheetProps> = ({
@@ -84,6 +150,7 @@ export const Sheet: React.FC<SheetProps> = ({
   isScrolling,
   setTabIsScrolling,
   instrument,
+  isMobile = false,
   ...props
 }) => {
   const containerRef = useRef<HTMLPreElement>(null)
@@ -199,8 +266,35 @@ export const Sheet: React.FC<SheetProps> = ({
   // so toolbar-driven re-renders don't re-parse large sheets.
   const renderedLines = useMemo(() => {
     const lines = tabData.split(/\r?\n|\r/g)
-    return lines.map((line, index) => renderLine(line, index, transpose, isScrolling, instrument))
-  }, [tabData, transpose, isScrolling, instrument])
+
+    if (!isMobile) {
+      return lines.map((line, index) => renderLine(line, index, transpose, isScrolling, instrument))
+    }
+
+    // Mobile: detect chord-line immediately followed by a plain lyric line and
+    // render them as a single wrappable unit so chords stay above their lyrics.
+    const result: React.ReactNode[] = []
+    let i = 0
+    while (i < lines.length) {
+      const classified = classifySheetLine(lines[i], transpose)
+
+      if (classified.kind === 'chord-line') {
+        const isTablature = classified.tokens.some(t => t.kind === 'string-indicator')
+        if (!isTablature && i + 1 < lines.length) {
+          const next = classifySheetLine(lines[i + 1], transpose)
+          if (next.kind === 'plain') {
+            result.push(renderChordLyricPair(classified, next.text, i))
+            i += 2
+            continue
+          }
+        }
+      }
+
+      result.push(renderLine(lines[i], i, transpose, isScrolling, instrument))
+      i++
+    }
+    return result
+  }, [tabData, transpose, isScrolling, instrument, isMobile])
 
   return (
     <pre ref={containerRef} className={styles.container} {...props}>

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -291,7 +291,30 @@ export const Sheet: React.FC<SheetProps> = ({
 
       if (classified.kind === 'chord-line') {
         const isTablature = classified.tokens.some(t => t.kind === 'string-indicator')
-        if (!isTablature && i + 1 < lines.length) {
+
+        if (isTablature) {
+          // Tablature is fixed-width ASCII art that must not wrap. Group the run
+          // of consecutive tab lines into one horizontally-scrollable block so
+          // every string stays column-aligned and the block scrolls as a unit.
+          const block: React.ReactNode[] = []
+          let j = i
+          while (j < lines.length) {
+            const c = classifySheetLine(lines[j], transpose)
+            const tab = c.kind === 'chord-line' && c.tokens.some(t => t.kind === 'string-indicator')
+            if (!tab) break
+            block.push(renderLine(lines[j], j, transpose, isScrolling, instrument))
+            j++
+          }
+          result.push(
+            <div key={`tab-${i}`} className={styles.tablatureBlock}>
+              {block}
+            </div>
+          )
+          i = j
+          continue
+        }
+
+        if (i + 1 < lines.length) {
           const next = classifySheetLine(lines[i + 1], transpose)
           if (next.kind === 'plain') {
             result.push(renderChordLyricPair(classified, next.text, i))

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -188,7 +188,8 @@ const reflowTablature = (rawLines: string[], cols: number): string[][] => {
       }
       if (cut > pos) end = cut
     }
-    systems.push(rawLines.map((l, i) => prefixes[i] + bodies[i].slice(pos, end)))
+    const segStart = pos, segEnd = end
+    systems.push(rawLines.map((l, i) => prefixes[i] + bodies[i].slice(segStart, segEnd)))
     pos = end
   }
   return systems
@@ -239,6 +240,7 @@ export const Sheet: React.FC<SheetProps> = ({
       }
     }
     recompute()
+    if (typeof ResizeObserver === 'undefined') return
     const ro = new ResizeObserver(recompute)
     ro.observe(container)
     ro.observe(measure)

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -70,32 +70,19 @@ const renderLine = (
 }
 
 /**
- * Snap a character position to the start of the word it falls inside.
- * If pos is already at a word boundary (space or start), return it unchanged.
- * This prevents chord splits from breaking words across lines.
- */
-const snapToWordStart = (pos: number, text: string): number => {
-  if (pos <= 0 || pos >= text.length) return pos
-  if (text[pos - 1] === ' ') return pos   // already at a word start
-  let i = pos
-  while (i > 0 && text[i - 1] !== ' ') i--
-  return i
-}
-
-/**
- * Mobile-only: renders a chord-line + following plain-line as a flex row
- * of segments so the whole unit wraps while keeping each chord above the
- * lyric characters it annotates.
+ * Mobile-only: renders a chord-line + following plain-line as a flex row of
+ * per-word units. Each word is its own column (chord cell above, word below),
+ * so the row wraps between whole words - never mid-word and never off-screen -
+ * while each chord stays anchored above the word it annotates.
  */
 const renderChordLyricPair = (
   chordLine: Extract<SheetLine, { kind: 'chord-line' }>,
   lyricText: string,
   index: number,
 ): React.ReactNode => {
-  // Compute character position of each chord token by summing preceding raw lengths
+  // Character position of each chord token (sum of preceding raw lengths).
   let charPos = 0
   const chords: Array<{ pos: number; display: string }> = []
-
   for (const token of chordLine.tokens) {
     if (token.kind === 'chord') {
       chords.push({ pos: charPos, display: token.display })
@@ -103,50 +90,52 @@ const renderChordLyricPair = (
     charPos += token.raw.length
   }
 
-  type Segment = { chordDisplay?: string; text: string }
-  const segments: Segment[] = []
+  // Split the lyric into word units: each non-space run plus its trailing
+  // spaces. Trailing spaces ride along so monospace spacing is preserved and
+  // each unit stays a single, unbreakable word.
+  type Unit = { text: string; start: number; chord?: string }
+  const units: Unit[] = []
+  const wordRe = /\S+\s*/g
+  let m: RegExpExecArray | null
+  while ((m = wordRe.exec(lyricText)) !== null) {
+    units.push({ text: m[0], start: m.index })
+  }
+  if (units.length === 0) {
+    units.push({ text: lyricText.length ? lyricText : ' ', start: 0 })
+  } else if (units[0].start > 0) {
+    // Fold any leading whitespace into the first word unit.
+    units[0] = { text: lyricText.slice(0, units[0].start) + units[0].text, start: 0 }
+  }
 
-  if (chords.length === 0) {
-    // No chords — treat like a plain pair
-    segments.push({ text: lyricText })
-  } else {
-    // Snap chord positions to word boundaries so splits never occur mid-word,
-    // then ensure positions are still strictly increasing.
-    const snapped = chords.map(c => ({ ...c, pos: snapToWordStart(c.pos, lyricText) }))
-    for (let i = 1; i < snapped.length; i++) {
-      if (snapped[i].pos <= snapped[i - 1].pos) {
-        snapped[i].pos = snapped[i - 1].pos
-      }
+  // Anchor each chord above the word it sits over (the last word starting at or
+  // before the chord position). On collision push right so no chord is dropped
+  // and their left-to-right order is preserved.
+  let lastIdx = -1
+  for (const c of chords) {
+    let idx = 0
+    for (let u = 0; u < units.length; u++) {
+      if (units[u].start <= c.pos) idx = u
+      else break
     }
-
-    // Text before the first chord (if the first chord isn't at position 0)
-    if (snapped[0].pos > 0) {
-      segments.push({ text: lyricText.slice(0, snapped[0].pos) })
-    }
-    // Each chord followed by the lyric characters up to the next chord (or end)
-    for (let i = 0; i < snapped.length; i++) {
-      const start = snapped[i].pos
-      const end = snapped[i + 1]?.pos ?? lyricText.length
-      segments.push({
-        chordDisplay: snapped[i].display,
-        text: lyricText.slice(start, end),
-      })
-    }
+    if (idx <= lastIdx) idx = lastIdx + 1
+    if (idx >= units.length) break // no room left
+    units[idx].chord = c.display
+    lastIdx = idx
   }
 
   return (
     <div key={index} className={styles.chordLyricPair}>
-      {segments.map((seg, i) => (
+      {units.map((u, i) => (
         <span key={i} className={styles.chordLyricSegment}>
-          {/* Invisible placeholder keeps lyric baseline aligned when no chord */}
+          {/* Invisible placeholder keeps the lyric baseline aligned when no chord */}
           <span
             className={styles.chord}
-            style={{ visibility: seg.chordDisplay ? 'visible' : 'hidden' }}
-            aria-hidden={!seg.chordDisplay}
+            style={{ visibility: u.chord ? 'visible' : 'hidden' }}
+            aria-hidden={!u.chord}
           >
-            {seg.chordDisplay ?? ' '}
+            {u.chord ?? ' '}
           </span>
-          <span className={styles.lyricText}>{seg.text || ' '}</span>
+          <span className={styles.lyricText}>{u.text}</span>
         </span>
       ))}
     </div>

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -70,6 +70,19 @@ const renderLine = (
 }
 
 /**
+ * Snap a character position to the start of the word it falls inside.
+ * If pos is already at a word boundary (space or start), return it unchanged.
+ * This prevents chord splits from breaking words across lines.
+ */
+const snapToWordStart = (pos: number, text: string): number => {
+  if (pos <= 0 || pos >= text.length) return pos
+  if (text[pos - 1] === ' ') return pos   // already at a word start
+  let i = pos
+  while (i > 0 && text[i - 1] !== ' ') i--
+  return i
+}
+
+/**
  * Mobile-only: renders a chord-line + following plain-line as a flex row
  * of segments so the whole unit wraps while keeping each chord above the
  * lyric characters it annotates.
@@ -97,16 +110,25 @@ const renderChordLyricPair = (
     // No chords — treat like a plain pair
     segments.push({ text: lyricText })
   } else {
+    // Snap chord positions to word boundaries so splits never occur mid-word,
+    // then ensure positions are still strictly increasing.
+    const snapped = chords.map(c => ({ ...c, pos: snapToWordStart(c.pos, lyricText) }))
+    for (let i = 1; i < snapped.length; i++) {
+      if (snapped[i].pos <= snapped[i - 1].pos) {
+        snapped[i].pos = snapped[i - 1].pos
+      }
+    }
+
     // Text before the first chord (if the first chord isn't at position 0)
-    if (chords[0].pos > 0) {
-      segments.push({ text: lyricText.slice(0, chords[0].pos) })
+    if (snapped[0].pos > 0) {
+      segments.push({ text: lyricText.slice(0, snapped[0].pos) })
     }
     // Each chord followed by the lyric characters up to the next chord (or end)
-    for (let i = 0; i < chords.length; i++) {
-      const start = chords[i].pos
-      const end = chords[i + 1]?.pos ?? lyricText.length
+    for (let i = 0; i < snapped.length; i++) {
+      const start = snapped[i].pos
+      const end = snapped[i + 1]?.pos ?? lyricText.length
       segments.push({
-        chordDisplay: chords[i].display,
+        chordDisplay: snapped[i].display,
         text: lyricText.slice(start, end),
       })
     }

--- a/libs/ui/src/lib/sheet/sheet.module.css
+++ b/libs/ui/src/lib/sheet/sheet.module.css
@@ -83,4 +83,8 @@
     -webkit-overflow-scrolling: touch;
     max-width: 100%;
   }
+
+  .tablatureSystem {
+    margin-bottom: 0.9em;
+  }
 }

--- a/libs/ui/src/lib/sheet/sheet.module.css
+++ b/libs/ui/src/lib/sheet/sheet.module.css
@@ -70,6 +70,7 @@
     order: 1;
     flex: 1;
     min-height: 0;
+    overflow-x: hidden;
     overflow-y: auto;
     height: auto;
     padding-bottom: 16px;
@@ -79,8 +80,7 @@
 
   .tablatureBlock {
     white-space: pre;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    overflow: hidden;
     max-width: 100%;
   }
 

--- a/libs/ui/src/lib/sheet/sheet.module.css
+++ b/libs/ui/src/lib/sheet/sheet.module.css
@@ -41,6 +41,29 @@
   user-select: none;
 }
 
+/* ── Mobile chord+lyric pair ──────────────────────────────────── */
+
+/* Wrapping flex row: each segment is a (chord-above, lyric-below) column.
+   Segments wrap as atomic units so the chord stays above its lyric text. */
+.chordLyricPair {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  margin-top: 1em;
+}
+
+.chordLyricSegment {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+/* Lyric text within a segment — pre so spaces are preserved */
+.lyricText {
+  white-space: pre;
+}
+
 @media (max-width: 599px) {
   .container {
     /* Sheet fills remaining space above the bottom SheetToolbar */
@@ -50,5 +73,7 @@
     overflow-y: auto;
     height: auto;
     padding-bottom: 16px;
+    /* Allow wrapping for the chord+lyric pair segments */
+    white-space: normal;
   }
 }

--- a/libs/ui/src/lib/sheet/sheet.module.css
+++ b/libs/ui/src/lib/sheet/sheet.module.css
@@ -76,4 +76,11 @@
     /* Allow wrapping for the chord+lyric pair segments */
     white-space: normal;
   }
+
+  .tablatureBlock {
+    white-space: pre;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    max-width: 100%;
+  }
 }

--- a/libs/ui/src/lib/sheet/sheet.module.css
+++ b/libs/ui/src/lib/sheet/sheet.module.css
@@ -43,6 +43,12 @@
 
 @media (max-width: 599px) {
   .container {
-    padding-bottom: calc(60px + var(--safe-bottom) + 16px);
+    /* Sheet fills remaining space above the bottom SheetToolbar */
+    order: 1;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    height: auto;
+    padding-bottom: 16px;
   }
 }

--- a/libs/ui/src/lib/sheet/sheet.module.css
+++ b/libs/ui/src/lib/sheet/sheet.module.css
@@ -40,3 +40,9 @@
 .blankLine {
   user-select: none;
 }
+
+@media (max-width: 599px) {
+  .container {
+    padding-bottom: calc(60px + var(--safe-bottom) + 16px);
+  }
+}

--- a/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
+++ b/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
@@ -93,19 +93,42 @@
 
 @media (max-width: 599px) {
   .container {
-    /* Reorder to bottom of the player flex column — avoids position:fixed
-       being trapped by overflow:hidden ancestors on mobile WebView */
     order: 2;
     flex-shrink: 0;
+    /* No wrapping — keep all controls on one scrollable row */
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+    gap: 0.375rem;
     border-top: 1px solid var(--klank-color-border);
     border-bottom: none;
-    flex-wrap: wrap;
-    gap: 0.375rem;
     background: var(--klank-color-background);
     min-height: 44px;
     height: auto;
-    padding-bottom: var(--safe-bottom);
-    padding-left: max(0.75rem, var(--safe-left));
-    padding-right: max(0.75rem, var(--safe-right));
+    /* Use max() so there's always breathing room above the Android nav bar
+       even when env(safe-area-inset-bottom) returns 0 in Tauri WebView */
+    padding-bottom: max(8px, var(--safe-bottom));
+    padding-left: max(0.5rem, var(--safe-left));
+    padding-right: max(0.5rem, var(--safe-right));
+    padding-top: 0;
+  }
+
+  .container::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Song name is already at the top of the tab content — hide in bottom bar */
+  .songName {
+    display: none;
+  }
+
+  /* Shrink increment buttons slightly so all three groups + action buttons
+     fit on one line without scrolling on a 360 px viewport */
+  .controls {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    overflow: visible;
   }
 }

--- a/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
+++ b/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
@@ -90,3 +90,23 @@
     opacity: 0.7;
   }
 }
+
+@media (max-width: 599px) {
+  .container {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding-bottom: var(--safe-bottom);
+    padding-left: max(0.75rem, var(--safe-left));
+    padding-right: max(0.75rem, var(--safe-right));
+    border-top: 1px solid var(--klank-color-border);
+    border-bottom: none;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    z-index: 100;
+    background: var(--klank-color-background);
+    min-height: 44px;
+    height: auto;
+  }
+}

--- a/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
+++ b/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
@@ -95,40 +95,39 @@
   .container {
     order: 2;
     flex-shrink: 0;
-    /* No wrapping — keep all controls on one scrollable row */
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    scrollbar-width: none;
-    gap: 0.375rem;
+    /* Wrap so song name occupies its own line above the controls */
+    flex-wrap: wrap;
+    gap: 0.25rem;
     border-top: 1px solid var(--klank-color-border);
     border-bottom: none;
     background: var(--klank-color-background);
-    min-height: 44px;
     height: auto;
-    /* Use max() so there's always breathing room above the Android nav bar
-       even when env(safe-area-inset-bottom) returns 0 in Tauri WebView */
-    padding-bottom: max(8px, var(--safe-bottom));
-    padding-left: max(0.5rem, var(--safe-left));
-    padding-right: max(0.5rem, var(--safe-right));
-    padding-top: 0;
+    padding: 4px max(0.5rem, var(--safe-left)) max(8px, var(--safe-bottom)) max(0.5rem, var(--safe-right));
   }
 
-  .container::-webkit-scrollbar {
-    display: none;
-  }
-
-  /* Song name is already at the top of the tab content — hide in bottom bar */
+  /* Song name: full-width first line */
   .songName {
-    display: none;
+    flex: 0 0 100%;
+    font-size: 0.8125rem;
+    padding: 2px 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    order: 1;
   }
 
-  /* Shrink increment buttons slightly so all three groups + action buttons
-     fit on one line without scrolling on a 360 px viewport */
+  /* Controls: full-width second line, scrollable horizontally */
   .controls {
-    flex-shrink: 0;
+    order: 2;
+    flex: 0 0 100%;
+    overflow-x: auto;
+    scrollbar-width: none;
     display: flex;
     align-items: center;
     gap: 0.375rem;
-    overflow: visible;
+  }
+
+  .controls::-webkit-scrollbar {
+    display: none;
   }
 }

--- a/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
+++ b/libs/ui/src/lib/sheetToolbar/sheetToolbar.module.css
@@ -93,20 +93,19 @@
 
 @media (max-width: 599px) {
   .container {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding-bottom: var(--safe-bottom);
-    padding-left: max(0.75rem, var(--safe-left));
-    padding-right: max(0.75rem, var(--safe-right));
+    /* Reorder to bottom of the player flex column — avoids position:fixed
+       being trapped by overflow:hidden ancestors on mobile WebView */
+    order: 2;
+    flex-shrink: 0;
     border-top: 1px solid var(--klank-color-border);
     border-bottom: none;
     flex-wrap: wrap;
     gap: 0.375rem;
-    z-index: 100;
     background: var(--klank-color-background);
     min-height: 44px;
     height: auto;
+    padding-bottom: var(--safe-bottom);
+    padding-left: max(0.75rem, var(--safe-left));
+    padding-right: max(0.75rem, var(--safe-right));
   }
 }

--- a/libs/ui/src/lib/theme/ThemeProvider.tsx
+++ b/libs/ui/src/lib/theme/ThemeProvider.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { getThemeVariables, Theme } from './theme';
 
 type ThemeProviderProps = {
@@ -14,6 +15,14 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
 }) => {
   const themeVariables = getThemeVariables(theme)
+
+  useEffect(() => {
+    const variables = getThemeVariables(theme);
+    for (const [key, value] of Object.entries(variables)) {
+      document.body.style.setProperty(key, String(value));
+    }
+    document.body.style.colorScheme = theme === 'Dark' ? 'dark' : 'light';
+  }, [theme]);
 
   return <body
     className={className ?? ''}

--- a/libs/ui/src/lib/toolbar/Toolbar.tsx
+++ b/libs/ui/src/lib/toolbar/Toolbar.tsx
@@ -37,6 +37,8 @@ type ToolbarProps = {
   onSettingsClick?: () => void
   tree: TreeEntry[]
   isCollapsed?: boolean
+  /** When true the "Go to Tab" button is hidden (it lives in the mobile drawer instead). */
+  hideGoToTab?: boolean
 } & React.ComponentPropsWithRef<'li'>
 
 export const Toolbar: React.FC<ToolbarProps> = ({
@@ -51,6 +53,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   onSettingsClick,
   tree,
   isCollapsed,
+  hideGoToTab,
   ...props
 }) => {
   const handleBaseDirectoryChange = () => {
@@ -87,13 +90,15 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       <ToolTip message="Settings">
         <Button iconButton={true} icon={<SettingsIcon />} onClick={onSettingsClick} />
       </ToolTip>
-      <ToolTip message="Go to Tab">
-        <Button
-          onClick={() => goToActiveTab()}
-          iconButton={true}
-          icon={<TargetIcon />}
-        />
-      </ToolTip>
+      {!hideGoToTab && (
+        <ToolTip message="Go to Tab">
+          <Button
+            onClick={() => goToActiveTab()}
+            iconButton={true}
+            icon={<TargetIcon />}
+          />
+        </ToolTip>
+      )}
       <ToolTip message="Go to Random Tab">
         <Button
           onClick={() => handleRandomPathUpdate()}
@@ -101,13 +106,15 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           icon={<ShuffleIcon />}
         />
       </ToolTip>
-      <ToolTip message="New Playlist">
-        <Button
-          onClick={() => onRequestCreatePlaylist?.()}
-          iconButton={true}
-          icon={<NewPlaylistIcon />}
-        />
-      </ToolTip>
+      {onRequestCreatePlaylist && (
+        <ToolTip message="New Playlist">
+          <Button
+            onClick={() => onRequestCreatePlaylist()}
+            iconButton={true}
+            icon={<NewPlaylistIcon />}
+          />
+        </ToolTip>
+      )}
       {downloadError && (
         <span className={styles.downloadError} title={downloadError}>
           Error

--- a/libs/ui/src/lib/toolbar/Toolbar.tsx
+++ b/libs/ui/src/lib/toolbar/Toolbar.tsx
@@ -39,6 +39,8 @@ type ToolbarProps = {
   isCollapsed?: boolean
   /** When true the "Go to Tab" button is hidden (it lives in the mobile drawer instead). */
   hideGoToTab?: boolean
+  /** When true the Refresh button is hidden (it lives in the mobile drawer instead). */
+  hideRefresh?: boolean
 } & React.ComponentPropsWithRef<'li'>
 
 export const Toolbar: React.FC<ToolbarProps> = ({
@@ -54,6 +56,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   tree,
   isCollapsed,
   hideGoToTab,
+  hideRefresh,
   ...props
 }) => {
   const handleBaseDirectoryChange = () => {
@@ -80,13 +83,15 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           />
         </ToolTip>
       )}
-      <ToolTip message="Refresh">
-        <Button
-          onClick={() => setNeedsUpdate(true)}
-          iconButton={true}
-          icon={<RefreshIcon />}
-        />
-      </ToolTip>
+      {!hideRefresh && (
+        <ToolTip message="Refresh">
+          <Button
+            onClick={() => setNeedsUpdate(true)}
+            iconButton={true}
+            icon={<RefreshIcon />}
+          />
+        </ToolTip>
+      )}
       <ToolTip message="Settings">
         <Button iconButton={true} icon={<SettingsIcon />} onClick={onSettingsClick} />
       </ToolTip>
@@ -120,18 +125,20 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           Error
         </span>
       )}
-      <ToolTip message={isDownloading ? 'Downloading…' : 'Download Tab'}>
-        <Button
-          onClick={() => onRequestDownload?.()}
-          iconButton={true}
-          disabled={isDownloading}
-          icon={
-            isDownloading
-              ? <span className={styles.spinner}><RefreshIcon /></span>
-              : <DownloadIcon />
-          }
-        />
-      </ToolTip>
+      {onRequestDownload && (
+        <ToolTip message={isDownloading ? 'Downloading…' : 'Download Tab'}>
+          <Button
+            onClick={() => onRequestDownload()}
+            iconButton={true}
+            disabled={isDownloading}
+            icon={
+              isDownloading
+                ? <span className={styles.spinner}><RefreshIcon /></span>
+                : <DownloadIcon />
+            }
+          />
+        </ToolTip>
+      )}
     </li>
   )
 }

--- a/libs/ui/src/lib/toolbar/toolbar.module.css
+++ b/libs/ui/src/lib/toolbar/toolbar.module.css
@@ -49,6 +49,7 @@
 @media (max-width: 599px) {
   .container,
   .container.collapsed {
+    flex: 1;
     flex-direction: row;
     height: 44px;
     padding: 0 4px;
@@ -57,6 +58,7 @@
     overflow-x: auto;
     scrollbar-width: none;
     align-items: center;
+    justify-content: flex-end;
   }
 
   .container::-webkit-scrollbar,

--- a/libs/ui/src/lib/toolbar/toolbar.module.css
+++ b/libs/ui/src/lib/toolbar/toolbar.module.css
@@ -45,3 +45,37 @@
 .collapsed .downloadError {
   display: none;
 }
+
+@media (max-width: 599px) {
+  .container,
+  .container.collapsed {
+    flex-direction: row;
+    height: 44px;
+    padding: 0 4px;
+    gap: 0;
+    border: none;
+    overflow-x: auto;
+    scrollbar-width: none;
+    align-items: center;
+  }
+
+  .container::-webkit-scrollbar,
+  .container.collapsed::-webkit-scrollbar {
+    display: none;
+  }
+
+  .container button,
+  .container.collapsed button,
+  .container a,
+  .container.collapsed a {
+    min-width: 40px;
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .downloadError {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Mobile & touch-device UI polish

Makes Klank usable on phones, tablets, and fold devices. The desktop layout is unchanged — all mobile behavior is gated behind `@media (max-width: 599px)` and `env(safe-area-inset-*)` values that resolve to `0px` on desktop.

### Layout
- Add `viewport-fit=cover` + `interactive-widget=resizes-visual` to the meta viewport, and `--safe-top/bottom/left/right` custom properties in `:root`.
- On mobile (≤599px): left sidebar → horizontal top bar; SheetToolbar + sheet fill the remaining height; file tree/playlist move into a slide-up bottom drawer.
- Logo row, top bar, and Searchbar share a consistent 44px height so all icons align.

### Tablature rendering
- Reflow tab/tablature blocks to fit the screen width so they're playable without horizontal scrolling; chord/lyric splits snap to word boundaries.
- Removed phantom horizontal scroll whitespace from the tablature block.

### Safe areas (tablets & folds, e.g. Samsung Fold 7)
- Sidebar gets `padding-top/bottom/left` from the safe-area vars so the OS status/nav bars don't cover the logo or Searchbar.
- Player container insets the SheetToolbar (top), sheet content (right), and bottom so nothing is hidden behind the status bar or gesture nav bar.

### Keyboard handling
- Download dialog and the mobile drawer use `height: 100dvh; bottom: auto` so they track the visual viewport and stay above the software keyboard when the search input is focused.

### Touch & interaction
- Menu resize handle now uses Pointer Events (mouse + touch + pen), with pointer capture, `pointercancel` handling, and `touch-action: none` — so the menu can be drag-resized on tablets/folds.

### Mobile drawer action row (per UX audit)
File-management actions live with the file tree instead of the always-visible top bar.
- **Top bar (mobile):** Settings · Shuffle · Edit · ← (drawer toggle)
- **Drawer action row**, split into two groups:
  - Utility (keep drawer open): **Go to current tab** · **Refresh**
  - Creation/navigation (close drawer or open a modal): **Shuffle** · **New Playlist** · **Download Tab**
- All drawer buttons use the shared `ToolTip` component with `aria-label`s.
- `Toolbar` gained `hideGoToTab` / `hideRefresh` props and made the New Playlist / Download buttons conditional, so the same component renders the trimmed mobile bar.
- Revived the desktop "Go to Tab" button: it looked up `getElementById('active')` but nothing set that id — now the active song `<li>` in `FileTreeView` carries `id="active"`.

### Android fixes
- Fixed the file-system capability scope so downloaded tabs list correctly in the Android drawer (`$APPLOCALDATA/**`).
- Restored the search bar inside the mobile drawer.

### Build hygiene
- Guards for `matchMedia` / `ResizeObserver` in jsdom, fixed a `no-loop-func` warning, dropped an unused var. Lint + tests green.

https://claude.ai/code/session_01ACGdj3Yck8MiiMxEtcAQCE