### PR TITLE
Unobtrusive background git sync + one-click auth

### DIFF
--- a/apps/klank/app/app.tsx
+++ b/apps/klank/app/app.tsx
@@ -9,6 +9,7 @@ import {
 } from '@klank/platform-api'
 import { Menu } from './components/menu/Menu'
 import { Player } from './components/player/Player'
+import { useGitSync } from './useGitSync'
 
 const MIN_WIDTH = 160
 const MAX_WIDTH = 800
@@ -31,6 +32,9 @@ export function App() {
   const [needsUpdate, setNeedsUpdate] = useState(false)
   const containerRef = useRef<HTMLElement>(null)
   const handleRef = useRef<HTMLDivElement>(null)
+
+  // Background git sync: refresh the file tree when a sync pulls remote changes.
+  useGitSync(() => setNeedsUpdate(true))
 
   useEffect(() => {
     setServerMode(!isTauri)

--- a/apps/klank/app/routes/settings.module.css
+++ b/apps/klank/app/routes/settings.module.css
@@ -181,6 +181,40 @@
   font-style: italic;
 }
 
+.syncStatus {
+  font-size: 0.8rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.statusOk {
+  color: var(--klank-color-success);
+}
+
+.statusWarn {
+  color: var(--klank-color-fail);
+  opacity: 0.85;
+}
+
+.statusError {
+  color: var(--klank-color-fail);
+}
+
+.linkButton {
+  background: none;
+  border: none;
+  color: var(--klank-color-text);
+  opacity: 0.7;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 4px 6px;
+  text-decoration: underline;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 @media (max-width: 599px) {
   .page {
     padding-top: var(--safe-top);

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -181,6 +181,23 @@ export default function Settings() {
     }
   }
 
+  const tokenRow = (
+    <div className={styles.row}>
+      <span className={styles.label}>Token</span>
+      <input
+        className={styles.commitInput}
+        type="password"
+        placeholder={hasToken ? '•••••••• (saved)' : 'HTTPS access token'}
+        value={token}
+        onChange={(e) => setTokenValue(e.target.value)}
+        disabled={busy}
+      />
+      <button className={styles.button} onClick={handleSaveToken} disabled={busy || (!token.trim() && !hasToken)}>
+        {token.trim() ? 'Save' : 'Clear'}
+      </button>
+    </div>
+  )
+
   return (
     <div className={styles.page}>
       <header className={styles.header}>
@@ -265,21 +282,9 @@ export default function Settings() {
             </div>
           )}
 
+          {/* Mobile has no credential helper, so the token is the primary control. */}
           {isMobile ? (
-            <div className={styles.row}>
-              <span className={styles.label}>Token</span>
-              <input
-                className={styles.commitInput}
-                type="password"
-                placeholder={hasToken ? '•••••••• (saved)' : 'HTTPS access token'}
-                value={token}
-                onChange={(e) => setTokenValue(e.target.value)}
-                disabled={busy}
-              />
-              <button className={styles.button} onClick={handleSaveToken} disabled={busy || (!token.trim() && !hasToken)}>
-                {token.trim() ? 'Save' : 'Clear'}
-              </button>
-            </div>
+            tokenRow
           ) : (
             <>
               <div className={styles.row}>
@@ -287,22 +292,7 @@ export default function Settings() {
                   {showAdvanced ? 'Hide advanced' : 'Advanced'}
                 </button>
               </div>
-              {showAdvanced && (
-                <div className={styles.row}>
-                  <span className={styles.label}>Token</span>
-                  <input
-                    className={styles.commitInput}
-                    type="password"
-                    placeholder={hasToken ? '•••••••• (saved)' : 'HTTPS access token'}
-                    value={token}
-                    onChange={(e) => setTokenValue(e.target.value)}
-                    disabled={busy}
-                  />
-                  <button className={styles.button} onClick={handleSaveToken} disabled={busy || (!token.trim() && !hasToken)}>
-                    {token.trim() ? 'Save' : 'Clear'}
-                  </button>
-                </div>
-              )}
+              {showAdvanced && tokenRow}
             </>
           )}
 

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -1,10 +1,21 @@
 import styles from './settings.module.css'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
-import { createGitService, getAppVersion, isMobileDevice, type GitChangedFile, type GitResult, type GitService } from '@klank/platform-api'
+import { createGitService, getAppVersion, isMobileDevice, type BranchInfo, type GitService } from '@klank/platform-api'
 import { useKlankStore } from '@klank/store'
+import { runGitSync } from '../useGitSync'
 
 type Status = { ok: boolean; message: string } | null
+
+const formatSince = (ts: number | null): string => {
+  if (!ts) return 'never'
+  const mins = Math.floor((Date.now() - ts) / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
 
 export default function Settings() {
   const navigate = useNavigate()
@@ -15,12 +26,16 @@ export default function Settings() {
   const instrument = useKlankStore().instrument
   const setInstrument = useKlankStore().setInstrument
   const fileService = useKlankStore().fileService
+  const setTabSettings = useKlankStore().setTabSettings
+  const setPlaylists = useKlankStore().setPlaylists
+  const syncSettings = useKlankStore().syncSettings
+  const setSyncSettings = useKlankStore().setSyncSettings
+  const syncStatus = useKlankStore().syncStatus
 
   const gitRef = useRef<GitService | null>(null)
   const [isRepo, setIsRepo] = useState<boolean | null>(null)
-  const [changedFiles, setChangedFiles] = useState<GitChangedFile[]>([])
-  const [unpushedCommits, setUnpushedCommits] = useState<string[]>([])
-  const [commitMessage, setCommitMessage] = useState('Update tabs')
+  const [branches, setBranches] = useState<BranchInfo[]>([])
+  const [currentBranch, setCurrentBranch] = useState<string>('')
   const [status, setStatus] = useState<Status>(null)
   const [busy, setBusy] = useState(false)
   const [version, setVersion] = useState<string>('')
@@ -28,13 +43,20 @@ export default function Settings() {
   const [hasToken, setHasToken] = useState(false)
   const [cloneUrl, setCloneUrl] = useState('')
 
-  const refreshGitState = async (dir: string, git: GitService) => {
-    const [files, commits] = await Promise.all([
-      git.getChangedFiles(dir),
-      git.getUnpushedCommits(dir),
+  const refreshBranches = async (dir: string, git: GitService) => {
+    const list = await git.listBranches(dir)
+    setBranches(list)
+    setCurrentBranch(list.find((b) => b.isHead)?.name ?? '')
+  }
+
+  const rehydrate = async (dir: string) => {
+    if (!fileService) return
+    const [settings, playlists] = await Promise.all([
+      fileService.readTabSettings(dir),
+      fileService.readPlaylists(dir),
     ])
-    setChangedFiles(files)
-    setUnpushedCommits(commits)
+    setTabSettings(settings)
+    setPlaylists(playlists)
   }
 
   useEffect(() => {
@@ -51,7 +73,7 @@ export default function Settings() {
         if (cancelled) return
         setIsRepo(repo)
         setHasToken(tokenStored)
-        if (repo) await refreshGitState(baseDirectory, git)
+        if (repo) await refreshBranches(baseDirectory, git)
       } catch {
         // not in Tauri context (server render)
       }
@@ -68,13 +90,6 @@ export default function Settings() {
     if (!fileService) return
     const path = await fileService.getDirectoryPath()
     if (path) setBaseDirectory(path)
-  }
-
-  const applyResult = async (result: GitResult) => {
-    setStatus({ ok: result.success, message: result.output || result.error || '' })
-    if (result.success && baseDirectory && gitRef.current) {
-      await refreshGitState(baseDirectory, gitRef.current)
-    }
   }
 
   const handleSaveToken = async () => {
@@ -100,38 +115,38 @@ export default function Settings() {
       setStatus({ ok: result.success, message: result.output || result.error || '' })
       if (result.success) {
         setIsRepo(true)
-        await refreshGitState(baseDirectory, gitRef.current)
+        await refreshBranches(baseDirectory, gitRef.current)
+        await rehydrate(baseDirectory)
       }
     } finally {
       setBusy(false)
     }
   }
 
-  const handlePull = async () => {
-    if (!baseDirectory || !gitRef.current || busy) return
+  const handleSyncNow = async () => {
+    if (!gitRef.current || !baseDirectory || busy) return
     setBusy(true)
     try {
-      await applyResult(await gitRef.current.pull(baseDirectory))
+      await runGitSync(gitRef.current, baseDirectory, fileService)
+      await refreshBranches(baseDirectory, gitRef.current)
     } finally {
       setBusy(false)
     }
   }
 
-  const handleCommit = async () => {
-    if (!baseDirectory || !gitRef.current || busy || !commitMessage.trim()) return
+  const handleSelectBranch = async (name: string) => {
+    if (!gitRef.current || !baseDirectory || busy || name === currentBranch) return
     setBusy(true)
     try {
-      await applyResult(await gitRef.current.commit(baseDirectory, commitMessage.trim()))
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const handlePush = async () => {
-    if (!baseDirectory || !gitRef.current || busy) return
-    setBusy(true)
-    try {
-      await applyResult(await gitRef.current.push(baseDirectory))
+      // Commit/push current branch first so switching never loses local edits.
+      await runGitSync(gitRef.current, baseDirectory, fileService)
+      const result = await gitRef.current.checkoutBranch(baseDirectory, name)
+      setStatus({ ok: result.success, message: result.output || result.error || '' })
+      if (result.success) {
+        await rehydrate(baseDirectory)
+        await runGitSync(gitRef.current, baseDirectory, fileService)
+        await refreshBranches(baseDirectory, gitRef.current)
+      }
     } finally {
       setBusy(false)
     }
@@ -199,7 +214,7 @@ export default function Settings() {
         </section>
 
         <section className={styles.section}>
-          <h2>Git</h2>
+          <h2>Sync</h2>
 
           <div className={styles.row}>
             <span className={styles.label}>Token</span>
@@ -243,59 +258,74 @@ export default function Settings() {
 
           {isRepo === true && (
             <>
-              <div>
-                <div className={styles.row} style={{ marginBottom: 8 }}>
-                  <span className={styles.label}>Changes</span>
-                  <span style={{ fontSize: '0.875rem', opacity: 0.7 }}>
-                    {changedFiles.length} file{changedFiles.length !== 1 ? 's' : ''}
-                  </span>
-                </div>
-                {changedFiles.length === 0 ? (
-                  <span className={styles.noChanges}>No uncommitted changes</span>
-                ) : (
-                  <div className={styles.fileList}>
-                    {changedFiles.map((f, i) => (
-                      <div key={i} className={styles.fileItem}>
-                        <span className={styles.fileStatus}>{f.status}</span>
-                        <span>{f.path}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
+              <div className={styles.row}>
+                <span className={styles.label}>Branch</span>
+                <select
+                  className={styles.commitInput}
+                  value={currentBranch}
+                  onChange={(e) => handleSelectBranch(e.target.value)}
+                  disabled={busy || branches.length === 0}
+                >
+                  {branches.length === 0 && <option value="">…</option>}
+                  {branches.map((b) => (
+                    <option key={b.name} value={b.name}>
+                      {b.name}{b.isRemote ? ' (remote)' : ''}
+                    </option>
+                  ))}
+                </select>
               </div>
 
               <div className={styles.row}>
-                <button className={styles.button} onClick={handlePull} disabled={busy}>
-                  Pull
+                <span className={styles.label}>Status</span>
+                <span className={styles.dirPath}>
+                  {syncStatus.state === 'syncing'
+                    ? 'Syncing…'
+                    : syncStatus.state === 'error'
+                      ? `Error: ${syncStatus.message}`
+                      : syncStatus.state === 'offline'
+                        ? syncStatus.message
+                        : `Last synced ${formatSince(syncStatus.lastSyncedAt)}`}
+                </span>
+                <button className={styles.button} onClick={handleSyncNow} disabled={busy}>
+                  Sync now
                 </button>
               </div>
 
               <div className={styles.row}>
+                <span className={styles.label}>Auto-sync</span>
+                <button
+                  className={styles.button}
+                  onClick={() => setSyncSettings({ enabled: !syncSettings.enabled })}
+                  disabled={busy}
+                >
+                  {syncSettings.enabled ? 'On' : 'Off'}
+                </button>
+              </div>
+
+              <div className={styles.row}>
+                <span className={styles.label}>Every</span>
                 <input
                   className={styles.commitInput}
-                  type="text"
-                  value={commitMessage}
-                  onChange={(e) => setCommitMessage(e.target.value)}
-                  placeholder="Commit message"
-                  disabled={busy}
+                  type="number"
+                  min={1}
+                  value={syncSettings.intervalMinutes}
+                  onChange={(e) => setSyncSettings({ intervalMinutes: Math.max(1, Number(e.target.value) || 1) })}
+                  disabled={busy || !syncSettings.enabled}
                 />
-                <button
-                  className={styles.button}
-                  onClick={handleCommit}
-                  disabled={busy || changedFiles.length === 0 || !commitMessage.trim()}
-                >
-                  Commit
-                </button>
+                <span className={styles.label}>min</span>
               </div>
 
               <div className={styles.row}>
-                <button
-                  className={styles.button}
-                  onClick={handlePush}
-                  disabled={busy || unpushedCommits.length === 0}
-                >
-                  Push{unpushedCommits.length > 0 ? ` (${unpushedCommits.length})` : ''}
-                </button>
+                <span className={styles.label}>After edit</span>
+                <input
+                  className={styles.commitInput}
+                  type="number"
+                  min={0}
+                  value={syncSettings.debounceMinutes}
+                  onChange={(e) => setSyncSettings({ debounceMinutes: Math.max(0, Number(e.target.value) || 0) })}
+                  disabled={busy || !syncSettings.enabled}
+                />
+                <span className={styles.label}>min</span>
               </div>
 
               {status && (

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -41,7 +41,10 @@ export default function Settings() {
   const [version, setVersion] = useState<string>('')
   const [token, setTokenValue] = useState('')
   const [hasToken, setHasToken] = useState(false)
+  const [systemCreds, setSystemCreds] = useState(false)
+  const [showAdvanced, setShowAdvanced] = useState(false)
   const [cloneUrl, setCloneUrl] = useState('')
+  const isMobile = isMobileDevice()
 
   const refreshBranches = async (dir: string, git: GitService) => {
     const list = await git.listBranches(dir)
@@ -66,13 +69,15 @@ export default function Settings() {
         const git = await createGitService()
         gitRef.current = git
         if (!baseDirectory) return
-        const [repo, tokenStored] = await Promise.all([
+        const [repo, tokenStored, sysCreds] = await Promise.all([
           git.isGitRepo(baseDirectory),
           git.hasToken(),
+          git.systemCredentialsEnabled(),
         ])
         if (cancelled) return
         setIsRepo(repo)
         setHasToken(tokenStored)
+        setSystemCreds(sysCreds)
         if (repo) await refreshBranches(baseDirectory, git)
       } catch {
         // not in Tauri context (server render)
@@ -102,6 +107,30 @@ export default function Settings() {
       setStatus({ ok: true, message: token.trim() ? 'Token saved.' : 'Token cleared.' })
     } catch (e) {
       setStatus({ ok: false, message: e instanceof Error ? e.message : 'Could not save token' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleUseSystemCreds = async () => {
+    if (!gitRef.current || !baseDirectory || busy) return
+    setBusy(true)
+    try {
+      const result = await gitRef.current.useSystemCredentials(baseDirectory)
+      setStatus({ ok: result.success, message: result.output || result.error || '' })
+      if (result.success) setSystemCreds(true)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDisconnectSystemCreds = async () => {
+    if (!gitRef.current || busy) return
+    setBusy(true)
+    try {
+      await gitRef.current.disableSystemCredentials()
+      setSystemCreds(false)
+      setStatus({ ok: true, message: 'Disconnected system Git credentials.' })
     } finally {
       setBusy(false)
     }
@@ -216,20 +245,66 @@ export default function Settings() {
         <section className={styles.section}>
           <h2>Sync</h2>
 
-          <div className={styles.row}>
-            <span className={styles.label}>Token</span>
-            <input
-              className={styles.commitInput}
-              type="password"
-              placeholder={hasToken ? '•••••••• (saved)' : 'HTTPS access token'}
-              value={token}
-              onChange={(e) => setTokenValue(e.target.value)}
-              disabled={busy}
-            />
-            <button className={styles.button} onClick={handleSaveToken} disabled={busy || (!token.trim() && !hasToken)}>
-              {token.trim() ? 'Save' : 'Clear'}
-            </button>
-          </div>
+          {/* Access: desktop gets one-click system credentials; PAT is the
+              cross-platform fallback (and the only option on mobile). */}
+          {!isMobile && (
+            <div className={styles.row}>
+              <span className={styles.label}>Account</span>
+              {systemCreds ? (
+                <>
+                  <span className={styles.dirPath}>Using system Git credentials ✓</span>
+                  <button className={styles.button} onClick={handleDisconnectSystemCreds} disabled={busy}>
+                    Disconnect
+                  </button>
+                </>
+              ) : (
+                <button className={styles.button} onClick={handleUseSystemCreds} disabled={busy}>
+                  Use system Git credentials
+                </button>
+              )}
+            </div>
+          )}
+
+          {isMobile ? (
+            <div className={styles.row}>
+              <span className={styles.label}>Token</span>
+              <input
+                className={styles.commitInput}
+                type="password"
+                placeholder={hasToken ? '•••••••• (saved)' : 'HTTPS access token'}
+                value={token}
+                onChange={(e) => setTokenValue(e.target.value)}
+                disabled={busy}
+              />
+              <button className={styles.button} onClick={handleSaveToken} disabled={busy || (!token.trim() && !hasToken)}>
+                {token.trim() ? 'Save' : 'Clear'}
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className={styles.row}>
+                <button className={styles.button} onClick={() => setShowAdvanced((v) => !v)} disabled={busy}>
+                  {showAdvanced ? 'Hide advanced' : 'Advanced'}
+                </button>
+              </div>
+              {showAdvanced && (
+                <div className={styles.row}>
+                  <span className={styles.label}>Token</span>
+                  <input
+                    className={styles.commitInput}
+                    type="password"
+                    placeholder={hasToken ? '•••••••• (saved)' : 'HTTPS access token'}
+                    value={token}
+                    onChange={(e) => setTokenValue(e.target.value)}
+                    disabled={busy}
+                  />
+                  <button className={styles.button} onClick={handleSaveToken} disabled={busy || (!token.trim() && !hasToken)}>
+                    {token.trim() ? 'Save' : 'Clear'}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
 
           {isRepo === null && (
             <span className={styles.infoMessage}>Checking repository…</span>

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -2,7 +2,7 @@ import styles from './settings.module.css'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { createGitService, getAppVersion, isMobileDevice, type BranchInfo, type GitService } from '@klank/platform-api'
-import { useKlankStore } from '@klank/store'
+import { useKlankStore, type SyncStatus } from '@klank/store'
 import { runGitSync } from '../useGitSync'
 
 type Status = { ok: boolean; message: string } | null
@@ -15,6 +15,42 @@ const formatSince = (ts: number | null): string => {
   const hours = Math.floor(mins / 60)
   if (hours < 24) return `${hours}h ago`
   return `${Math.floor(hours / 24)}d ago`
+}
+
+type SyncTone = 'ok' | 'warn' | 'error' | 'neutral'
+
+/**
+ * Maps the raw sync status to one concise, actionable line (and an optional raw
+ * detail), so the user can tell auth from connectivity issues at a glance without
+ * the section being flooded with libgit2 output.
+ */
+export const describeSyncStatus = (status: SyncStatus): { text: string; tone: SyncTone; detail?: string } => {
+  switch (status.state) {
+    case 'syncing':
+      return { text: 'Syncing…', tone: 'neutral' }
+    case 'offline':
+      return status.kind === 'auth'
+        ? { text: '⚠ Not signed in — connect an account below', tone: 'warn' }
+        : { text: status.message || 'Not syncing', tone: 'neutral' }
+    case 'error':
+      if (status.kind === 'auth')
+        return { text: '✕ Sign-in needed — check your token or system credentials', tone: 'error', detail: status.message }
+      if (status.kind === 'network')
+        return { text: '✕ Can’t reach the remote — check your connection', tone: 'error', detail: status.message }
+      return { text: '✕ Sync failed', tone: 'error', detail: status.message }
+    case 'idle':
+    default:
+      return status.lastSyncedAt
+        ? { text: `✓ Synced · ${formatSince(status.lastSyncedAt)}`, tone: 'ok' }
+        : { text: 'Not synced yet', tone: 'neutral' }
+  }
+}
+
+const toneClass: Record<SyncTone, string> = {
+  ok: 'statusOk',
+  warn: 'statusWarn',
+  error: 'statusError',
+  neutral: '',
 }
 
 export default function Settings() {
@@ -43,8 +79,10 @@ export default function Settings() {
   const [hasToken, setHasToken] = useState(false)
   const [systemCreds, setSystemCreds] = useState(false)
   const [showAdvanced, setShowAdvanced] = useState(false)
+  const [showSyncDetail, setShowSyncDetail] = useState(false)
   const [cloneUrl, setCloneUrl] = useState('')
   const isMobile = isMobileDevice()
+  const sync = describeSyncStatus(syncStatus)
 
   const refreshBranches = async (dir: string, git: GitService) => {
     const list = await git.listBranches(dir)
@@ -342,19 +380,24 @@ export default function Settings() {
 
               <div className={styles.row}>
                 <span className={styles.label}>Status</span>
-                <span className={styles.dirPath}>
-                  {syncStatus.state === 'syncing'
-                    ? 'Syncing…'
-                    : syncStatus.state === 'error'
-                      ? `Error: ${syncStatus.message}`
-                      : syncStatus.state === 'offline'
-                        ? syncStatus.message
-                        : `Last synced ${formatSince(syncStatus.lastSyncedAt)}`}
+                <span
+                  className={`${styles.syncStatus} ${toneClass[sync.tone] ? styles[toneClass[sync.tone]] : ''}`}
+                  title={syncStatus.message || undefined}
+                >
+                  {sync.text}
                 </span>
+                {sync.detail && (
+                  <button className={styles.linkButton} onClick={() => setShowSyncDetail((v) => !v)}>
+                    {showSyncDetail ? 'Hide' : 'Details'}
+                  </button>
+                )}
                 <button className={styles.button} onClick={handleSyncNow} disabled={busy}>
                   Sync now
                 </button>
               </div>
+              {sync.detail && showSyncDetail && (
+                <div className={`${styles.statusLine} ${styles.error}`}>{sync.detail}</div>
+              )}
 
               <div className={styles.row}>
                 <span className={styles.label}>Auto-sync</span>

--- a/apps/klank/app/useGitSync.ts
+++ b/apps/klank/app/useGitSync.ts
@@ -19,16 +19,24 @@ export async function runGitSync(
   try {
     const [isRepo, authed] = await Promise.all([git.isGitRepo(baseDirectory), git.isAuthenticated()])
     if (!isRepo || !authed) {
-      setSyncStatus({ state: 'offline', message: isRepo ? 'Not signed in' : 'No repository' })
+      setSyncStatus(
+        isRepo
+          ? { state: 'offline', message: 'Not signed in', kind: 'auth' }
+          : { state: 'offline', message: 'No repository', kind: undefined },
+      )
       return
     }
-    setSyncStatus({ state: 'syncing', message: 'Syncing…' })
+    setSyncStatus({ state: 'syncing', message: 'Syncing…', kind: undefined })
     const result = await git.sync(baseDirectory)
     if (!result.success) {
-      setSyncStatus({ state: 'error', message: result.error || result.message || 'Sync failed' })
+      setSyncStatus({
+        state: 'error',
+        message: result.error || result.message || 'Sync failed',
+        kind: result.errorKind ?? 'other',
+      })
       return
     }
-    setSyncStatus({ state: 'idle', lastSyncedAt: Date.now(), message: result.message })
+    setSyncStatus({ state: 'idle', lastSyncedAt: Date.now(), message: result.message, kind: undefined })
     if (result.changed && fileService) {
       const [settings, playlists] = await Promise.all([
         fileService.readTabSettings(baseDirectory),
@@ -39,7 +47,7 @@ export async function runGitSync(
       onChanged?.()
     }
   } catch (e) {
-    setSyncStatus({ state: 'error', message: e instanceof Error ? e.message : 'Sync failed' })
+    setSyncStatus({ state: 'error', message: e instanceof Error ? e.message : 'Sync failed', kind: 'other' })
   }
 }
 

--- a/apps/klank/app/useGitSync.ts
+++ b/apps/klank/app/useGitSync.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { onTabsChanged, useKlankStore } from '@klank/store'
+import { createGitService, type FileService, type GitService } from '@klank/platform-api'
+
+const MINUTE_MS = 60_000
+
+/**
+ * Runs one sync: updates `syncStatus`, delegates to the Rust `git_sync`, and
+ * re-hydrates disk-backed state when the working tree changed. Shared by the
+ * background loop and the manual "Sync now" button so both behave identically.
+ */
+export async function runGitSync(
+  git: GitService,
+  baseDirectory: string,
+  fileService: FileService | undefined,
+  onChanged?: () => void,
+): Promise<void> {
+  const { setSyncStatus, setTabSettings, setPlaylists } = useKlankStore.getState()
+  try {
+    const [isRepo, hasToken] = await Promise.all([git.isGitRepo(baseDirectory), git.hasToken()])
+    if (!isRepo || !hasToken) {
+      setSyncStatus({ state: 'offline', message: isRepo ? 'No access token' : 'No repository' })
+      return
+    }
+    setSyncStatus({ state: 'syncing', message: 'Syncing…' })
+    const result = await git.sync(baseDirectory)
+    if (!result.success) {
+      setSyncStatus({ state: 'error', message: result.error || result.message || 'Sync failed' })
+      return
+    }
+    setSyncStatus({ state: 'idle', lastSyncedAt: Date.now(), message: result.message })
+    if (result.changed && fileService) {
+      const [settings, playlists] = await Promise.all([
+        fileService.readTabSettings(baseDirectory),
+        fileService.readPlaylists(baseDirectory),
+      ])
+      setTabSettings(settings)
+      setPlaylists(playlists)
+      onChanged?.()
+    }
+  } catch (e) {
+    setSyncStatus({ state: 'error', message: e instanceof Error ? e.message : 'Sync failed' })
+  }
+}
+
+/**
+ * Drives unobtrusive background git sync. The user only configures access (token)
+ * and a branch; this hook keeps the local tab folder and the remote converged by
+ * itself — on startup, on a periodic timer, shortly after local edits settle
+ * (debounced), and when the window regains focus. Every run delegates to the Rust
+ * `git_sync` (auto-commit → pull-rebase → auto-resolve → push), which also serializes
+ * concurrent runs. When a sync pulls remote changes, disk-backed state is re-hydrated.
+ *
+ * @param onChanged Called after a sync that changed the working tree (e.g. to
+ *   refresh the file tree). Settings/playlists are re-hydrated automatically.
+ */
+export function useGitSync(onChanged?: () => void): void {
+  const baseDirectory = useKlankStore((s) => s.baseDirectory)
+  const fileService = useKlankStore((s) => s.fileService)
+  const { enabled, intervalMinutes, debounceMinutes } = useKlankStore((s) => s.syncSettings)
+
+  const gitRef = useRef<GitService | null>(null)
+  const runningRef = useRef(false)
+  const queuedRef = useRef(false)
+  // Always-latest sync implementation, so the stable `trigger` never goes stale.
+  const runSyncRef = useRef<() => Promise<void>>(async () => undefined)
+  const onChangedRef = useRef(onChanged)
+  onChangedRef.current = onChanged
+
+  useEffect(() => {
+    let cancelled = false
+    createGitService()
+      .then((g) => {
+        if (!cancelled) gitRef.current = g
+      })
+      .catch(() => undefined) // not in a Tauri context (browser/server)
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Rebuilt every render so it closes over the current store values. Coalesces
+  // overlapping requests into a single follow-up run.
+  runSyncRef.current = async () => {
+    const git = gitRef.current
+    if (!git || !baseDirectory) return
+    if (runningRef.current) {
+      queuedRef.current = true
+      return
+    }
+    runningRef.current = true
+    try {
+      await runGitSync(git, baseDirectory, fileService, onChangedRef.current)
+    } finally {
+      runningRef.current = false
+      if (queuedRef.current) {
+        queuedRef.current = false
+        void runSyncRef.current()
+      }
+    }
+  }
+
+  const trigger = useCallback(() => {
+    void runSyncRef.current()
+  }, [])
+
+  // Startup + whenever the directory or enabled flag changes.
+  useEffect(() => {
+    if (enabled && baseDirectory) trigger()
+  }, [enabled, baseDirectory, trigger])
+
+  // Periodic timer.
+  useEffect(() => {
+    if (!enabled) return
+    const id = setInterval(trigger, Math.max(1, intervalMinutes) * MINUTE_MS)
+    return () => clearInterval(id)
+  }, [enabled, intervalMinutes, trigger])
+
+  // Debounced sync after local edits settle.
+  useEffect(() => {
+    if (!enabled) return
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const unsubscribe = onTabsChanged(() => {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(trigger, Math.max(0, debounceMinutes) * MINUTE_MS)
+    })
+    return () => {
+      unsubscribe()
+      if (timer) clearTimeout(timer)
+    }
+  }, [enabled, debounceMinutes, trigger])
+
+  // Sync when the user returns to the app.
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return
+    const onFocus = () => trigger()
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') trigger()
+    }
+    window.addEventListener('focus', onFocus)
+    document.addEventListener('visibilitychange', onVisible)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [enabled, trigger])
+}

--- a/apps/klank/app/useGitSync.ts
+++ b/apps/klank/app/useGitSync.ts
@@ -17,9 +17,9 @@ export async function runGitSync(
 ): Promise<void> {
   const { setSyncStatus, setTabSettings, setPlaylists } = useKlankStore.getState()
   try {
-    const [isRepo, hasToken] = await Promise.all([git.isGitRepo(baseDirectory), git.hasToken()])
-    if (!isRepo || !hasToken) {
-      setSyncStatus({ state: 'offline', message: isRepo ? 'No access token' : 'No repository' })
+    const [isRepo, authed] = await Promise.all([git.isGitRepo(baseDirectory), git.isAuthenticated()])
+    if (!isRepo || !authed) {
+      setSyncStatus({ state: 'offline', message: isRepo ? 'Not signed in' : 'No repository' })
       return
     }
     setSyncStatus({ state: 'syncing', message: 'Syncing…' })

--- a/apps/klank/app/useGitSync.ts
+++ b/apps/klank/app/useGitSync.ts
@@ -4,6 +4,10 @@ import { createGitService, type FileService, type GitService } from '@klank/plat
 
 const MINUTE_MS = 60_000
 
+/** Coerces a possibly-corrupt persisted minute value to a safe number. */
+export const clampMinutes = (value: number, min: number, fallback: number): number =>
+  Number.isFinite(value) ? Math.max(min, value) : fallback
+
 /**
  * Runs one sync: updates `syncStatus`, delegates to the Rust `git_sync`, and
  * re-hydrates disk-backed state when the working tree changed. Shared by the
@@ -120,7 +124,7 @@ export function useGitSync(onChanged?: () => void): void {
   // Periodic timer.
   useEffect(() => {
     if (!enabled) return
-    const id = setInterval(trigger, Math.max(1, intervalMinutes) * MINUTE_MS)
+    const id = setInterval(trigger, clampMinutes(intervalMinutes, 1, 30) * MINUTE_MS)
     return () => clearInterval(id)
   }, [enabled, intervalMinutes, trigger])
 
@@ -130,7 +134,7 @@ export function useGitSync(onChanged?: () => void): void {
     let timer: ReturnType<typeof setTimeout> | undefined
     const unsubscribe = onTabsChanged(() => {
       if (timer) clearTimeout(timer)
-      timer = setTimeout(trigger, Math.max(0, debounceMinutes) * MINUTE_MS)
+      timer = setTimeout(trigger, clampMinutes(debounceMinutes, 0, 5) * MINUTE_MS)
     })
     return () => {
       unsubscribe()

--- a/apps/klank/src-tauri/permissions/allow-git.toml
+++ b/apps/klank/src-tauri/permissions/allow-git.toml
@@ -14,4 +14,8 @@ commands.allow = [
   "git_sync",
   "git_list_branches",
   "git_checkout_branch",
+  "git_is_authenticated",
+  "git_system_credentials_enabled",
+  "git_use_system_credentials",
+  "git_disable_system_credentials",
 ]

--- a/apps/klank/src-tauri/permissions/allow-git.toml
+++ b/apps/klank/src-tauri/permissions/allow-git.toml
@@ -11,4 +11,7 @@ commands.allow = [
   "git_clone",
   "git_set_token",
   "git_has_token",
+  "git_sync",
+  "git_list_branches",
+  "git_checkout_branch",
 ]

--- a/apps/klank/src-tauri/src/git.rs
+++ b/apps/klank/src-tauri/src/git.rs
@@ -9,7 +9,7 @@
 use git2::{
     build::{CheckoutBuilder, RepoBuilder},
     BranchType, Commit, Cred, CredentialType, Error, ErrorCode, FetchOptions, Index, IndexConflict,
-    Oid, PushOptions, RemoteCallbacks, Repository, Signature, StatusOptions,
+    Oid, PushOptions, RemoteCallbacks, Repository, Signature, StatusOptions, Tree,
 };
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -718,10 +718,13 @@ fn rebase_onto_upstream(
     let upstream_tree = upstream_commit.tree()?;
 
     let mut merged = repo.merge_trees(&base_tree, &local_tree, &upstream_tree, None)?;
+    let local_newer = local_commit.time().seconds() >= upstream_commit.time().seconds(); // tie → local
+    // Resolve every path changed on BOTH sides ourselves — overriding libgit2's
+    // line-level text auto-merge so tabs follow whole-file "latest wins" and the
+    // settings file always gets the semantic JSON merge (not a fragile line merge).
+    resolve_dual_changes(&mut merged, repo, &base_tree, &local_tree, &upstream_tree, local_newer, result)?;
+    // Safety net for anything the tree diff couldn't name (e.g. non-UTF-8 paths).
     if merged.has_conflicts() {
-        // merge_trees: ours (stage 2) = local, theirs (stage 3) = upstream.
-        let local_newer =
-            local_commit.time().seconds() >= upstream_commit.time().seconds(); // tie → local
         resolve_conflicts(&mut merged, repo, local_newer, result)?;
     }
 
@@ -789,6 +792,96 @@ fn resolve_conflicts(
         }
     }
     Ok(())
+}
+
+/// Deterministically resolves every path changed on both sides relative to the
+/// merge base, overriding libgit2's text auto-merge. `.klank-settings.json` gets the
+/// semantic 3-way JSON merge; every other path (tabs included) is whole-file "latest
+/// commit time wins" — a deleted winning side leaves the path removed.
+fn resolve_dual_changes(
+    index: &mut Index,
+    repo: &Repository,
+    base_tree: &Tree,
+    local_tree: &Tree,
+    upstream_tree: &Tree,
+    local_newer: bool,
+    result: &mut SyncResult,
+) -> Result<(), Error> {
+    let local_changed = changed_paths(repo, base_tree, local_tree)?;
+    let remote_changed = changed_paths(repo, base_tree, upstream_tree)?;
+    for path in local_changed.intersection(&remote_changed) {
+        let p = Path::new(path);
+        let local_entry = local_tree.get_path(p).ok();
+        let remote_entry = upstream_tree.get_path(p).ok();
+        // Both sides converged on identical content → merge_trees already has it.
+        if let (Some(l), Some(r)) = (&local_entry, &remote_entry) {
+            if l.id() == r.id() {
+                continue;
+            }
+        }
+        result.conflicts_resolved += 1;
+        index.remove_path(p)?;
+
+        if is_settings_path(path) {
+            let base = blob_bytes_at(repo, base_tree, p)?;
+            let local_b = blob_bytes_at(repo, local_tree, p)?;
+            let remote_b = blob_bytes_at(repo, upstream_tree, p)?;
+            if let Some(bytes) =
+                merge_settings_json(base.as_deref(), local_b.as_deref(), remote_b.as_deref(), local_newer)
+            {
+                let oid = repo.blob(&bytes)?;
+                index.add(&make_index_entry(path, oid, 0o100644))?;
+                continue;
+            }
+            // All sides unparseable — fall through to whole-file latest-wins.
+        }
+
+        let winner = if local_newer { local_entry.as_ref() } else { remote_entry.as_ref() };
+        if let Some(e) = winner {
+            index.add(&make_index_entry(path, e.id(), e.filemode() as u32))?;
+        }
+        // else: the winning side deleted the file → leave it removed.
+    }
+    Ok(())
+}
+
+/// Paths that differ between `base` and `other` (added, modified, or deleted).
+fn changed_paths(repo: &Repository, base: &Tree, other: &Tree) -> Result<BTreeSet<String>, Error> {
+    let diff = repo.diff_tree_to_tree(Some(base), Some(other), None)?;
+    let mut out = BTreeSet::new();
+    for d in diff.deltas() {
+        for f in [d.new_file().path(), d.old_file().path()].into_iter().flatten() {
+            if let Some(s) = f.to_str() {
+                out.insert(s.to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn blob_bytes_at(repo: &Repository, tree: &Tree, path: &Path) -> Result<Option<Vec<u8>>, Error> {
+    match tree.get_path(path) {
+        Ok(entry) => Ok(Some(repo.find_blob(entry.id())?.content().to_vec())),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Builds a fresh stage-0 index entry for `path` pointing at an existing blob.
+fn make_index_entry(path: &str, oid: Oid, mode: u32) -> git2::IndexEntry {
+    git2::IndexEntry {
+        ctime: git2::IndexTime::new(0, 0),
+        mtime: git2::IndexTime::new(0, 0),
+        dev: 0,
+        ino: 0,
+        mode,
+        uid: 0,
+        gid: 0,
+        file_size: 0,
+        id: oid,
+        flags: 0,
+        flags_extended: 0,
+        path: path.as_bytes().to_vec(),
+    }
 }
 
 /// Rebuilds an index entry at merge stage 0 (`IndexEntry` is not `Clone` in git2).
@@ -1170,6 +1263,35 @@ mod tests {
     }
 
     #[test]
+    fn rebase_same_tab_disjoint_lines_takes_whole_latest() {
+        // Both sides edit *different lines* of the same tab. libgit2's text merge
+        // would splice them; our whole-file "latest wins" must take the newer side
+        // verbatim instead.
+        let (dir, repo) = temp_repo();
+        write(&dir, "song.tab.txt", "L1\nL2\nL3\n");
+        let base = commit_all(&repo, "base", 1000);
+        repo.branch("local", &repo.find_commit(base).unwrap(), false).unwrap();
+
+        write(&dir, "song.tab.txt", "R1\nL2\nL3\n"); // remote edits line 1
+        let main_oid = commit_all(&repo, "remote", 2000);
+
+        switch_to_local(&repo);
+        write(&dir, "song.tab.txt", "L1\nL2\nL3-local\n"); // local edits line 3, newer
+        commit_all(&repo, "local", 5000);
+
+        let mut result = SyncResult::default();
+        rebase_onto_upstream(&repo, "local", main_oid, &mut result).unwrap();
+        assert_eq!(result.conflicts_resolved, 1);
+        assert_eq!(
+            std::fs::read_to_string(dir.join("song.tab.txt")).unwrap(),
+            "L1\nL2\nL3-local\n",
+            "newer side wins the whole file — no line splicing",
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn rebase_clean_merge_keeps_both_sides() {
         let (dir, repo) = temp_repo();
         write(&dir, "a.tab.txt", "A0");
@@ -1278,6 +1400,25 @@ mod tests {
 
         let other = Error::from_str("some merge weirdness");
         assert_eq!(classify_error(&other), "other");
+    }
+
+    #[test]
+    fn json_merge_same_playlist_edited_both_sides_takes_newer() {
+        let base = br#"{"playlists":[{"id":"1","name":"A","paths":[],"createdAt":1}]}"#.as_slice();
+        let local = br#"{"playlists":[{"id":"1","name":"A","paths":["x"],"createdAt":1}]}"#.as_slice();
+        let remote = br#"{"playlists":[{"id":"1","name":"A","paths":["y"],"createdAt":1}]}"#.as_slice();
+
+        let merged = merge_settings_json(Some(base), Some(local), Some(remote), true).unwrap();
+        let v: Value = serde_json::from_slice(&merged).unwrap();
+        assert_eq!(v["playlists"][0]["paths"], serde_json::json!(["x"]), "newer side's playlist wins");
+    }
+
+    #[test]
+    fn current_branch_name_handles_unborn_head() {
+        let (dir, repo) = temp_repo(); // freshly init'd: HEAD is unborn
+        let name = current_branch_name(&repo).unwrap();
+        assert!(!name.is_empty(), "unborn HEAD still yields a default branch name");
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/apps/klank/src-tauri/src/git.rs
+++ b/apps/klank/src-tauri/src/git.rs
@@ -419,6 +419,9 @@ pub struct SyncResult {
     pub changed: bool,
     pub message: String,
     pub error: Option<String>,
+    /// Coarse failure category for actionable UI feedback: `"auth"`, `"network"`,
+    /// or `"other"`. Only set when `success` is false.
+    pub error_kind: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -427,6 +430,30 @@ pub struct BranchInfo {
     pub is_head: bool,
     pub is_remote: bool,
     pub upstream: Option<String>,
+}
+
+/// Buckets a libgit2 error so the UI can say whether sync failed on authentication
+/// or connectivity (vs. something else) without parsing raw messages on the frontend.
+fn classify_error(e: &Error) -> &'static str {
+    use git2::ErrorClass;
+    let msg = e.message().to_lowercase();
+    let auth = matches!(e.class(), ErrorClass::Callback)
+        || e.code() == ErrorCode::Auth
+        || ["credential", "authentication", "unauthorized", "401", "403"]
+            .iter()
+            .any(|s| msg.contains(s));
+    if auth {
+        return "auth";
+    }
+    let network = matches!(e.class(), ErrorClass::Net | ErrorClass::Http | ErrorClass::Ssl)
+        || ["connect", "resolve", "timed out", "timeout", "network", "failed to send"]
+            .iter()
+            .any(|s| msg.contains(s));
+    if network {
+        "network"
+    } else {
+        "other"
+    }
 }
 
 /// Auto-commit → fetch → rebase (auto-resolving conflicts) → push. Never prompts;
@@ -439,6 +466,7 @@ pub fn git_sync(app: tauri::AppHandle, dir: String) -> SyncResult {
             success: false,
             message: e.message().to_string(),
             error: Some(e.message().to_string()),
+            error_kind: Some(classify_error(&e).into()),
             ..Default::default()
         },
     }
@@ -1231,6 +1259,25 @@ mod tests {
         assert!(!dir.join("song.tab.txt").exists(), "newer side deleted → file removed");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn classify_error_buckets_auth_network_and_other() {
+        use git2::{ErrorClass, ErrorCode};
+        let auth_code = Error::new(ErrorCode::Auth, ErrorClass::None, "denied");
+        assert_eq!(classify_error(&auth_code), "auth");
+        let auth_cb = Error::new(ErrorCode::GenericError, ErrorClass::Callback, "no usable git credentials");
+        assert_eq!(classify_error(&auth_cb), "auth");
+        let auth_msg = Error::from_str("remote: Authentication failed for repo");
+        assert_eq!(classify_error(&auth_msg), "auth");
+
+        let net_class = Error::new(ErrorCode::GenericError, ErrorClass::Net, "boom");
+        assert_eq!(classify_error(&net_class), "network");
+        let net_msg = Error::from_str("failed to connect to github.com: could not resolve host");
+        assert_eq!(classify_error(&net_msg), "network");
+
+        let other = Error::from_str("some merge weirdness");
+        assert_eq!(classify_error(&other), "other");
     }
 
     #[test]

--- a/apps/klank/src-tauri/src/git.rs
+++ b/apps/klank/src-tauri/src/git.rs
@@ -500,19 +500,15 @@ fn sync_inner(app: &tauri::AppHandle, dir: &str) -> Result<SyncResult, Error> {
 
         let (ahead, _behind) = repo.graph_ahead_behind(head_oid(&repo)?, upstream)?;
         if ahead == 0 {
-            result.success = true;
             result.up_to_date = !committed && result.pulled == 0;
-            result.changed = result.pulled > 0 || result.conflicts_resolved > 0;
-            result.message = sync_message(&result);
+            finalize_sync(&mut result);
             return Ok(result);
         }
 
         match push_branch(app, &repo, &branch) {
             Ok(()) => {
                 result.pushed = ahead;
-                result.success = true;
-                result.changed = result.pulled > 0 || result.conflicts_resolved > 0;
-                result.message = sync_message(&result);
+                finalize_sync(&mut result);
                 return Ok(result);
             }
             Err(e) => {
@@ -537,6 +533,13 @@ fn sync_inner(app: &tauri::AppHandle, dir: &str) -> Result<SyncResult, Error> {
 
 fn head_oid(repo: &Repository) -> Result<Oid, Error> {
     repo.head()?.target().ok_or_else(|| Error::from_str("no HEAD"))
+}
+
+/// Marks a sync successful and fills in the derived `changed` flag and summary.
+fn finalize_sync(result: &mut SyncResult) {
+    result.success = true;
+    result.changed = result.pulled > 0 || result.conflicts_resolved > 0;
+    result.message = sync_message(result);
 }
 
 fn sync_message(r: &SyncResult) -> String {
@@ -992,6 +995,13 @@ mod tests {
         repo.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parents).unwrap()
     }
 
+    /// Checks out the `local` branch and resets the working tree to it.
+    fn switch_to_local(repo: &Repository) {
+        repo.set_head("refs/heads/local").unwrap();
+        let obj = repo.revparse_single("refs/heads/local").unwrap();
+        repo.reset(&obj, git2::ResetType::Hard, None).unwrap();
+    }
+
     // ── Pure JSON 3-way merge ───────────────────────────────────────────────
 
     #[test]
@@ -1081,9 +1091,7 @@ mod tests {
         let main_oid = commit_all(&repo, "A", 3000);
 
         // Local side (commit B) — older (secs 2000), diverged.
-        repo.set_head("refs/heads/local").unwrap();
-        let local_obj = repo.revparse_single("refs/heads/local").unwrap();
-        repo.reset(&local_obj, git2::ResetType::Hard, None).unwrap();
+        switch_to_local(&repo);
         write(&dir, "song.tab.txt", "B_VERSION");
         write(
             &dir,
@@ -1121,9 +1129,7 @@ mod tests {
         write(&dir, "song.tab.txt", "REMOTE");
         let main_oid = commit_all(&repo, "remote", 2000);
 
-        repo.set_head("refs/heads/local").unwrap();
-        let local_obj = repo.revparse_single("refs/heads/local").unwrap();
-        repo.reset(&local_obj, git2::ResetType::Hard, None).unwrap();
+        switch_to_local(&repo);
         write(&dir, "song.tab.txt", "LOCAL");
         commit_all(&repo, "local", 5000); // newer than remote
 
@@ -1133,5 +1139,114 @@ mod tests {
         assert_eq!(tab, "LOCAL", "local commit newer → local wins");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rebase_clean_merge_keeps_both_sides() {
+        let (dir, repo) = temp_repo();
+        write(&dir, "a.tab.txt", "A0");
+        write(&dir, "b.tab.txt", "B0");
+        let base = commit_all(&repo, "base", 1000);
+        repo.branch("local", &repo.find_commit(base).unwrap(), false).unwrap();
+
+        // Remote edits a different file than local → no conflict.
+        write(&dir, "b.tab.txt", "B-REMOTE");
+        let main_oid = commit_all(&repo, "remote", 2000);
+
+        switch_to_local(&repo);
+        write(&dir, "a.tab.txt", "A-LOCAL");
+        commit_all(&repo, "local", 3000);
+
+        let mut result = SyncResult::default();
+        rebase_onto_upstream(&repo, "local", main_oid, &mut result).unwrap();
+        assert_eq!(result.conflicts_resolved, 0, "disjoint edits must not conflict");
+        assert_eq!(std::fs::read_to_string(dir.join("a.tab.txt")).unwrap(), "A-LOCAL");
+        assert_eq!(std::fs::read_to_string(dir.join("b.tab.txt")).unwrap(), "B-REMOTE");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rebase_produces_linear_fast_forwardable_history() {
+        let (dir, repo) = temp_repo();
+        write(&dir, "song.tab.txt", "BASE");
+        let base = commit_all(&repo, "base", 1000);
+        repo.branch("local", &repo.find_commit(base).unwrap(), false).unwrap();
+        write(&dir, "song.tab.txt", "REMOTE");
+        let main_oid = commit_all(&repo, "remote", 2000);
+        switch_to_local(&repo);
+        write(&dir, "song.tab.txt", "LOCAL");
+        commit_all(&repo, "local", 3000);
+
+        let mut result = SyncResult::default();
+        rebase_onto_upstream(&repo, "local", main_oid, &mut result).unwrap();
+
+        // The integrated tip has exactly one parent: the upstream tip → the remote
+        // can fast-forward to it (no merge commit, linear history).
+        let tip = repo.find_commit(head_oid(&repo).unwrap()).unwrap();
+        assert_eq!(tip.parent_count(), 1);
+        assert_eq!(tip.parent_id(0).unwrap(), main_oid);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rebase_fast_forwards_when_no_local_commits() {
+        let (dir, repo) = temp_repo();
+        write(&dir, "song.tab.txt", "BASE");
+        let base = commit_all(&repo, "base", 1000);
+        repo.branch("local", &repo.find_commit(base).unwrap(), false).unwrap();
+        write(&dir, "song.tab.txt", "REMOTE");
+        let main_oid = commit_all(&repo, "remote", 2000);
+        switch_to_local(&repo); // local is purely behind, no local commits
+
+        let mut result = SyncResult::default();
+        let integrated = rebase_onto_upstream(&repo, "local", main_oid, &mut result).unwrap();
+        assert_eq!(integrated, 1);
+        assert_eq!(result.conflicts_resolved, 0);
+        // Pure fast-forward: local now points exactly at the upstream tip.
+        assert_eq!(repo.refname_to_id("refs/heads/local").unwrap(), main_oid);
+        assert_eq!(std::fs::read_to_string(dir.join("song.tab.txt")).unwrap(), "REMOTE");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rebase_delete_modify_latest_wins() {
+        let (dir, repo) = temp_repo();
+        write(&dir, "song.tab.txt", "BASE");
+        let base = commit_all(&repo, "base", 1000);
+        repo.branch("local", &repo.find_commit(base).unwrap(), false).unwrap();
+
+        // Remote modifies the file (older); local deletes it (newer) → deletion wins.
+        write(&dir, "song.tab.txt", "REMOTE-EDIT");
+        let main_oid = commit_all(&repo, "remote", 2000);
+        switch_to_local(&repo);
+        std::fs::remove_file(dir.join("song.tab.txt")).unwrap();
+        commit_all(&repo, "local-delete", 5000);
+
+        let mut result = SyncResult::default();
+        rebase_onto_upstream(&repo, "local", main_oid, &mut result).unwrap();
+        assert!(result.conflicts_resolved >= 1);
+        assert!(!dir.join("song.tab.txt").exists(), "newer side deleted → file removed");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn json_merge_key_deleted_by_newer_side_is_removed() {
+        let base = br#"{"k":{"fontSize":1}}"#.as_slice();
+        let local = br#"{}"#.as_slice(); // local removed k
+        let remote = br#"{"k":{"fontSize":1}}"#.as_slice();
+
+        // Local (deletion) is newer → key removed.
+        let removed = merge_settings_json(Some(base), Some(local), Some(remote), true).unwrap();
+        let v: Value = serde_json::from_slice(&removed).unwrap();
+        assert!(v.get("k").is_none(), "newer deletion removes the key");
+
+        // Remote (unchanged) is newer → deletion still wins because remote == base.
+        let kept = merge_settings_json(Some(base), Some(local), Some(remote), false).unwrap();
+        let v: Value = serde_json::from_slice(&kept).unwrap();
+        assert!(v.get("k").is_none(), "remote unchanged from base → local deletion applies");
     }
 }

--- a/apps/klank/src-tauri/src/git.rs
+++ b/apps/klank/src-tauri/src/git.rs
@@ -8,10 +8,12 @@
 
 use git2::{
     build::{CheckoutBuilder, RepoBuilder},
-    Cred, CredentialType, Error, FetchOptions, PushOptions, RemoteCallbacks, Repository,
-    Signature, StatusOptions,
+    BranchType, Commit, Cred, CredentialType, Error, ErrorCode, FetchOptions, Index, IndexConflict,
+    Oid, PushOptions, RemoteCallbacks, Repository, Signature, StatusOptions,
 };
 use serde::Serialize;
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use tauri::Manager;
 
@@ -283,4 +285,751 @@ fn clone_inner(app: tauri::AppHandle, url: &str, dir: &str) -> Result<(), Error>
     builder.fetch_options(fo);
     builder.clone(url, Path::new(dir))?;
     Ok(())
+}
+
+// ───────────────────────── Unobtrusive auto-sync ─────────────────────────
+//
+// `git_sync` is the single entry point the app's background loop calls: it
+// auto-commits local edits, pulls with rebase, auto-resolves conflicts without
+// ever prompting (whole-file "latest commit time wins" for tabs; semantic 3-way
+// JSON merge for `.klank-settings.json`), and pushes — so two devices (or two
+// people) sharing a tab repo converge seamlessly. A process-wide mutex serializes
+// syncs so two never overlap.
+
+const MAX_SYNC_ATTEMPTS: usize = 5;
+const SETTINGS_FILE: &str = ".klank-settings.json";
+const PLAYLISTS_KEY: &str = "playlists";
+/// `GIT_INDEX_ENTRY_STAGEMASK` — bits 12-13 of `IndexEntry::flags` hold the merge stage.
+const STAGE_MASK: u16 = 0x3000;
+
+static SYNC_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[derive(Serialize, Default)]
+pub struct SyncResult {
+    pub success: bool,
+    pub committed: bool,
+    pub pulled: usize,
+    pub pushed: usize,
+    pub conflicts_resolved: usize,
+    pub branch: Option<String>,
+    pub up_to_date: bool,
+    /// True when the working tree changed underneath the app (so the UI re-hydrates).
+    pub changed: bool,
+    pub message: String,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct BranchInfo {
+    pub name: String,
+    pub is_head: bool,
+    pub is_remote: bool,
+    pub upstream: Option<String>,
+}
+
+/// Auto-commit → fetch → rebase (auto-resolving conflicts) → push. Never prompts;
+/// returns a structured summary of what happened.
+#[tauri::command]
+pub fn git_sync(app: tauri::AppHandle, dir: String) -> SyncResult {
+    match sync_inner(&app, &dir) {
+        Ok(r) => r,
+        Err(e) => SyncResult {
+            success: false,
+            message: e.message().to_string(),
+            error: Some(e.message().to_string()),
+            ..Default::default()
+        },
+    }
+}
+
+#[tauri::command]
+pub fn git_list_branches(dir: String) -> Result<Vec<BranchInfo>, String> {
+    list_branches_inner(&dir).map_err(|e| e.message().to_string())
+}
+
+#[tauri::command]
+pub fn git_checkout_branch(dir: String, branch: String) -> GitResult {
+    match checkout_branch_inner(&dir, &branch) {
+        Ok(msg) => GitResult::ok(msg),
+        Err(e) => GitResult::err(e),
+    }
+}
+
+fn sync_inner(app: &tauri::AppHandle, dir: &str) -> Result<SyncResult, Error> {
+    let _guard = SYNC_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let repo = Repository::discover(dir)?;
+    let mut result = SyncResult::default();
+    let branch = current_branch_name(&repo)?;
+    result.branch = Some(branch.clone());
+
+    // 1. Commit any local edits first so the working tree is clean for rebase.
+    let (committed, _msg) = auto_commit(&repo)?;
+    result.committed = committed;
+
+    // 2. Fetch. No remote → commit-only success.
+    if !fetch_origin(app, &repo, &branch)? {
+        result.success = true;
+        result.up_to_date = !committed;
+        result.message = if committed {
+            "Committed locally (no remote)".into()
+        } else {
+            "No remote configured".into()
+        };
+        return Ok(result);
+    }
+
+    let upstream_ref = format!("refs/remotes/origin/{branch}");
+
+    // 3. No upstream branch yet → first push.
+    let Some(mut upstream) = repo.find_reference(&upstream_ref).ok().and_then(|r| r.target()) else {
+        push_branch(app, &repo, &branch)?;
+        result.pushed = 1;
+        result.success = true;
+        result.message = format!("Pushed new branch {branch}");
+        return Ok(result);
+    };
+
+    // 4. Rebase-then-push, retrying if the remote moved under us.
+    for attempt in 0..MAX_SYNC_ATTEMPTS {
+        let (_ahead, behind) = repo.graph_ahead_behind(head_oid(&repo)?, upstream)?;
+        if behind > 0 {
+            result.pulled += rebase_onto_upstream(&repo, &branch, upstream, &mut result)?;
+        }
+
+        let (ahead, _behind) = repo.graph_ahead_behind(head_oid(&repo)?, upstream)?;
+        if ahead == 0 {
+            result.success = true;
+            result.up_to_date = !committed && result.pulled == 0;
+            result.changed = result.pulled > 0 || result.conflicts_resolved > 0;
+            result.message = sync_message(&result);
+            return Ok(result);
+        }
+
+        match push_branch(app, &repo, &branch) {
+            Ok(()) => {
+                result.pushed = ahead;
+                result.success = true;
+                result.changed = result.pulled > 0 || result.conflicts_resolved > 0;
+                result.message = sync_message(&result);
+                return Ok(result);
+            }
+            Err(e) => {
+                let retriable = e.code() == ErrorCode::NotFastForward
+                    || e.message().contains("rejected")
+                    || e.message().contains("fast-forward");
+                if retriable && attempt + 1 < MAX_SYNC_ATTEMPTS {
+                    fetch_origin(app, &repo, &branch)?;
+                    upstream = repo
+                        .find_reference(&upstream_ref)
+                        .ok()
+                        .and_then(|r| r.target())
+                        .unwrap_or(upstream);
+                    continue;
+                }
+                return Err(e);
+            }
+        }
+    }
+    Err(Error::from_str("remote moving too fast, try again"))
+}
+
+fn head_oid(repo: &Repository) -> Result<Oid, Error> {
+    repo.head()?.target().ok_or_else(|| Error::from_str("no HEAD"))
+}
+
+fn sync_message(r: &SyncResult) -> String {
+    let mut parts = Vec::new();
+    if r.committed {
+        parts.push("committed".to_string());
+    }
+    if r.pulled > 0 {
+        parts.push(format!("pulled {}", r.pulled));
+    }
+    if r.conflicts_resolved > 0 {
+        parts.push(format!("auto-merged {}", r.conflicts_resolved));
+    }
+    if r.pushed > 0 {
+        parts.push(format!("pushed {}", r.pushed));
+    }
+    if parts.is_empty() {
+        "Already up to date".into()
+    } else {
+        parts.join(", ")
+    }
+}
+
+/// Branch name from HEAD, tolerating an unborn HEAD (fresh repo, no commits yet).
+fn current_branch_name(repo: &Repository) -> Result<String, Error> {
+    if let Ok(head) = repo.head() {
+        return head
+            .shorthand()
+            .map(str::to_string)
+            .ok_or_else(|| Error::from_str("no current branch"));
+    }
+    if let Ok(reference) = repo.find_reference("HEAD") {
+        if let Some(target) = reference.symbolic_target() {
+            return Ok(target.strip_prefix("refs/heads/").unwrap_or(target).to_string());
+        }
+    }
+    let cfg = repo.config()?;
+    Ok(cfg.get_string("init.defaultBranch").unwrap_or_else(|_| "main".into()))
+}
+
+/// Stages every change (untracked, modified, deleted) and commits. `.gitignore` is
+/// honored. Returns whether anything was committed and the generated message.
+fn auto_commit(repo: &Repository) -> Result<(bool, String), Error> {
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(true).recurse_untracked_dirs(true);
+    let statuses = repo.statuses(Some(&mut opts))?;
+    if statuses.is_empty() {
+        return Ok((false, String::new()));
+    }
+    let (mut added, mut modified, mut deleted) = (0usize, 0usize, 0usize);
+    for e in statuses.iter() {
+        let s = e.status();
+        if s.is_wt_new() || s.is_index_new() {
+            added += 1;
+        } else if s.is_wt_deleted() || s.is_index_deleted() {
+            deleted += 1;
+        } else {
+            modified += 1;
+        }
+    }
+
+    let mut index = repo.index()?;
+    index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
+    index.update_all(["*"].iter(), None)?; // records working-tree deletions
+    index.write()?;
+    let tree = repo.find_tree(index.write_tree()?)?;
+    let sig = signature(repo)?;
+    let parent = repo.head().ok().and_then(|h| h.target()).and_then(|o| repo.find_commit(o).ok());
+    let parents: Vec<&Commit> = parent.iter().collect();
+    let total = added + modified + deleted;
+    let msg = format!(
+        "klank sync: {total} changed (A{added} M{modified} D{deleted}) @ {}",
+        chrono::Utc::now().to_rfc3339()
+    );
+    repo.commit(Some("HEAD"), &sig, &sig, &msg, &tree, &parents)?;
+    Ok((true, msg))
+}
+
+/// Fetches `origin` for `branch`. Returns `false` when there is no `origin` remote.
+fn fetch_origin(app: &tauri::AppHandle, repo: &Repository, branch: &str) -> Result<bool, Error> {
+    let mut remote = match repo.find_remote("origin") {
+        Ok(r) => r,
+        Err(_) => return Ok(false),
+    };
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks(app.clone()));
+    remote.fetch(&[branch], Some(&mut fo), None)?;
+    Ok(true)
+}
+
+/// Pushes `branch` to `origin`, surfacing a non-fast-forward rejection as an error
+/// (so the caller can re-fetch/re-rebase). Never force-pushes.
+fn push_branch(app: &tauri::AppHandle, repo: &Repository, branch: &str) -> Result<(), Error> {
+    let mut remote = repo.find_remote("origin")?;
+    let rejected = std::rc::Rc::new(std::cell::RefCell::new(None::<String>));
+    let mut cb = callbacks(app.clone());
+    {
+        let rejected = rejected.clone();
+        cb.push_update_reference(move |refname, status| {
+            if let Some(s) = status {
+                *rejected.borrow_mut() = Some(format!("{refname}: {s}"));
+            }
+            Ok(())
+        });
+    }
+    let mut po = PushOptions::new();
+    po.remote_callbacks(cb);
+    remote.push(&[format!("refs/heads/{branch}:refs/heads/{branch}")], Some(&mut po))?;
+    if let Some(msg) = rejected.borrow().clone() {
+        return Err(Error::from_str(&format!("push rejected: {msg}")));
+    }
+    Ok(())
+}
+
+/// Integrates upstream into the local branch and leaves a linear history that the
+/// remote can fast-forward to. Rather than drive libgit2's rebase state machine
+/// (whose in-memory `commit` ignores manual index edits), we 3-way `merge_trees`,
+/// auto-resolve conflicts in the resulting index, and write one squashed commit
+/// parented on the upstream tip. Returns the number of upstream commits integrated.
+fn rebase_onto_upstream(
+    repo: &Repository,
+    branch: &str,
+    upstream_oid: Oid,
+    result: &mut SyncResult,
+) -> Result<usize, Error> {
+    let local_oid = head_oid(repo)?;
+    let (ahead, behind) = repo.graph_ahead_behind(local_oid, upstream_oid)?;
+    if behind == 0 {
+        return Ok(0); // already contains upstream; nothing to integrate
+    }
+
+    let refname = format!("refs/heads/{branch}");
+
+    // Pure fast-forward: no local commits to preserve, just move to upstream.
+    if ahead == 0 {
+        repo.reference(&refname, upstream_oid, true, "klank sync: fast-forward")?;
+        repo.set_head(&refname)?;
+        repo.checkout_head(Some(CheckoutBuilder::new().force()))?;
+        return Ok(behind);
+    }
+
+    // Diverged: 3-way merge local (ours) with upstream (theirs).
+    let local_commit = repo.find_commit(local_oid)?;
+    let upstream_commit = repo.find_commit(upstream_oid)?;
+    let base_oid = repo.merge_base(local_oid, upstream_oid)?;
+    let base_tree = repo.find_commit(base_oid)?.tree()?;
+    let local_tree = local_commit.tree()?;
+    let upstream_tree = upstream_commit.tree()?;
+
+    let mut merged = repo.merge_trees(&base_tree, &local_tree, &upstream_tree, None)?;
+    if merged.has_conflicts() {
+        // merge_trees: ours (stage 2) = local, theirs (stage 3) = upstream.
+        let local_newer =
+            local_commit.time().seconds() >= upstream_commit.time().seconds(); // tie → local
+        resolve_conflicts(&mut merged, repo, local_newer, result)?;
+    }
+
+    let tree = repo.find_tree(merged.write_tree_to(repo)?)?;
+    let sig = signature(repo)?;
+    // Detached create (parent = upstream, not the current tip), then force the ref.
+    let new_oid = repo.commit(
+        None,
+        &sig,
+        &sig,
+        "klank sync: merge local changes",
+        &tree,
+        &[&upstream_commit],
+    )?;
+    repo.reference(&refname, new_oid, true, "klank sync: integrate")?;
+    repo.set_head(&refname)?;
+    repo.checkout_head(Some(CheckoutBuilder::new().force()))?;
+    Ok(behind)
+}
+
+/// Auto-resolves every conflict in a `merge_trees` index, where ours (stage 2) is
+/// the local side and theirs (stage 3) is the remote (upstream) side. `.klank-settings.json`
+/// gets a semantic 3-way JSON merge; everything else is whole-file "latest commit
+/// time wins" (a deleted winning side leaves the path removed).
+fn resolve_conflicts(
+    index: &mut Index,
+    repo: &Repository,
+    local_newer: bool,
+    result: &mut SyncResult,
+) -> Result<(), Error> {
+    let conflicts: Vec<IndexConflict> = index.conflicts()?.collect::<Result<_, _>>()?;
+    for c in &conflicts {
+        let path = conflict_path(c);
+        result.conflicts_resolved += 1;
+        let local = c.our.as_ref();
+        let remote = c.their.as_ref();
+
+        if is_settings_path(&path) {
+            let base = blob_for(repo, c.ancestor.as_ref())?;
+            let local_bytes = blob_for(repo, local)?;
+            let remote_bytes = blob_for(repo, remote)?;
+            if let Some(bytes) = merge_settings_json(
+                base.as_deref(),
+                local_bytes.as_deref(),
+                remote_bytes.as_deref(),
+                local_newer,
+            ) {
+                let template = local.or(remote).or(c.ancestor.as_ref());
+                index.remove_path(Path::new(&path))?;
+                if let Some(t) = template {
+                    let mut entry = entry_at_stage0(t);
+                    entry.id = repo.blob(&bytes)?;
+                    entry.file_size = bytes.len() as u32;
+                    index.add(&entry)?;
+                }
+                continue;
+            }
+            // All sides unparseable — fall through to whole-file latest-wins.
+        }
+
+        let winner = if local_newer { local } else { remote };
+        index.remove_path(Path::new(&path))?;
+        if let Some(entry) = winner {
+            index.add(&entry_at_stage0(entry))?; // re-add winning blob at stage 0
+        }
+    }
+    Ok(())
+}
+
+/// Rebuilds an index entry at merge stage 0 (`IndexEntry` is not `Clone` in git2).
+fn entry_at_stage0(src: &git2::IndexEntry) -> git2::IndexEntry {
+    git2::IndexEntry {
+        ctime: src.ctime,
+        mtime: src.mtime,
+        dev: src.dev,
+        ino: src.ino,
+        mode: src.mode,
+        uid: src.uid,
+        gid: src.gid,
+        file_size: src.file_size,
+        id: src.id,
+        flags: src.flags & !STAGE_MASK,
+        flags_extended: src.flags_extended,
+        path: src.path.clone(),
+    }
+}
+
+fn conflict_path(c: &IndexConflict) -> String {
+    let bytes = c
+        .our
+        .as_ref()
+        .or(c.their.as_ref())
+        .or(c.ancestor.as_ref())
+        .map(|e| e.path.clone())
+        .unwrap_or_default();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn is_settings_path(path: &str) -> bool {
+    path.replace('\\', "/").ends_with(SETTINGS_FILE)
+}
+
+fn blob_for(repo: &Repository, entry: Option<&git2::IndexEntry>) -> Result<Option<Vec<u8>>, Error> {
+    match entry {
+        Some(e) => Ok(Some(repo.find_blob(e.id)?.content().to_vec())),
+        None => Ok(None),
+    }
+}
+
+/// Semantic 3-way merge of `.klank-settings.json`. Returns `None` only when every
+/// side is unparseable (caller then falls back to whole-file). Output mirrors the
+/// frontend writer: sorted keys, 2-space indent (see `libs/platform-api/.../fs.ts`).
+fn merge_settings_json(
+    base: Option<&[u8]>,
+    local: Option<&[u8]>,
+    remote: Option<&[u8]>,
+    local_newer: bool,
+) -> Option<Vec<u8>> {
+    let parse = |b: Option<&[u8]>| -> Option<Map<String, Value>> {
+        b.and_then(|x| serde_json::from_slice::<Value>(x).ok())
+            .and_then(|v| v.as_object().cloned())
+    };
+    let (base_v, local_v, remote_v) = (parse(base), parse(local), parse(remote));
+    if base_v.is_none() && local_v.is_none() && remote_v.is_none() {
+        return None;
+    }
+    let base_m = base_v.unwrap_or_default();
+    let local_m = local_v.unwrap_or_default();
+    let remote_m = remote_v.unwrap_or_default();
+
+    let mut keys: BTreeSet<&String> = BTreeSet::new();
+    keys.extend(base_m.keys());
+    keys.extend(local_m.keys());
+    keys.extend(remote_m.keys());
+
+    let mut out = Map::new();
+    for key in keys {
+        let (b, l, r) = (base_m.get(key), local_m.get(key), remote_m.get(key));
+        let merged = if key == PLAYLISTS_KEY {
+            merge_playlists(b, l, r, local_newer)
+        } else {
+            three_way_value(b, l, r, local_newer)
+        };
+        if let Some(v) = merged {
+            out.insert(key.clone(), v);
+        }
+    }
+    serde_json::to_vec_pretty(&Value::Object(out)).ok()
+}
+
+/// Classic 3-way merge of a single JSON value. `None` means "absent" (a deletion);
+/// returning `None` omits the key. On a true both-sides-changed conflict the
+/// latest-commit-time side wins.
+fn three_way_value(
+    base: Option<&Value>,
+    local: Option<&Value>,
+    remote: Option<&Value>,
+    local_newer: bool,
+) -> Option<Value> {
+    if local == remote {
+        return local.cloned();
+    }
+    if local == base {
+        return remote.cloned(); // local unchanged → take remote (possibly a deletion)
+    }
+    if remote == base {
+        return local.cloned(); // remote unchanged → take local
+    }
+    if local_newer {
+        local.cloned()
+    } else {
+        remote.cloned()
+    }
+}
+
+/// Merges the `playlists` array by playlist `id`, 3-way per playlist, ordering the
+/// result by `createdAt` then `id` for stable, minimal diffs.
+fn merge_playlists(
+    base: Option<&Value>,
+    local: Option<&Value>,
+    remote: Option<&Value>,
+    local_newer: bool,
+) -> Option<Value> {
+    let by_id = |v: Option<&Value>| -> BTreeMap<String, Value> {
+        let mut m = BTreeMap::new();
+        if let Some(Value::Array(arr)) = v {
+            for item in arr {
+                if let Some(id) = item.get("id").and_then(Value::as_str) {
+                    m.insert(id.to_string(), item.clone());
+                }
+            }
+        }
+        m
+    };
+    let (base_m, local_m, remote_m) = (by_id(base), by_id(local), by_id(remote));
+    let mut ids: BTreeSet<&String> = BTreeSet::new();
+    ids.extend(base_m.keys());
+    ids.extend(local_m.keys());
+    ids.extend(remote_m.keys());
+
+    let mut merged: Vec<Value> = ids
+        .into_iter()
+        .filter_map(|id| three_way_value(base_m.get(id), local_m.get(id), remote_m.get(id), local_newer))
+        .collect();
+    merged.sort_by(|a, b| {
+        let ca = a.get("createdAt").and_then(Value::as_i64).unwrap_or(0);
+        let cb = b.get("createdAt").and_then(Value::as_i64).unwrap_or(0);
+        ca.cmp(&cb).then_with(|| {
+            let ia = a.get("id").and_then(Value::as_str).unwrap_or("");
+            let ib = b.get("id").and_then(Value::as_str).unwrap_or("");
+            ia.cmp(ib)
+        })
+    });
+    Some(Value::Array(merged))
+}
+
+fn list_branches_inner(dir: &str) -> Result<Vec<BranchInfo>, Error> {
+    let repo = Repository::discover(dir)?;
+    let mut out: Vec<BranchInfo> = Vec::new();
+    for b in repo.branches(Some(BranchType::Local))? {
+        let (branch, _) = b?;
+        let Some(name) = branch.name()?.map(str::to_string) else { continue };
+        let upstream = branch
+            .upstream()
+            .ok()
+            .and_then(|u| u.name().ok().flatten().map(str::to_string));
+        out.push(BranchInfo { name, is_head: branch.is_head(), is_remote: false, upstream });
+    }
+    let local: BTreeSet<String> = out.iter().map(|b| b.name.clone()).collect();
+    for b in repo.branches(Some(BranchType::Remote))? {
+        let (branch, _) = b?;
+        let Some(full) = branch.name()?.map(str::to_string) else { continue };
+        if full.ends_with("/HEAD") {
+            continue;
+        }
+        let short = full.strip_prefix("origin/").unwrap_or(&full).to_string();
+        if local.contains(&short) {
+            continue;
+        }
+        out.push(BranchInfo { name: short, is_head: false, is_remote: true, upstream: None });
+    }
+    Ok(out)
+}
+
+/// Switches HEAD to `branch`. Creates a local tracking branch from `origin/<branch>`
+/// when only the remote-tracking ref exists. Uses a safe checkout so it never
+/// clobbers uncommitted work (the app calls `git_sync` first to commit).
+fn checkout_branch_inner(dir: &str, branch: &str) -> Result<String, Error> {
+    let repo = Repository::discover(dir)?;
+    let local_ref = format!("refs/heads/{branch}");
+    if repo.find_reference(&local_ref).is_err() {
+        let remote = repo
+            .find_reference(&format!("refs/remotes/origin/{branch}"))
+            .map_err(|_| Error::from_str("no such branch"))?
+            .peel_to_commit()?;
+        let mut local = repo.branch(branch, &remote, false)?;
+        let _ = local.set_upstream(Some(&format!("origin/{branch}")));
+    }
+    let obj = repo.revparse_single(&local_ref)?;
+    repo.checkout_tree(&obj, Some(CheckoutBuilder::new().safe()))?;
+    repo.set_head(&local_ref)?;
+    Ok(format!("Switched to {branch}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use git2::Time;
+    use std::path::PathBuf;
+
+    fn temp_repo() -> (PathBuf, Repository) {
+        let mut p = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        p.push(format!("klank-git-test-{}-{}", std::process::id(), nanos));
+        std::fs::create_dir_all(&p).unwrap();
+        let repo = Repository::init(&p).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@klank").unwrap();
+        (p, repo)
+    }
+
+    fn write(dir: &Path, name: &str, content: &str) {
+        std::fs::write(dir.join(name), content).unwrap();
+    }
+
+    fn commit_all(repo: &Repository, msg: &str, secs: i64) -> Oid {
+        let mut index = repo.index().unwrap();
+        index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None).unwrap();
+        index.update_all(["*"].iter(), None).unwrap();
+        index.write().unwrap();
+        let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+        let sig = Signature::new("Test", "test@klank", &Time::new(secs, 0)).unwrap();
+        let parent = repo.head().ok().and_then(|h| h.target()).and_then(|o| repo.find_commit(o).ok());
+        let parents: Vec<&Commit> = parent.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parents).unwrap()
+    }
+
+    // ── Pure JSON 3-way merge ───────────────────────────────────────────────
+
+    #[test]
+    fn json_merge_disjoint_keys_both_survive() {
+        let merged = merge_settings_json(
+            Some(br#"{}"#),
+            Some(br#"{"a.tab.txt":{"fontSize":1}}"#),
+            Some(br#"{"b.tab.txt":{"fontSize":2}}"#),
+            true,
+        )
+        .unwrap();
+        let v: Value = serde_json::from_slice(&merged).unwrap();
+        assert!(v.get("a.tab.txt").is_some(), "local-only key must survive");
+        assert!(v.get("b.tab.txt").is_some(), "remote-only key must survive");
+    }
+
+    #[test]
+    fn json_merge_conflict_prefers_newer() {
+        let (base, local, remote) = (
+            br#"{"k":{"fontSize":1}}"#.as_slice(),
+            br#"{"k":{"fontSize":2}}"#.as_slice(),
+            br#"{"k":{"fontSize":3}}"#.as_slice(),
+        );
+        let local_wins = merge_settings_json(Some(base), Some(local), Some(remote), true).unwrap();
+        let v: Value = serde_json::from_slice(&local_wins).unwrap();
+        assert_eq!(v["k"]["fontSize"], 2);
+
+        let remote_wins = merge_settings_json(Some(base), Some(local), Some(remote), false).unwrap();
+        let v: Value = serde_json::from_slice(&remote_wins).unwrap();
+        assert_eq!(v["k"]["fontSize"], 3);
+    }
+
+    #[test]
+    fn json_merge_playlists_by_id() {
+        let merged = merge_settings_json(
+            Some(br#"{"playlists":[]}"#),
+            Some(br#"{"playlists":[{"id":"1","name":"L","paths":[],"createdAt":1}]}"#),
+            Some(br#"{"playlists":[{"id":"2","name":"R","paths":[],"createdAt":2}]}"#),
+            true,
+        )
+        .unwrap();
+        let v: Value = serde_json::from_slice(&merged).unwrap();
+        let arr = v["playlists"].as_array().unwrap();
+        assert_eq!(arr.len(), 2, "playlists from both sides merge by id");
+        assert_eq!(arr[0]["id"], "1"); // ordered by createdAt
+        assert_eq!(arr[1]["id"], "2");
+    }
+
+    #[test]
+    fn json_output_is_sorted_2space() {
+        let merged =
+            merge_settings_json(Some(br#"{}"#), Some(br#"{"b":1,"a":2}"#), Some(br#"{}"#), true).unwrap();
+        let s = String::from_utf8(merged).unwrap();
+        assert!(s.contains("\n  \"a\""), "2-space indent expected: {s}");
+        assert!(s.find("\"a\"").unwrap() < s.find("\"b\"").unwrap(), "keys must be sorted");
+    }
+
+    #[test]
+    fn json_merge_all_unparseable_returns_none() {
+        assert!(merge_settings_json(Some(b"not json"), Some(b"also bad"), None, true).is_none());
+    }
+
+    // ── Real libgit2 rebase + auto-resolution ───────────────────────────────
+
+    #[test]
+    fn rebase_auto_resolves_tab_and_settings() {
+        let (dir, repo) = temp_repo();
+
+        write(&dir, "song.tab.txt", "BASE");
+        write(
+            &dir,
+            ".klank-settings.json",
+            r#"{"Z.tab.txt":{"fontSize":10,"transpose":0,"scrollSpeed":1}}"#,
+        );
+        let base = commit_all(&repo, "base", 1000);
+
+        let base_commit = repo.find_commit(base).unwrap();
+        repo.branch("local", &base_commit, false).unwrap();
+
+        // Remote side (commit A) — newer (secs 3000).
+        write(&dir, "song.tab.txt", "A_VERSION");
+        write(
+            &dir,
+            ".klank-settings.json",
+            r#"{"X.tab.txt":{"fontSize":15,"transpose":0,"scrollSpeed":1},"Z.tab.txt":{"fontSize":20,"transpose":0,"scrollSpeed":1}}"#,
+        );
+        let main_oid = commit_all(&repo, "A", 3000);
+
+        // Local side (commit B) — older (secs 2000), diverged.
+        repo.set_head("refs/heads/local").unwrap();
+        let local_obj = repo.revparse_single("refs/heads/local").unwrap();
+        repo.reset(&local_obj, git2::ResetType::Hard, None).unwrap();
+        write(&dir, "song.tab.txt", "B_VERSION");
+        write(
+            &dir,
+            ".klank-settings.json",
+            r#"{"Y.tab.txt":{"fontSize":25,"transpose":0,"scrollSpeed":1},"Z.tab.txt":{"fontSize":30,"transpose":0,"scrollSpeed":1}}"#,
+        );
+        commit_all(&repo, "B", 2000);
+
+        let mut result = SyncResult::default();
+        let integrated = rebase_onto_upstream(&repo, "local", main_oid, &mut result).unwrap();
+        assert_eq!(integrated, 1);
+        assert!(result.conflicts_resolved >= 2, "tab + settings both conflicted");
+
+        // Whole-file tab: remote (A @3000) is newer than local (B @2000) → A wins.
+        let tab = std::fs::read_to_string(dir.join("song.tab.txt")).unwrap();
+        assert_eq!(tab, "A_VERSION");
+
+        let settings: Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.join(".klank-settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(settings["Z.tab.txt"]["fontSize"], 20, "conflict → newer (A) wins");
+        assert!(settings.get("X.tab.txt").is_some(), "A-only key survives");
+        assert!(settings.get("Y.tab.txt").is_some(), "B-only key survives");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rebase_whole_file_local_newer_wins() {
+        let (dir, repo) = temp_repo();
+        write(&dir, "song.tab.txt", "BASE");
+        let base = commit_all(&repo, "base", 1000);
+        repo.branch("local", &repo.find_commit(base).unwrap(), false).unwrap();
+
+        write(&dir, "song.tab.txt", "REMOTE");
+        let main_oid = commit_all(&repo, "remote", 2000);
+
+        repo.set_head("refs/heads/local").unwrap();
+        let local_obj = repo.revparse_single("refs/heads/local").unwrap();
+        repo.reset(&local_obj, git2::ResetType::Hard, None).unwrap();
+        write(&dir, "song.tab.txt", "LOCAL");
+        commit_all(&repo, "local", 5000); // newer than remote
+
+        let mut result = SyncResult::default();
+        rebase_onto_upstream(&repo, "local", main_oid, &mut result).unwrap();
+        let tab = std::fs::read_to_string(dir.join("song.tab.txt")).unwrap();
+        assert_eq!(tab, "LOCAL", "local commit newer → local wins");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/apps/klank/src-tauri/src/git.rs
+++ b/apps/klank/src-tauri/src/git.rs
@@ -54,6 +54,32 @@ fn read_token(app: &tauri::AppHandle) -> Option<String> {
     }
 }
 
+/// Marker file recording that the user opted into the OS git credential helper
+/// (desktop). It carries no secret — `callbacks()` already resolves the helper —
+/// it just tells the app that auth is configured so sync stops asking for a PAT.
+const CRED_MODE_FILE: &str = "git_cred_mode";
+
+fn cred_mode_path(app: &tauri::AppHandle) -> Option<std::path::PathBuf> {
+    app.path().app_config_dir().ok().map(|d| d.join(CRED_MODE_FILE))
+}
+
+fn system_credentials_enabled(app: &tauri::AppHandle) -> bool {
+    cred_mode_path(app).map(|p| p.exists()).unwrap_or(false)
+}
+
+fn set_system_credentials(app: &tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let path = cred_mode_path(app).ok_or("no config directory")?;
+    if !enabled {
+        let _ = std::fs::remove_file(&path);
+        return Ok(());
+    }
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&path, "system").map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 /// Stores (or, when empty, clears) the HTTPS Personal Access Token used for
 /// push/pull/clone. Written app-private with `0600` perms on unix.
 #[tauri::command]
@@ -83,6 +109,62 @@ pub fn git_has_token(app: tauri::AppHandle) -> bool {
     read_token(&app).is_some()
 }
 
+/// Whether sync has any usable authentication: a stored PAT, or the user has opted
+/// into the OS credential helper. The frontend gates sync on this (not on the PAT
+/// alone) so a configured helper works with no token.
+#[tauri::command]
+pub fn git_is_authenticated(app: tauri::AppHandle) -> bool {
+    read_token(&app).is_some() || system_credentials_enabled(&app)
+}
+
+/// Whether the user has opted into the OS credential helper.
+#[tauri::command]
+pub fn git_system_credentials_enabled(app: tauri::AppHandle) -> bool {
+    system_credentials_enabled(&app)
+}
+
+/// Desktop one-click sign-in: verifies the OS git credential helper can authenticate
+/// against the repo's `origin` (this is what triggers Git Credential Manager's
+/// interactive login on first use), and on success records that auth is configured.
+#[tauri::command]
+pub fn git_use_system_credentials(app: tauri::AppHandle, dir: String) -> GitResult {
+    match probe_system_credentials(&dir) {
+        Ok(()) => match set_system_credentials(&app, true) {
+            Ok(()) => GitResult::ok("Using system Git credentials"),
+            Err(e) => GitResult { success: false, output: String::new(), error: Some(e) },
+        },
+        Err(e) => GitResult::err(e),
+    }
+}
+
+/// Turns off the system-credential opt-in (does not touch any stored PAT).
+#[tauri::command]
+pub fn git_disable_system_credentials(app: tauri::AppHandle) -> Result<(), String> {
+    set_system_credentials(&app, false)
+}
+
+fn probe_system_credentials(dir: &str) -> Result<(), Error> {
+    let repo = Repository::discover(dir)?;
+    let mut remote = repo.find_remote("origin")?;
+    if let Some(url) = remote.url() {
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            return Err(Error::from_str(
+                "origin is not an HTTPS remote — the credential helper only applies to HTTPS",
+            ));
+        }
+    }
+    // Auth-only handshake using the helper exclusively (no stored PAT).
+    remote
+        .connect_auth(git2::Direction::Fetch, Some(callbacks_system_only()), None)
+        .map_err(|_| {
+            Error::from_str(
+                "no system Git credentials found — configure a credential helper (e.g. Git Credential Manager) or set a token under Advanced",
+            )
+        })?;
+    let _ = remote.disconnect();
+    Ok(())
+}
+
 /// Builds credential callbacks: PAT first (Android + as an override), then the
 /// system credential helper (desktop).
 fn callbacks(app: tauri::AppHandle) -> RemoteCallbacks<'static> {
@@ -109,6 +191,26 @@ fn callbacks(app: tauri::AppHandle) -> RemoteCallbacks<'static> {
         Err(Error::from_str(
             "no usable git credentials — set a token in Settings",
         ))
+    });
+    cb
+}
+
+/// Credential callbacks that use ONLY the OS credential helper (no stored PAT), so
+/// the "Use system Git credentials" probe genuinely tests the helper.
+fn callbacks_system_only() -> RemoteCallbacks<'static> {
+    let mut cb = RemoteCallbacks::new();
+    cb.credentials(move |url, username, allowed| {
+        if allowed.contains(CredentialType::USER_PASS_PLAINTEXT) {
+            if let Ok(config) = git2::Config::open_default() {
+                if let Ok(cred) = Cred::credential_helper(&config, url, username) {
+                    return Ok(cred);
+                }
+            }
+        }
+        if allowed.contains(CredentialType::DEFAULT) {
+            return Cred::default();
+        }
+        Err(Error::from_str("no system git credentials"))
     });
     cb
 }

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -47,7 +47,10 @@ pub fn run() {
             git::git_unpushed,
             git::git_clone,
             git::git_set_token,
-            git::git_has_token
+            git::git_has_token,
+            git::git_sync,
+            git::git_list_branches,
+            git::git_checkout_branch
         ]);
     #[cfg(not(desktop))]
     let builder = builder.invoke_handler(tauri::generate_handler![
@@ -60,7 +63,10 @@ pub fn run() {
         git::git_unpushed,
         git::git_clone,
         git::git_set_token,
-        git::git_has_token
+        git::git_has_token,
+        git::git_sync,
+        git::git_list_branches,
+        git::git_checkout_branch
     ]);
 
     builder

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -50,7 +50,11 @@ pub fn run() {
             git::git_has_token,
             git::git_sync,
             git::git_list_branches,
-            git::git_checkout_branch
+            git::git_checkout_branch,
+            git::git_is_authenticated,
+            git::git_system_credentials_enabled,
+            git::git_use_system_credentials,
+            git::git_disable_system_credentials
         ]);
     #[cfg(not(desktop))]
     let builder = builder.invoke_handler(tauri::generate_handler![
@@ -66,7 +70,11 @@ pub fn run() {
         git::git_has_token,
         git::git_sync,
         git::git_list_branches,
-        git::git_checkout_branch
+        git::git_checkout_branch,
+        git::git_is_authenticated,
+        git::git_system_credentials_enabled,
+        git::git_use_system_credentials,
+        git::git_disable_system_credentials
     ]);
 
     builder

--- a/apps/klank/tests/useGitSync.spec.ts
+++ b/apps/klank/tests/useGitSync.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useKlankStore, type SyncStatus } from '@klank/store'
 import type { FileService, GitService, SyncResult } from '@klank/platform-api'
-import { runGitSync } from '../app/useGitSync'
+import { clampMinutes, runGitSync } from '../app/useGitSync'
 import { describeSyncStatus } from '../app/routes/settings'
 
 const baseDir = '/tabs'
@@ -94,6 +94,19 @@ describe('runGitSync', () => {
       undefined,
     )
     expect(useKlankStore.getState().syncStatus.kind).toBe('other')
+  })
+})
+
+describe('clampMinutes', () => {
+  it('keeps valid values at or above the minimum', () => {
+    expect(clampMinutes(30, 1, 30)).toBe(30)
+    expect(clampMinutes(0, 1, 30)).toBe(1)
+  })
+
+  it('falls back when the value is not finite (corrupt persisted state)', () => {
+    expect(clampMinutes(NaN, 1, 30)).toBe(30)
+    expect(clampMinutes(Infinity, 0, 5)).toBe(5)
+    expect(clampMinutes(-Infinity, 0, 5)).toBe(5)
   })
 })
 

--- a/apps/klank/tests/useGitSync.spec.ts
+++ b/apps/klank/tests/useGitSync.spec.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
 import { useKlankStore, type SyncStatus } from '@klank/store'
 import type { FileService, GitService, SyncResult } from '@klank/platform-api'
-import { clampMinutes, runGitSync } from '../app/useGitSync'
+import { clampMinutes, runGitSync, useGitSync } from '../app/useGitSync'
 import { describeSyncStatus } from '../app/routes/settings'
 
 const baseDir = '/tabs'
@@ -142,5 +143,44 @@ describe('describeSyncStatus', () => {
     const d = describeSyncStatus(make({ state: 'offline', kind: 'auth', message: 'Not signed in' }))
     expect(d.tone).toBe('warn')
     expect(d.detail).toBeUndefined()
+  })
+})
+
+describe('useGitSync scheduling guard', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('clamps a corrupt persisted interval so setInterval never receives NaN', () => {
+    // Regression: a NaN interval made `setInterval(NaN)` fire every tick (runaway).
+    useKlankStore.setState({
+      baseDirectory: '/tabs',
+      syncSettings: { enabled: true, intervalMinutes: NaN, debounceMinutes: 5 },
+    })
+    const spy = vi.spyOn(globalThis, 'setInterval')
+    const { unmount } = renderHook(() => useGitSync())
+    expect(spy).toHaveBeenCalledWith(expect.any(Function), 30 * 60_000) // fallback, not NaN
+    expect(spy.mock.calls.every(([, ms]) => Number.isFinite(ms))).toBe(true)
+    unmount()
+  })
+
+  it('uses the configured interval when it is valid', () => {
+    useKlankStore.setState({
+      baseDirectory: '/tabs',
+      syncSettings: { enabled: true, intervalMinutes: 15, debounceMinutes: 5 },
+    })
+    const spy = vi.spyOn(globalThis, 'setInterval')
+    const { unmount } = renderHook(() => useGitSync())
+    expect(spy).toHaveBeenCalledWith(expect.any(Function), 15 * 60_000)
+    unmount()
+  })
+
+  it('does not schedule a timer while auto-sync is disabled', () => {
+    useKlankStore.setState({
+      baseDirectory: '/tabs',
+      syncSettings: { enabled: false, intervalMinutes: 30, debounceMinutes: 5 },
+    })
+    const spy = vi.spyOn(globalThis, 'setInterval')
+    const { unmount } = renderHook(() => useGitSync())
+    expect(spy).not.toHaveBeenCalled()
+    unmount()
   })
 })

--- a/apps/klank/tests/useGitSync.spec.ts
+++ b/apps/klank/tests/useGitSync.spec.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { useKlankStore } from '@klank/store'
+import { useKlankStore, type SyncStatus } from '@klank/store'
 import type { FileService, GitService, SyncResult } from '@klank/platform-api'
 import { runGitSync } from '../app/useGitSync'
+import { describeSyncStatus } from '../app/routes/settings'
 
 const baseDir = '/tabs'
 
@@ -35,6 +36,7 @@ describe('runGitSync', () => {
     await runGitSync(makeGit({ isAuthenticated: async () => false, sync }), baseDir, undefined)
     expect(sync).not.toHaveBeenCalled()
     expect(useKlankStore.getState().syncStatus.state).toBe('offline')
+    expect(useKlankStore.getState().syncStatus.kind).toBe('auth')
   })
 
   it('reports "No repository" when the folder is not a git repo', async () => {
@@ -74,13 +76,58 @@ describe('runGitSync', () => {
     expect(useKlankStore.getState().syncStatus.state).toBe('idle')
   })
 
-  it('surfaces sync failures as an error status', async () => {
+  it('surfaces sync failures with their error category', async () => {
     await runGitSync(
-      makeGit({ sync: async () => okResult({ success: false, error: 'boom', message: 'boom' }) }),
+      makeGit({ sync: async () => okResult({ success: false, error: 'boom', message: 'boom', errorKind: 'network' }) }),
       baseDir,
       undefined,
     )
     expect(useKlankStore.getState().syncStatus.state).toBe('error')
     expect(useKlankStore.getState().syncStatus.message).toBe('boom')
+    expect(useKlankStore.getState().syncStatus.kind).toBe('network')
+  })
+
+  it('defaults the error category to "other" when the engine omits it', async () => {
+    await runGitSync(
+      makeGit({ sync: async () => okResult({ success: false, error: 'boom' }) }),
+      baseDir,
+      undefined,
+    )
+    expect(useKlankStore.getState().syncStatus.kind).toBe('other')
+  })
+})
+
+describe('describeSyncStatus', () => {
+  const make = (over: Partial<SyncStatus>): SyncStatus => ({
+    state: 'idle',
+    lastSyncedAt: null,
+    message: '',
+    ...over,
+  })
+
+  it('shows an ok tone with a timestamp once synced', () => {
+    const d = describeSyncStatus(make({ state: 'idle', lastSyncedAt: Date.now() }))
+    expect(d.tone).toBe('ok')
+    expect(d.text).toContain('Synced')
+  })
+
+  it('flags an auth error with no raw text in the headline', () => {
+    const d = describeSyncStatus(make({ state: 'error', kind: 'auth', message: 'remote: 403' }))
+    expect(d.tone).toBe('error')
+    expect(d.text.toLowerCase()).toContain('sign-in')
+    expect(d.text).not.toContain('403') // raw detail is tucked away
+    expect(d.detail).toBe('remote: 403')
+  })
+
+  it('flags a connectivity error', () => {
+    const d = describeSyncStatus(make({ state: 'error', kind: 'network', message: 'could not resolve host' }))
+    expect(d.tone).toBe('error')
+    expect(d.text.toLowerCase()).toContain('reach')
+  })
+
+  it('warns (not errors) when offline because of missing auth', () => {
+    const d = describeSyncStatus(make({ state: 'offline', kind: 'auth', message: 'Not signed in' }))
+    expect(d.tone).toBe('warn')
+    expect(d.detail).toBeUndefined()
   })
 })

--- a/apps/klank/tests/useGitSync.spec.ts
+++ b/apps/klank/tests/useGitSync.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useKlankStore } from '@klank/store'
+import type { FileService, GitService, SyncResult } from '@klank/platform-api'
+import { runGitSync } from '../app/useGitSync'
+
+const baseDir = '/tabs'
+
+const okResult = (over: Partial<SyncResult> = {}): SyncResult => ({
+  success: true,
+  committed: false,
+  pulled: 0,
+  pushed: 0,
+  conflictsResolved: 0,
+  upToDate: true,
+  changed: false,
+  message: 'ok',
+  ...over,
+})
+
+const makeGit = (over: Partial<GitService>): GitService =>
+  ({
+    isGitRepo: async () => true,
+    isAuthenticated: async () => true,
+    sync: async () => okResult(),
+    ...over,
+  }) as unknown as GitService
+
+afterEach(() => {
+  useKlankStore.getState().setSyncStatus({ state: 'idle', lastSyncedAt: null, message: '' })
+})
+
+describe('runGitSync', () => {
+  it('stays offline and never syncs when not signed in', async () => {
+    const sync = vi.fn()
+    await runGitSync(makeGit({ isAuthenticated: async () => false, sync }), baseDir, undefined)
+    expect(sync).not.toHaveBeenCalled()
+    expect(useKlankStore.getState().syncStatus.state).toBe('offline')
+  })
+
+  it('reports "No repository" when the folder is not a git repo', async () => {
+    const sync = vi.fn()
+    await runGitSync(makeGit({ isGitRepo: async () => false, sync }), baseDir, undefined)
+    expect(sync).not.toHaveBeenCalled()
+    expect(useKlankStore.getState().syncStatus.message).toBe('No repository')
+  })
+
+  it('re-hydrates settings + playlists and fires onChanged when the tree changed', async () => {
+    const readTabSettings = vi
+      .fn()
+      .mockResolvedValue({ '/tabs/a.tab.txt': { fontSize: 1, transpose: 0, scrollSpeed: 1 } })
+    const readPlaylists = vi.fn().mockResolvedValue([])
+    const fileService = { readTabSettings, readPlaylists } as unknown as FileService
+    const onChanged = vi.fn()
+
+    await runGitSync(
+      makeGit({ sync: async () => okResult({ changed: true, message: 'pulled 1' }) }),
+      baseDir,
+      fileService,
+      onChanged,
+    )
+
+    expect(readTabSettings).toHaveBeenCalledWith(baseDir)
+    expect(readPlaylists).toHaveBeenCalledWith(baseDir)
+    expect(onChanged).toHaveBeenCalledOnce()
+    expect(useKlankStore.getState().syncStatus.state).toBe('idle')
+    expect(useKlankStore.getState().syncStatus.lastSyncedAt).not.toBeNull()
+  })
+
+  it('does not re-hydrate when nothing changed', async () => {
+    const readTabSettings = vi.fn()
+    const fileService = { readTabSettings, readPlaylists: vi.fn() } as unknown as FileService
+    await runGitSync(makeGit({ sync: async () => okResult({ changed: false }) }), baseDir, fileService)
+    expect(readTabSettings).not.toHaveBeenCalled()
+    expect(useKlankStore.getState().syncStatus.state).toBe('idle')
+  })
+
+  it('surfaces sync failures as an error status', async () => {
+    await runGitSync(
+      makeGit({ sync: async () => okResult({ success: false, error: 'boom', message: 'boom' }) }),
+      baseDir,
+      undefined,
+    )
+    expect(useKlankStore.getState().syncStatus.state).toBe('error')
+    expect(useKlankStore.getState().syncStatus.message).toBe('boom')
+  })
+})

--- a/libs/platform-api/src/lib/git.ts
+++ b/libs/platform-api/src/lib/git.ts
@@ -3,6 +3,28 @@ import { invoke } from '@tauri-apps/api/core'
 export type GitChangedFile = { status: string; path: string }
 export type GitResult = { success: boolean; output: string; error?: string }
 
+/** Structured outcome of an auto-sync (commit → pull-rebase → push). */
+export type SyncResult = {
+  success: boolean
+  committed: boolean
+  pulled: number
+  pushed: number
+  conflictsResolved: number
+  branch?: string
+  upToDate: boolean
+  /** True when the working tree changed underneath the app, so it should re-hydrate. */
+  changed: boolean
+  message: string
+  error?: string
+}
+
+export type BranchInfo = {
+  name: string
+  isHead: boolean
+  isRemote: boolean
+  upstream?: string
+}
+
 export type GitService = {
   isGitRepo: (dir: string) => Promise<boolean>
   getChangedFiles: (dir: string) => Promise<GitChangedFile[]>
@@ -10,6 +32,16 @@ export type GitService = {
   commit: (dir: string, message: string) => Promise<GitResult>
   push: (dir: string) => Promise<GitResult>
   getUnpushedCommits: (dir: string) => Promise<string[]>
+  /**
+   * Unobtrusive auto-sync: auto-commits local edits, pulls with rebase
+   * (auto-resolving conflicts — latest commit time wins for tabs, 3-way JSON
+   * merge for config), and pushes. Never prompts.
+   */
+  sync: (dir: string) => Promise<SyncResult>
+  /** Lists local (and remote-only) branches so the user can pick one. */
+  listBranches: (dir: string) => Promise<BranchInfo[]>
+  /** Switches HEAD to `branch` (the selected branch sync operates on). */
+  checkoutBranch: (dir: string, branch: string) => Promise<GitResult>
   /** Clones `url` into `dir` (used to set up tab storage on mobile). */
   cloneRepo: (url: string, dir: string) => Promise<GitResult>
   /** Stores (or clears, when empty) the HTTPS Personal Access Token. */
@@ -17,6 +49,22 @@ export type GitService = {
   /** Whether a PAT is currently stored. */
   hasToken: () => Promise<boolean>
 }
+
+/** Rust `SyncResult` (snake_case) → TS `SyncResult` (camelCase). */
+type RawSyncResult = {
+  success: boolean
+  committed: boolean
+  pulled: number
+  pushed: number
+  conflicts_resolved: number
+  branch?: string
+  up_to_date: boolean
+  changed: boolean
+  message: string
+  error?: string
+}
+
+type RawBranchInfo = { name: string; is_head: boolean; is_remote: boolean; upstream?: string }
 
 /**
  * Git operations backed by the in-app libgit2 engine (Rust commands), so sync
@@ -48,6 +96,35 @@ const createTauriGitService = async (): Promise<GitService> => ({
       return []
     }
   },
+  async sync(dir) {
+    const r = await invoke<RawSyncResult>('git_sync', { dir })
+    return {
+      success: r.success,
+      committed: r.committed,
+      pulled: r.pulled,
+      pushed: r.pushed,
+      conflictsResolved: r.conflicts_resolved,
+      branch: r.branch,
+      upToDate: r.up_to_date,
+      changed: r.changed,
+      message: r.message,
+      error: r.error,
+    }
+  },
+  async listBranches(dir) {
+    try {
+      const raw = await invoke<RawBranchInfo[]>('git_list_branches', { dir })
+      return raw.map((b) => ({
+        name: b.name,
+        isHead: b.is_head,
+        isRemote: b.is_remote,
+        upstream: b.upstream,
+      }))
+    } catch {
+      return []
+    }
+  },
+  checkoutBranch: (dir, branch) => invoke<GitResult>('git_checkout_branch', { dir, branch }),
   cloneRepo: (url, dir) => invoke<GitResult>('git_clone', { url, dir }),
   setToken: (token) => invoke<void>('git_set_token', { token }),
   hasToken: () => invoke<boolean>('git_has_token'),

--- a/libs/platform-api/src/lib/git.ts
+++ b/libs/platform-api/src/lib/git.ts
@@ -48,6 +48,18 @@ export type GitService = {
   setToken: (token: string) => Promise<void>
   /** Whether a PAT is currently stored. */
   hasToken: () => Promise<boolean>
+  /** Whether sync has usable auth: a stored PAT or the opted-in OS credential helper. */
+  isAuthenticated: () => Promise<boolean>
+  /** Whether the user has opted into the OS git credential helper. */
+  systemCredentialsEnabled: () => Promise<boolean>
+  /**
+   * Desktop one-click sign-in: verifies the OS git credential helper can
+   * authenticate against `origin` (triggering GCM's interactive login if needed)
+   * and, on success, records that auth is configured. Not available on mobile.
+   */
+  useSystemCredentials: (dir: string) => Promise<GitResult>
+  /** Turns off the system-credential opt-in (leaves any stored PAT untouched). */
+  disableSystemCredentials: () => Promise<void>
 }
 
 /** Rust `SyncResult` (snake_case) → TS `SyncResult` (camelCase). */
@@ -128,6 +140,22 @@ const createTauriGitService = async (): Promise<GitService> => ({
   cloneRepo: (url, dir) => invoke<GitResult>('git_clone', { url, dir }),
   setToken: (token) => invoke<void>('git_set_token', { token }),
   hasToken: () => invoke<boolean>('git_has_token'),
+  async isAuthenticated() {
+    try {
+      return await invoke<boolean>('git_is_authenticated')
+    } catch {
+      return false
+    }
+  },
+  async systemCredentialsEnabled() {
+    try {
+      return await invoke<boolean>('git_system_credentials_enabled')
+    } catch {
+      return false
+    }
+  },
+  useSystemCredentials: (dir) => invoke<GitResult>('git_use_system_credentials', { dir }),
+  disableSystemCredentials: () => invoke<void>('git_disable_system_credentials'),
 })
 
 export const createGitService = async (): Promise<GitService> => createTauriGitService()

--- a/libs/platform-api/src/lib/git.ts
+++ b/libs/platform-api/src/lib/git.ts
@@ -3,6 +3,9 @@ import { invoke } from '@tauri-apps/api/core'
 export type GitChangedFile = { status: string; path: string }
 export type GitResult = { success: boolean; output: string; error?: string }
 
+/** Coarse failure category for actionable UI feedback. */
+export type SyncErrorKind = 'auth' | 'network' | 'other'
+
 /** Structured outcome of an auto-sync (commit → pull-rebase → push). */
 export type SyncResult = {
   success: boolean
@@ -16,6 +19,8 @@ export type SyncResult = {
   changed: boolean
   message: string
   error?: string
+  /** Failure category (only set when `success` is false). */
+  errorKind?: SyncErrorKind
 }
 
 export type BranchInfo = {
@@ -74,6 +79,7 @@ type RawSyncResult = {
   changed: boolean
   message: string
   error?: string
+  error_kind?: SyncErrorKind
 }
 
 type RawBranchInfo = { name: string; is_head: boolean; is_remote: boolean; upstream?: string }
@@ -121,6 +127,7 @@ const createTauriGitService = async (): Promise<GitService> => ({
       changed: r.changed,
       message: r.message,
       error: r.error,
+      errorKind: r.error_kind,
     }
   },
   async listBranches(dir) {

--- a/libs/store/src/lib/store-persistence.spec.ts
+++ b/libs/store/src/lib/store-persistence.spec.ts
@@ -53,9 +53,17 @@ describe('klank-storage migration and shape', () => {
     const raw = localStorageData['klank-storage']
     expect(raw).toBeDefined()
     const parsed = JSON.parse(raw) as { version: number; state: Record<string, unknown> }
-    expect(parsed.version).toBe(1)
+    expect(parsed.version).toBe(2)
     expect(parsed.state).not.toHaveProperty('playlists')
     expect(parsed.state).toHaveProperty('activePlaylistId')
     expect(parsed.state).toHaveProperty('activePlaylistIndex')
+    // Sync cadence is persisted so it survives reloads.
+    expect(parsed.state).toHaveProperty('syncSettings')
+  })
+
+  it('migrate fills in default sync settings for older persisted state', async () => {
+    const { useKlankStore } = await import('./store.js')
+    const { syncSettings } = useKlankStore.getState()
+    expect(syncSettings).toEqual({ enabled: true, intervalMinutes: 30, debounceMinutes: 5 })
   })
 })

--- a/libs/store/src/lib/store.spec.ts
+++ b/libs/store/src/lib/store.spec.ts
@@ -14,7 +14,7 @@ vi.stubGlobal('localStorage', {
 })
 
 import type { FileService } from '@klank/platform-api'
-import { useKlankStore, type Playlist } from './store.js'
+import { notifyTabsChanged, onTabsChanged, useKlankStore, type Playlist } from './store.js'
 
 const makePlaylist = (overrides: Partial<Playlist> = {}): Playlist => ({
   id: crypto.randomUUID(),
@@ -506,5 +506,41 @@ describe('setPlaylists hydration', () => {
 
     expect(useKlankStore.getState().activePlaylistId).toBe(playlist.id)
     expect(useKlankStore.getState().activePlaylistIndex).toBeNull()
+  })
+})
+
+describe('tab change signal', () => {
+  it('notifies subscribers and stops after unsubscribe', () => {
+    const fn = vi.fn()
+    const unsubscribe = onTabsChanged(fn)
+    notifyTabsChanged()
+    expect(fn).toHaveBeenCalledTimes(1)
+    unsubscribe()
+    notifyTabsChanged()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires when a tab-setting write happens', () => {
+    useKlankStore.setState({
+      baseDirectory: '/tabs',
+      tab: { ...useKlankStore.getState().tab, path: '/tabs/a.tab.txt' },
+    })
+    const fn = vi.fn()
+    const unsubscribe = onTabsChanged(fn)
+    useKlankStore.getState().setTabFontSize(15)
+    expect(fn).toHaveBeenCalled()
+    unsubscribe()
+  })
+})
+
+describe('syncSettings', () => {
+  it('merges partial updates without disturbing other fields', () => {
+    useKlankStore.getState().setSyncSettings({ intervalMinutes: 10 })
+    expect(useKlankStore.getState().syncSettings.intervalMinutes).toBe(10)
+    expect(useKlankStore.getState().syncSettings.enabled).toBe(true)
+
+    useKlankStore.getState().setSyncSettings({ enabled: false })
+    expect(useKlankStore.getState().syncSettings.enabled).toBe(false)
+    expect(useKlankStore.getState().syncSettings.intervalMinutes).toBe(10)
   })
 })

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -1,7 +1,7 @@
 import {create} from 'zustand'
 import {devtools, persist} from 'zustand/middleware'
 import type {} from '@redux-devtools/extension'
-import { FileService, PerTabSettings, type Instrument, type Playlist } from '@klank/platform-api'
+import { FileService, PerTabSettings, type Instrument, type Playlist, type SyncErrorKind } from '@klank/platform-api'
 
 export type { Instrument, Playlist }
 
@@ -57,6 +57,8 @@ export type SyncStatus = {
   /** Epoch ms of the last successful sync, or null if never. */
   lastSyncedAt: number | null
   message: string
+  /** Failure category for actionable feedback (set on error/offline). */
+  kind?: SyncErrorKind
 }
 
 /**

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -33,6 +33,49 @@ export type TabSetting = {
   link?: string
 }
 
+/** User-configurable auto-sync cadence. Persisted to localStorage. */
+export type SyncSettings = {
+  /** Master switch for background git sync. */
+  enabled: boolean
+  /** Periodic sync interval in minutes. */
+  intervalMinutes: number
+  /** Debounce after a local edit before syncing, in minutes. */
+  debounceMinutes: number
+}
+
+export const DEFAULT_SYNC_SETTINGS: SyncSettings = {
+  enabled: true,
+  intervalMinutes: 30,
+  debounceMinutes: 5,
+}
+
+export type SyncRunState = 'idle' | 'syncing' | 'error' | 'offline'
+
+/** Live status of the background sync loop, surfaced in Settings. Not persisted. */
+export type SyncStatus = {
+  state: SyncRunState
+  /** Epoch ms of the last successful sync, or null if never. */
+  lastSyncedAt: number | null
+  message: string
+}
+
+/**
+ * Lightweight change signal driving debounced auto-sync. Tab/settings/playlist
+ * writes call `notifyTabsChanged`; the auto-sync hook subscribes via `onTabsChanged`.
+ * Kept module-level (not React state) so store mutators can fire it like the
+ * existing fire-and-forget file writes.
+ */
+const tabsChangedListeners = new Set<() => void>()
+export const onTabsChanged = (fn: () => void): (() => void) => {
+  tabsChangedListeners.add(fn)
+  return () => {
+    tabsChangedListeners.delete(fn)
+  }
+}
+export const notifyTabsChanged = (): void => {
+  for (const fn of tabsChangedListeners) fn()
+}
+
 type KlankState = {
   /** Active tab directory chosen by the user. Not persisted. */
   baseDirectory?: string
@@ -93,6 +136,12 @@ type KlankState = {
    * Does not touch the file system — callers delete the file via FileService first.
    */
   deleteTab: (path: string) => void
+  /** @persisted Auto-sync cadence (interval, debounce, on/off). */
+  syncSettings: SyncSettings
+  setSyncSettings: (partial: Partial<SyncSettings>) => void
+  /** Live sync status for the Settings UI. Not persisted. */
+  syncStatus: SyncStatus
+  setSyncStatus: (status: Partial<SyncStatus>) => void
 }
 
 /** All valid scroll speed levels (0–9, displayed as 1–10). */
@@ -102,7 +151,7 @@ export type ScrollSpeeds = typeof SCROLL_SPEEDS[number]
 /** The slice of KlankState saved to localStorage — must match what `partialize` returns. */
 type PersistedKlankState = Pick<
   KlankState,
-  'tab' | 'theme' | 'ui' | 'baseDirectory' | 'activePlaylistId' | 'activePlaylistIndex'
+  'tab' | 'theme' | 'ui' | 'baseDirectory' | 'activePlaylistId' | 'activePlaylistIndex' | 'syncSettings'
 >
 
 /** Fire-and-forget write of all playlists to `.klank-settings.json`. No-op until a directory and FileService are set. */
@@ -110,7 +159,10 @@ const persistPlaylists = (
   state: Pick<KlankState, 'fileService' | 'baseDirectory'>,
   playlists: Playlist[],
 ) => {
-  if (state.baseDirectory) state.fileService?.writePlaylists(playlists, state.baseDirectory)
+  if (state.baseDirectory) {
+    state.fileService?.writePlaylists(playlists, state.baseDirectory)
+    notifyTabsChanged()
+  }
 }
 
 const clampFontSize = (size: number) => {
@@ -161,6 +213,10 @@ export const useKlankStore = create<KlankState>()(
         setMenuWidth: (menuWidth) => set((state) => ({...state, ui: {...state.ui, menuWidth}})),
         setTheme: (theme) => set((state) => ({...state, theme})),
         setInstrument: (instrument) => set((state) => ({...state, instrument})),
+        syncSettings: DEFAULT_SYNC_SETTINGS,
+        setSyncSettings: (partial) => set((state) => ({...state, syncSettings: {...state.syncSettings, ...partial}})),
+        syncStatus: { state: 'idle', lastSyncedAt: null, message: '' },
+        setSyncStatus: (status) => set((state) => ({...state, syncStatus: {...state.syncStatus, ...status}})),
         setTabPath: (path) => set((state) => {
           const saved = state.tabSettingByPath[path]
           const tab: TabSetting = {
@@ -178,6 +234,7 @@ export const useKlankStore = create<KlankState>()(
               transpose: state.tab.transpose,
               scrollSpeed: state.tab.scrollSpeed,
             }, state.baseDirectory)
+            notifyTabsChanged()
           }
           const tabSettingByPath = state.tab.path
             ? {
@@ -198,8 +255,10 @@ export const useKlankStore = create<KlankState>()(
           const tabSettingByPath = state.tab.path
             ? { ...state.tabSettingByPath, [state.tab.path]: entry }
             : state.tabSettingByPath
-          if (state.tab.path && state.baseDirectory)
+          if (state.tab.path && state.baseDirectory) {
             state.fileService?.writeTabSetting(state.tab.path, entry, state.baseDirectory)
+            notifyTabsChanged()
+          }
           return { ...state, tab, tabSettingByPath }
         }),
         setTabTranspose: (transpose) => set((state) => {
@@ -208,8 +267,10 @@ export const useKlankStore = create<KlankState>()(
           const tabSettingByPath = state.tab.path
             ? { ...state.tabSettingByPath, [state.tab.path]: entry }
             : state.tabSettingByPath
-          if (state.tab.path && state.baseDirectory)
+          if (state.tab.path && state.baseDirectory) {
             state.fileService?.writeTabSetting(state.tab.path, entry, state.baseDirectory)
+            notifyTabsChanged()
+          }
           return { ...state, tab, tabSettingByPath }
         }),
         setTabScrollSpeed: (scrollSpeed) => set((state) => {
@@ -218,8 +279,10 @@ export const useKlankStore = create<KlankState>()(
           const tabSettingByPath = state.tab.path
             ? { ...state.tabSettingByPath, [state.tab.path]: entry }
             : state.tabSettingByPath
-          if (state.tab.path && state.baseDirectory)
+          if (state.tab.path && state.baseDirectory) {
             state.fileService?.writeTabSetting(state.tab.path, entry, state.baseDirectory)
+            notifyTabsChanged()
+          }
           return { ...state, tab, tabSettingByPath }
         }),
         setTabIsScrolling: (isScrolling) => set((state) => ({...state, tab: {...state.tab, isScrolling}})),
@@ -389,13 +452,17 @@ export const useKlankStore = create<KlankState>()(
       }),
       {
         name: 'klank-storage',
-        version: 1,
+        version: 2,
         // v0 persisted playlists in localStorage; they now live in
         // .klank-settings.json, so stale localStorage copies are dropped.
+        // v2 adds syncSettings; defaults fill in for older persisted state.
         migrate: (persistedState) => {
           const state = { ...((persistedState ?? {}) as Record<string, unknown>) }
           delete state['playlists']
-          return state as unknown as PersistedKlankState
+          return {
+            ...state,
+            syncSettings: { ...DEFAULT_SYNC_SETTINGS, ...(state.syncSettings as Partial<SyncSettings> | undefined) },
+          } as unknown as PersistedKlankState
         },
         partialize: (state) => ({
           tab: { ...state.tab, isScrolling: false },
@@ -404,6 +471,7 @@ export const useKlankStore = create<KlankState>()(
           baseDirectory: state.baseDirectory,
           activePlaylistId: state.activePlaylistId,
           activePlaylistIndex: state.activePlaylistIndex,
+          syncSettings: state.syncSettings,
         }),
       }
     )


### PR DESCRIPTION
## Why

Git sync was manual and easy to wedge: separate **Pull / Commit / Push** buttons, a **fast-forward-only** pull that dead-ended (*"local and remote have diverged — resolve the conflict on a desktop"*) the moment two devices or two people edited the same repo, and authentication that only accepted a hand-made Personal Access Token. There was no automatic syncing at all.

This makes sync **completely unobtrusive**: the user configures access and picks a branch, and the app keeps the local tab folder and the remote converged by itself — so a shared tab repo feels like a seamless multi-device experience.

## What's in this PR

### 1. Unobtrusive background sync
- **`git_sync`** (Rust/`git2`): auto-commit local edits → fetch → integrate upstream into a **linear history** → push. A process-wide mutex serializes runs; the push loop re-fetches/re-integrates on a non-fast-forward rejection (never force-pushes).
- **Auto conflict resolution, no prompts** — every path changed on **both** sides (vs. the merge base) is resolved deterministically, overriding libgit2's line-level text merge:
  - **Whole `.tab.txt` files (and anything else): the side with the latest git commit time wins** — even when the two sides edited *different lines* of the same tab (no line-splicing). A deleted winner leaves the file removed.
  - `.klank-settings.json`: a **semantic 3-way JSON merge** — per-key, latest-commit-time on a true conflict; playlists merged by `id`. Output mirrors the frontend writer (sorted keys, 2-space indent) to keep diffs minimal.
  - Integration uses `merge_trees` + a squashed commit parented on the upstream tip (libgit2's in-memory rebase `commit` ignores manual index edits), keeping history fast-forwardable.
- **`useGitSync`** hook drives sync on startup, a configurable **timer (default 30 min)**, a **debounced run after edits settle (default 5 min)**, and on window focus. Runs are coalesced; a sync that pulled changes re-hydrates disk-backed state. Timer values are clamped against corrupt persisted state.
- Store gains a persisted `syncSettings` slice, a live `syncStatus`, and a `notifyTabsChanged` signal fired by tab/settings/playlist writes.
- **`git_list_branches` / `git_checkout_branch`** for branch selection (HEAD is the source of truth).

### 2. One-click authentication
- **Desktop: "Use system Git credentials"** — probes the OS git credential helper (Git Credential Manager / osxkeychain / libsecret) against `origin` via an auth-only handshake, triggering GCM's interactive login on first use, and records that auth is configured. Fixes the gap where sync gated on a stored PAT (`hasToken`) and never reached the helper that `callbacks()` already supported.
- **`git_is_authenticated`** (PAT **or** system helper) is the sync gate, so a configured helper syncs with **no token**.
- **PAT kept as the cross-platform/advanced fallback** (and the primary control on mobile, which has no credential helper). Needed for GitHub Enterprise, self-hosted, and non-GitHub remotes.

### 3. Settings UI + diagnostic status
Replaces Pull/Commit/Push with: a **branch picker** (selectable whenever it's a repo, independent of auth), a **"Sync now"** button, the configurable cadence controls, and the desktop **system-credentials** button with the PAT under **Advanced**.

The status line is **diagnostic** — one concise, tone-coloured headline tells the user *why* sync isn't working without flooding the screen:
- `✓ Synced · 2m ago` · `⚠ Not signed in` · `✕ Sign-in needed — check your token or system credentials` · `✕ Can't reach the remote — check your connection`.
- Failures are categorized in Rust (`error_kind`: auth / network / other) so the UI doesn't parse raw messages; the raw libgit2 text is available on hover and behind a collapsed **Details** toggle (mobile-friendly).

## Decisions (confirmed with the requester)
- Background loop + debounce; **30 min** timer, **5 min** post-edit debounce, all configurable.
- Conflicts resolved by **latest git commit time**; tabs are whole-file.
- Manual buttons replaced by status + "Sync now".
- **No** OAuth Device Flow (no OAuth App client ID available) → the one-click button is desktop-only; PAT remains for mobile/enterprise.

## Testing
- **Rust (30 tests):** real-libgit2 integration tests for the merge/rebase engine — conflict winners (both directions), **same-tab disjoint-line edits take the whole newer file**, disjoint/clean merges, fast-forward, linear fast-forwardable history, delete/modify, unborn HEAD; the JSON 3-way merge (disjoint keys, conflict tie-break, playlists-by-id incl. same-id edits, key deletion, output format); and `classify_error` bucketing.
- **TypeScript (klank 23):** `runGitSync` (auth/repo gating, re-hydrate + `onChanged`, error categories), `describeSyncStatus` table, `clampMinutes`, `useGitSync` scheduling (clamped timer, valid interval, disabled = no timer), and store tests (change-signal notify/unsubscribe + fires on a setting write; `syncSettings` merge).
- `nx build / lint / test` for `klank`, `store`, `platform-api` — green.

## Manual verification recommended before merge
These need a live environment and aren't unit-tested:
- Two clones sharing access, diverging edits → converge with no prompts.
- Desktop with GCM configured → **Use system Git credentials** authenticates and sync runs with no PAT; without a helper → `✕ Sign-in needed`; offline → `✕ Can't reach the remote`.
- Android smoke test of the integration path (vendored libgit2); PAT is the auth path there.

## Notes
- Not unit-tested (require a Tauri `AppHandle` / interactive helper): the `git_sync` orchestration glue, the credential-marker storage, and the live credential probe. Their building blocks (auto-commit, merge/rebase engine, error classification) are covered.
- Persist version bumped to `2`; a migration fills default sync settings for existing users.
- The old `git_pull` / `git_commit` / `git_push` / `git_unpushed` commands are retained (no longer used by the UI) and can be removed in a follow-up.

https://claude.ai/code/session_0138FbpD44WHqfHdFAvLAY86