### PR TITLE
feat(harmony): scales, modes & chord-scale browser with fretboard diagrams

### DIFF
--- a/apps/klank/app/components/menu/Menu.tsx
+++ b/apps/klank/app/components/menu/Menu.tsx
@@ -11,6 +11,7 @@ import {
   LogoIcon,
   NewPlaylistIcon,
   RefreshIcon,
+  ScalesIcon,
   Searchbar,
   ShuffleIcon,
   TargetIcon,
@@ -461,6 +462,7 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
           isDownloading={isDownloading}
           downloadError={downloadError}
           onSettingsClick={() => navigate('/settings')}
+          onHarmonyClick={() => navigate('/harmony')}
           isCollapsed={!isMenuExtended}
           hideGoToTab={isMobile}
           hideRefresh={isMobile}
@@ -551,6 +553,14 @@ export const Menu: React.FC<MenuProps> = ({ tree, setNeedsUpdate, ...props }) =>
                     icon={<DownloadIcon />}
                     aria-label="Download tab"
                     onClick={handleRequestDownload}
+                  />
+                </ToolTip>
+                <ToolTip message="Scales & Chords">
+                  <Button
+                    iconButton
+                    icon={<ScalesIcon />}
+                    aria-label="Scales & Chords"
+                    onClick={() => { navigate('/harmony'); toggleMenu(false) }}
                   />
                 </ToolTip>
               </div>

--- a/apps/klank/app/routes.tsx
+++ b/apps/klank/app/routes.tsx
@@ -4,4 +4,5 @@ export default [
   index('./app.tsx'),
   route('about', './routes/about.tsx'),
   route('settings', './routes/settings.tsx'),
+  route('harmony', './routes/harmony.tsx'),
   ] satisfies RouteConfig;

--- a/apps/klank/app/routes/harmony.module.css
+++ b/apps/klank/app/routes/harmony.module.css
@@ -399,11 +399,10 @@
   display: none;
 }
 
+/* Disclosure body: padding only — let the inner grid (.chordGrid / .positionGrid)
+   own its row-wrap layout so cards sit next to each other. */
 .disclosure > :not(summary) {
   padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
 }
 
 /* ── Position windows grid ────────────────────────────────────────────────── */

--- a/apps/klank/app/routes/harmony.module.css
+++ b/apps/klank/app/routes/harmony.module.css
@@ -1,0 +1,268 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--klank-color-background);
+  color: var(--klank-color-text);
+  overflow-y: auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--klank-color-border);
+  flex-shrink: 0;
+}
+
+.header h1 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.backButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--klank-color-text);
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 0.9rem;
+
+  &:hover {
+    background: var(--klank-color-highlight);
+  }
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  max-width: 900px;
+  width: 100%;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--klank-color-border);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.label {
+  font-size: 0.875rem;
+  color: var(--klank-color-text);
+  opacity: 0.7;
+  min-width: 80px;
+}
+
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--klank-color-secondary-background);
+  border: 1px solid var(--klank-color-border);
+  border-radius: 4px;
+  color: var(--klank-color-text);
+  cursor: pointer;
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  white-space: nowrap;
+
+  &:hover {
+    background: var(--klank-color-highlight);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.button.active {
+  background: var(--klank-color-highlight);
+  border-color: var(--klank-color-text);
+  font-weight: 600;
+}
+
+.select {
+  background: var(--klank-color-secondary-background);
+  border: 1px solid var(--klank-color-border);
+  border-radius: 4px;
+  color: var(--klank-color-text);
+  padding: 8px 10px;
+  font-size: 0.875rem;
+  cursor: pointer;
+
+  &:focus {
+    outline: 1px solid var(--klank-color-highlight);
+  }
+}
+
+/* ── Fretboard diagram full-neck ─────────────────────────────────────────── */
+
+.fretboardFullWrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.fretboardFull {
+  min-width: 480px;
+}
+
+/* ── Position windows grid ─────────────────────────────────────────────────── */
+
+.positionGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.positionCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 160px;
+}
+
+.positionLabel {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+/* ── Chord diagram grid ──────────────────────────────────────────────────── */
+
+.chordGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.chordCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.chordName {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.chordCaption {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+/* ── Chord-scales list ──────────────────────────────────────────────────── */
+
+.chordScaleItem {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--klank-color-border);
+}
+
+.chordScaleItem:last-child {
+  border-bottom: none;
+}
+
+.chordScaleName {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.chordScaleCategory {
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+/* ── Legend / degree row ─────────────────────────────────────────────────── */
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.legendItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  background: var(--klank-color-secondary-background);
+  border: 1px solid var(--klank-color-border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  min-width: 32px;
+}
+
+.legendDegree {
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.legendNote {
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+/* ── Mode info line ──────────────────────────────────────────────────────── */
+
+.modeInfo {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  font-style: italic;
+}
+
+/* ── Empty / info messages ───────────────────────────────────────────────── */
+
+.emptyMessage {
+  font-size: 0.875rem;
+  opacity: 0.6;
+  font-style: italic;
+}
+
+/* ── Subheading within section ─────────────────────────────────────────── */
+
+.subheading {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0;
+  margin-top: 8px;
+}
+
+@media (max-width: 599px) {
+  .page {
+    padding-top: var(--safe-top);
+    padding-bottom: calc(var(--safe-bottom) + 1rem);
+  }
+
+  .content {
+    padding: 16px;
+  }
+}

--- a/apps/klank/app/routes/harmony.module.css
+++ b/apps/klank/app/routes/harmony.module.css
@@ -1,7 +1,9 @@
+/* ── Page shell ───────────────────────────────────────────────────────────── */
+
 .page {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  min-height: 100vh;
   background: var(--klank-color-background);
   color: var(--klank-color-text);
   overflow-y: auto;
@@ -42,111 +44,182 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 0;
   padding: 24px;
   max-width: 900px;
   width: 100%;
+  box-sizing: border-box;
 }
 
-.section {
+/* ── Controls bar ─────────────────────────────────────────────────────────── */
+
+.controlsBar {
   display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.section h2 {
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0;
-  padding-bottom: 8px;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+  padding-bottom: 20px;
   border-bottom: 1px solid var(--klank-color-border);
 }
 
-.row {
+.controlGroup {
   display: flex;
   align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.label {
-  font-size: 0.875rem;
+.controlLabel {
+  font-size: 0.8rem;
   color: var(--klank-color-text);
-  opacity: 0.7;
-  min-width: 80px;
+  opacity: 0.6;
+  white-space: nowrap;
+  user-select: none;
 }
 
-.button {
+/* ── Segmented control ────────────────────────────────────────────────────── */
+
+.segmented {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--klank-color-secondary-background);
   border: 1px solid var(--klank-color-border);
-  border-radius: 4px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.segBtn {
+  background: none;
+  border: none;
+  border-right: 1px solid var(--klank-color-border);
   color: var(--klank-color-text);
   cursor: pointer;
-  padding: 8px 16px;
-  font-size: 0.875rem;
+  padding: 6px 14px;
+  font-size: 0.85rem;
   white-space: nowrap;
+  opacity: 0.6;
+  transition: background 0.1s, opacity 0.1s;
+
+  &:last-child {
+    border-right: none;
+  }
 
   &:hover {
     background: var(--klank-color-highlight);
+    opacity: 0.9;
   }
 
-  &:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
+  &:focus-visible {
+    outline: 2px solid var(--klank-color-highlight);
+    outline-offset: -2px;
+    z-index: 1;
   }
 }
 
-.button.active {
+.segBtnActive {
   background: var(--klank-color-highlight);
-  border-color: var(--klank-color-text);
+  opacity: 1;
   font-weight: 600;
+  color: var(--klank-color-text);
 }
+
+/* ── Shared select ────────────────────────────────────────────────────────── */
 
 .select {
   background: var(--klank-color-secondary-background);
   border: 1px solid var(--klank-color-border);
-  border-radius: 4px;
+  border-radius: 6px;
   color: var(--klank-color-text);
-  padding: 8px 10px;
+  padding: 6px 10px;
   font-size: 0.875rem;
   cursor: pointer;
+  min-width: 0;
 
   &:focus {
-    outline: 1px solid var(--klank-color-highlight);
+    outline: 2px solid var(--klank-color-highlight);
+    outline-offset: 1px;
   }
 }
 
-/* ── Fretboard diagram full-neck ─────────────────────────────────────────── */
+/* ── Tab bar ──────────────────────────────────────────────────────────────── */
 
-.fretboardFullWrap {
-  width: 100%;
-  overflow-x: auto;
-}
-
-.fretboardFull {
-  min-width: 480px;
-}
-
-/* ── Position windows grid ─────────────────────────────────────────────────── */
-
-.positionGrid {
+.tabBar {
   display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
+  gap: 0;
+  border-bottom: 2px solid var(--klank-color-border);
+  margin-bottom: 24px;
+  margin-top: 20px;
 }
 
-.positionCard {
+.tabBtn {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px; /* overlap the tabBar border */
+  color: var(--klank-color-text);
+  cursor: pointer;
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  opacity: 0.55;
+  white-space: nowrap;
+  transition: opacity 0.1s;
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--klank-color-highlight);
+    outline-offset: -2px;
+    border-radius: 4px 4px 0 0;
+  }
+}
+
+.tabBtnActive {
+  opacity: 1;
+  font-weight: 600;
+  border-bottom-color: var(--klank-color-text);
+}
+
+/* ── Tab panel ────────────────────────────────────────────────────────────── */
+
+.tabPanel {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  width: 160px;
+  gap: 20px;
 }
 
-/* ── Chord diagram grid ──────────────────────────────────────────────────── */
+/* ── Filter row (quality / scale selects within a tab) ─────────────────── */
+
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* ── Chord tab ────────────────────────────────────────────────────────────── */
+
+.chordHeading {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.chordName {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.chordNoteInfo {
+  font-size: 0.8rem;
+  opacity: 0.6;
+  font-family: monospace;
+  letter-spacing: 0.02em;
+}
+
+.chordNoteInfoSep {
+  margin: 0 4px;
+  opacity: 0.4;
+}
 
 .chordGrid {
   display: flex;
@@ -162,75 +235,14 @@
   gap: 6px;
 }
 
-.chordName {
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-
 .chordCaption {
-  font-size: 0.75rem;
-  opacity: 0.7;
+  font-size: 0.78rem;
+  opacity: 0.75;
+  text-align: center;
 }
 
-/* ── Chord-scales list ──────────────────────────────────────────────────── */
-
-.chordScaleItem {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding-bottom: 24px;
-  border-bottom: 1px solid var(--klank-color-border);
-}
-
-.chordScaleItem:last-child {
-  border-bottom: none;
-}
-
-.chordScaleName {
-  font-size: 0.9rem;
-  font-weight: 600;
-}
-
-.chordScaleCategory {
-  font-size: 0.75rem;
-  opacity: 0.6;
-}
-
-/* ── Legend / degree row ─────────────────────────────────────────────────── */
-
-.legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.legendItem {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-  background: var(--klank-color-secondary-background);
-  border: 1px solid var(--klank-color-border);
-  border-radius: 4px;
-  padding: 4px 8px;
-  min-width: 32px;
-}
-
-.legendDegree {
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.legendNote {
-  font-size: 0.7rem;
-  opacity: 0.7;
-}
-
-/* ── Mode info line ──────────────────────────────────────────────────────── */
-
-.modeInfo {
-  font-size: 0.8rem;
-  opacity: 0.7;
+.romanNumeral {
+  font-weight: 700;
   font-style: italic;
 }
 
@@ -240,16 +252,233 @@
   font-size: 0.875rem;
   opacity: 0.6;
   font-style: italic;
-}
-
-/* ── Subheading within section ─────────────────────────────────────────── */
-
-.subheading {
-  font-size: 0.9rem;
-  font-weight: 600;
   margin: 0;
-  margin-top: 8px;
 }
+
+/* ── Scales tab: primary block ────────────────────────────────────────────── */
+
+.scaleHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.scaleTitle {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.scaleDescription {
+  font-size: 0.875rem;
+  opacity: 0.65;
+  margin: 0;
+}
+
+.modeRelation {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  font-style: italic;
+  margin: 0;
+}
+
+.formulaRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.formulaLabel {
+  font-size: 0.78rem;
+  opacity: 0.55;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.formulaSteps {
+  font-size: 0.875rem;
+  font-family: monospace;
+  letter-spacing: 0.04em;
+  opacity: 0.85;
+}
+
+/* ── Legend chips ─────────────────────────────────────────────────────────── */
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.legendChip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  background: var(--klank-color-secondary-background);
+  border: 1px solid var(--klank-color-border);
+  border-radius: 6px;
+  padding: 5px 9px;
+  min-width: 34px;
+  cursor: default;
+  transition: border-color 0.1s;
+}
+
+.legendChipRoot {
+  border-color: var(--klank-color-text);
+  background: var(--klank-color-highlight);
+}
+
+.legendDegree {
+  font-size: 0.78rem;
+  font-weight: 700;
+  font-family: monospace;
+}
+
+.legendNote {
+  font-size: 0.68rem;
+  opacity: 0.6;
+}
+
+/* ── Fretboard diagram containers ─────────────────────────────────────────── */
+
+.fretboardFullWrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.fretboardFull {
+  min-width: 520px;
+}
+
+/* ── Progressive disclosure (details/summary) ─────────────────────────────── */
+
+.disclosure {
+  border: 1px solid var(--klank-color-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.disclosureSummary {
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 12px 16px;
+  cursor: pointer;
+  user-select: none;
+  list-style: none; /* remove default triangle on Safari */
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--klank-color-secondary-background);
+
+  &::before {
+    content: '▶';
+    font-size: 0.65rem;
+    opacity: 0.5;
+    transition: transform 0.15s;
+  }
+
+  &:hover {
+    background: var(--klank-color-highlight);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--klank-color-highlight);
+    outline-offset: -2px;
+  }
+}
+
+.disclosure[open] > .disclosureSummary::before {
+  transform: rotate(90deg);
+}
+
+/* Remove default marker cross-browser */
+.disclosureSummary::-webkit-details-marker {
+  display: none;
+}
+
+.disclosure > :not(summary) {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ── Position windows grid ────────────────────────────────────────────────── */
+
+.positionGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.positionCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 160px;
+}
+
+/* ── Chord-scales tab ─────────────────────────────────────────────────────── */
+
+.chordScaleIntro {
+  font-size: 0.9rem;
+  margin: 0;
+  opacity: 0.8;
+}
+
+.chordScaleList {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.chordScaleItem {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px 0;
+  border-bottom: 1px solid var(--klank-color-border);
+
+  &:first-child {
+    padding-top: 0;
+  }
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+}
+
+.chordScaleHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.chordScaleName {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.chordScaleCategory {
+  font-size: 0.75rem;
+  opacity: 0.5;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.chordScaleDesc {
+  font-size: 0.85rem;
+  opacity: 0.65;
+  margin: 0;
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
 
 @media (max-width: 599px) {
   .page {
@@ -259,5 +488,22 @@
 
   .content {
     padding: 16px;
+  }
+
+  .controlsBar {
+    gap: 12px;
+  }
+
+  .tabBtn {
+    padding: 10px 12px;
+    font-size: 0.8rem;
+  }
+
+  .chordName {
+    font-size: 1rem;
+  }
+
+  .scaleTitle {
+    font-size: 1rem;
   }
 }

--- a/apps/klank/app/routes/harmony.module.css
+++ b/apps/klank/app/routes/harmony.module.css
@@ -146,11 +146,6 @@
   width: 160px;
 }
 
-.positionLabel {
-  font-size: 0.75rem;
-  opacity: 0.7;
-}
-
 /* ── Chord diagram grid ──────────────────────────────────────────────────── */
 
 .chordGrid {

--- a/apps/klank/app/routes/harmony.tsx
+++ b/apps/klank/app/routes/harmony.tsx
@@ -230,18 +230,17 @@ export default function Harmony() {
 
             {/* Position windows */}
             {(() => {
-              const positions = getScalePositions(rootPitch, scale, tuning)
+              const positions = getScalePositions(rootPitch, tuning)
               if (positions.length === 0) return null
               return (
                 <>
                   <h3 className={styles.subheading}>Position windows</h3>
                   <div className={styles.positionGrid}>
-                    {positions.map((pos) => (
-                      <div key={pos.startFret} className={styles.positionCard}>
-                        <span className={styles.positionLabel}>{pos.label}</span>
+                    {positions.map((startFret) => (
+                      <div key={startFret} className={styles.positionCard}>
                         <FretboardDiagram
                           grid={fullGrid}
-                          startFret={pos.startFret}
+                          startFret={startFret}
                           fretCount={5}
                           labelMode={labelMode}
                           noteNames={noteNames}
@@ -255,21 +254,19 @@ export default function Harmony() {
 
             {/* Diatonic triads */}
             {(() => {
-              const triads = getDiatonicTriads(rootPitch, scale)
-              const withChords = triads.filter((t) => t.chordKey !== null)
+              const withChords = getDiatonicTriads(rootPitch, scale)
+                .filter((t): t is { degree: string; chordKey: string } => t.chordKey !== null)
               if (withChords.length === 0) return null
               return (
                 <>
                   <h3 className={styles.subheading}>Diatonic triads</h3>
                   <div className={styles.chordGrid}>
-                    {withChords.map((t, i) => {
-                      const key = t.chordKey
-                      if (key === null) return null
-                      const variants = lookupChordDiagram(chordMap, key)
+                    {withChords.map((t) => {
+                      const variants = lookupChordDiagram(chordMap, t.chordKey)
                       if (variants.length === 0) return null
                       return (
-                        <div key={i} className={styles.chordCard}>
-                          <div className={styles.chordCaption}>{t.degree}: {key}</div>
+                        <div key={t.degree} className={styles.chordCard}>
+                          <div className={styles.chordCaption}>{t.degree}: {t.chordKey}</div>
                           <ChordDiagram variant={variants[0]} strings={variants[0].frets.length} />
                         </div>
                       )

--- a/apps/klank/app/routes/harmony.tsx
+++ b/apps/klank/app/routes/harmony.tsx
@@ -1,0 +1,339 @@
+import styles from './harmony.module.css'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import {
+  SCALES,
+  CHORD_QUALITIES,
+  CHORD_ROOTS,
+  NOTE_PITCH,
+  INSTRUMENT_TUNING,
+  pitchName,
+  getScaleById,
+  scalesForQuality,
+  getScaleFretboard,
+  getScalePositions,
+  getDiatonicTriads,
+  loadChordDiagrams,
+  lookupChordDiagram,
+  type ChordDiagramMap,
+} from '@klank/platform-api'
+import { useKlankStore } from '@klank/store'
+import { ChordDiagram, FretboardDiagram } from '@klank/ui'
+
+export default function Harmony() {
+  const navigate = useNavigate()
+  const instrument = useKlankStore().instrument
+  const setInstrument = useKlankStore().setInstrument
+  const harmony = useKlankStore().harmony
+  const setHarmony = useKlankStore().setHarmony
+
+  const rootPitch = harmony.rootPitch
+  const scale = getScaleById(harmony.scaleId) ?? SCALES[0]
+  const quality = harmony.quality
+
+  const [labelMode, setLabelMode] = useState<'degree' | 'note'>('degree')
+  const [chordMap, setChordMap] = useState<ChordDiagramMap>({})
+
+  const tuning = INSTRUMENT_TUNING[instrument]
+  const noteNames = Array.from({ length: 12 }, (_, i) => pitchName(i))
+
+  // Load chord diagrams when instrument changes
+  useEffect(() => {
+    let cancelled = false
+    loadChordDiagrams(instrument).then((map) => {
+      if (!cancelled) setChordMap(map)
+    })
+    return () => { cancelled = true }
+  }, [instrument])
+
+  // Derive root name for display (find the CHORD_ROOTS entry matching rootPitch)
+  const rootName = CHORD_ROOTS.find((r) => NOTE_PITCH[r] === rootPitch) ?? pitchName(rootPitch)
+
+  // Full neck grid (reused by scales tab and chord-scales tab)
+  const fullGrid = getScaleFretboard(rootPitch, scale, tuning)
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <button className={styles.backButton} onClick={() => navigate(-1)}>
+          ← Back
+        </button>
+        <h1>Harmony</h1>
+      </header>
+
+      <div className={styles.content}>
+        {/* ── Shared controls ─────────────────────────────────────────────── */}
+        <section className={styles.section}>
+          <div className={styles.row}>
+            <span className={styles.label}>Key</span>
+            <select
+              className={styles.select}
+              value={rootName}
+              onChange={(e) => setHarmony({ rootPitch: NOTE_PITCH[e.target.value] ?? 0 })}
+            >
+              {CHORD_ROOTS.map((r) => (
+                <option key={r} value={r}>{r}</option>
+              ))}
+            </select>
+
+            <span className={styles.label}>Instrument</span>
+            <button
+              className={styles.button}
+              style={{ opacity: instrument === 'guitar' ? 1 : 0.5 }}
+              onClick={() => setInstrument('guitar')}
+            >
+              Guitar
+            </button>
+            <button
+              className={styles.button}
+              style={{ opacity: instrument === 'bass' ? 1 : 0.5 }}
+              onClick={() => setInstrument('bass')}
+            >
+              Bass
+            </button>
+
+            <button
+              className={styles.button}
+              onClick={() => setLabelMode((m) => m === 'degree' ? 'note' : 'degree')}
+            >
+              {labelMode === 'degree' ? 'Degrees' : 'Notes'}
+            </button>
+          </div>
+
+          {/* Tab switcher */}
+          <div className={styles.row}>
+            {(
+              [
+                { tab: 'chords', label: 'Chords' },
+                { tab: 'scales', label: 'Scales & Modes' },
+                { tab: 'chord-scales', label: 'Chord-scales' },
+              ] as const
+            ).map(({ tab, label }) => (
+              <button
+                key={tab}
+                className={`${styles.button}${harmony.tab === tab ? ' ' + styles.active : ''}`}
+                onClick={() => setHarmony({ tab })}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Tab: Chords ──────────────────────────────────────────────────── */}
+        {harmony.tab === 'chords' && (
+          <section className={styles.section}>
+            <div className={styles.row}>
+              <span className={styles.label}>Quality</span>
+              <select
+                className={styles.select}
+                value={quality}
+                onChange={(e) => setHarmony({ quality: e.target.value })}
+              >
+                {CHORD_QUALITIES.map((q) => (
+                  <option key={q} value={q}>{q === '' ? 'major' : q}</option>
+                ))}
+              </select>
+            </div>
+
+            {(() => {
+              const chordKey = rootName + quality
+              const variants = lookupChordDiagram(chordMap, chordKey)
+              return (
+                <>
+                  <div className={styles.chordName}>{chordKey || `${rootName} major`}</div>
+                  {variants.length === 0 ? (
+                    <div className={styles.emptyMessage}>No diagram available.</div>
+                  ) : (
+                    <div className={styles.chordGrid}>
+                      {variants.map((v, i) => (
+                        <div key={i} className={styles.chordCard}>
+                          <ChordDiagram variant={v} strings={v.frets.length} />
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </>
+              )
+            })()}
+          </section>
+        )}
+
+        {/* ── Tab: Scales & Modes ──────────────────────────────────────────── */}
+        {harmony.tab === 'scales' && (
+          <section className={styles.section}>
+            <div className={styles.row}>
+              <span className={styles.label}>Scale</span>
+              <select
+                className={styles.select}
+                value={scale.id}
+                onChange={(e) => setHarmony({ scaleId: e.target.value })}
+              >
+                {(
+                  // Group by category
+                  (() => {
+                    const groups: Record<string, typeof SCALES[number][]> = {}
+                    for (const s of SCALES) {
+                      if (!groups[s.category]) groups[s.category] = []
+                      groups[s.category].push(s)
+                    }
+                    return Object.entries(groups).map(([cat, scales]) => (
+                      <optgroup key={cat} label={cat}>
+                        {scales.map((s) => (
+                          <option key={s.id} value={s.id}>{s.name}</option>
+                        ))}
+                      </optgroup>
+                    ))
+                  })()
+                )}
+              </select>
+            </div>
+
+            {/* Scale header */}
+            <div className={styles.subheading}>
+              {rootName} {scale.name}
+            </div>
+
+            {/* Mode info */}
+            {scale.modeOf && scale.modeDegree != null && (
+              <div className={styles.modeInfo}>
+                Mode {scale.modeDegree} of {(() => {
+                  const parent = getScaleById(scale.modeOf)
+                  return parent ? parent.name : scale.modeOf
+                })()}
+              </div>
+            )}
+
+            {/* Legend: degree over note */}
+            <div className={styles.legend}>
+              {scale.intervals.map((interval, i) => {
+                const notePitch = (rootPitch + interval) % 12
+                return (
+                  <div key={i} className={styles.legendItem}>
+                    <span className={styles.legendDegree}>{scale.degrees[i]}</span>
+                    <span className={styles.legendNote}>{pitchName(notePitch)}</span>
+                  </div>
+                )
+              })}
+            </div>
+
+            {/* Full neck fretboard */}
+            <div className={styles.fretboardFullWrap}>
+              <div className={styles.fretboardFull}>
+                <FretboardDiagram
+                  grid={fullGrid}
+                  labelMode={labelMode}
+                  noteNames={noteNames}
+                />
+              </div>
+            </div>
+
+            {/* Position windows */}
+            {(() => {
+              const positions = getScalePositions(rootPitch, scale, tuning)
+              if (positions.length === 0) return null
+              return (
+                <>
+                  <h3 className={styles.subheading}>Position windows</h3>
+                  <div className={styles.positionGrid}>
+                    {positions.map((pos) => (
+                      <div key={pos.startFret} className={styles.positionCard}>
+                        <span className={styles.positionLabel}>{pos.label}</span>
+                        <FretboardDiagram
+                          grid={fullGrid}
+                          startFret={pos.startFret}
+                          fretCount={5}
+                          labelMode={labelMode}
+                          noteNames={noteNames}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )
+            })()}
+
+            {/* Diatonic triads */}
+            {(() => {
+              const triads = getDiatonicTriads(rootPitch, scale)
+              const withChords = triads.filter((t) => t.chordKey !== null)
+              if (withChords.length === 0) return null
+              return (
+                <>
+                  <h3 className={styles.subheading}>Diatonic triads</h3>
+                  <div className={styles.chordGrid}>
+                    {withChords.map((t, i) => {
+                      const key = t.chordKey
+                      if (key === null) return null
+                      const variants = lookupChordDiagram(chordMap, key)
+                      if (variants.length === 0) return null
+                      return (
+                        <div key={i} className={styles.chordCard}>
+                          <div className={styles.chordCaption}>{t.degree}: {key}</div>
+                          <ChordDiagram variant={variants[0]} strings={variants[0].frets.length} />
+                        </div>
+                      )
+                    })}
+                  </div>
+                </>
+              )
+            })()}
+          </section>
+        )}
+
+        {/* ── Tab: Chord-scales ─────────────────────────────────────────────── */}
+        {harmony.tab === 'chord-scales' && (
+          <section className={styles.section}>
+            <div className={styles.row}>
+              <span className={styles.label}>Quality</span>
+              <select
+                className={styles.select}
+                value={quality}
+                onChange={(e) => setHarmony({ quality: e.target.value })}
+              >
+                {CHORD_QUALITIES.map((q) => (
+                  <option key={q} value={q}>{q === '' ? 'major' : q}</option>
+                ))}
+              </select>
+            </div>
+
+            {(() => {
+              const compatibleScales = scalesForQuality(quality)
+              if (compatibleScales.length === 0) {
+                return (
+                  <div className={styles.emptyMessage}>
+                    No scales defined for this chord quality.
+                  </div>
+                )
+              }
+              return (
+                <div>
+                  {compatibleScales.map((s) => {
+                    const csGrid = getScaleFretboard(rootPitch, s, tuning)
+                    return (
+                      <div key={s.id} className={styles.chordScaleItem}>
+                        <div className={styles.chordScaleName}>
+                          {rootName} {s.name}
+                        </div>
+                        <div className={styles.chordScaleCategory}>{s.category}</div>
+                        <div className={styles.fretboardFullWrap}>
+                          <div className={styles.fretboardFull}>
+                            <FretboardDiagram
+                              grid={csGrid}
+                              labelMode={labelMode}
+                              noteNames={noteNames}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              )
+            })()}
+          </section>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/klank/app/routes/harmony.tsx
+++ b/apps/klank/app/routes/harmony.tsx
@@ -5,6 +5,7 @@ import {
   SCALES,
   CHORD_QUALITIES,
   CHORD_ROOTS,
+  CHORD_INTERVALS,
   NOTE_PITCH,
   INSTRUMENT_TUNING,
   pitchName,
@@ -12,13 +13,23 @@ import {
   scalesForQuality,
   getScaleFretboard,
   getScalePositions,
+  getStepPattern,
+  intervalName,
   getDiatonicTriads,
+  parseChordKey,
   loadChordDiagrams,
   lookupChordDiagram,
   type ChordDiagramMap,
 } from '@klank/platform-api'
 import { useKlankStore } from '@klank/store'
 import { ChordDiagram, FretboardDiagram } from '@klank/ui'
+
+// Ordinal helper: 1 → "1st", 2 → "2nd", etc.
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0])
+}
 
 export default function Harmony() {
   const navigate = useNavigate()
@@ -36,6 +47,8 @@ export default function Harmony() {
 
   const tuning = INSTRUMENT_TUNING[instrument]
   const noteNames = Array.from({ length: 12 }, (_, i) => pitchName(i))
+  // Open-string labels for FretboardDiagram (low-to-high)
+  const stringLabels = tuning.map((p) => pitchName(p))
 
   // Load chord diagrams when instrument changes
   useEffect(() => {
@@ -63,10 +76,12 @@ export default function Harmony() {
 
       <div className={styles.content}>
         {/* ── Shared controls ─────────────────────────────────────────────── */}
-        <section className={styles.section}>
-          <div className={styles.row}>
-            <span className={styles.label}>Key</span>
+        <div className={styles.controlsBar}>
+          {/* Key select */}
+          <div className={styles.controlGroup}>
+            <label className={styles.controlLabel} htmlFor="harmony-key-select">Key</label>
             <select
+              id="harmony-key-select"
               className={styles.select}
               value={rootName}
               onChange={(e) => setHarmony({ rootPitch: NOTE_PITCH[e.target.value] ?? 0 })}
@@ -75,57 +90,79 @@ export default function Harmony() {
                 <option key={r} value={r}>{r}</option>
               ))}
             </select>
-
-            <span className={styles.label}>Instrument</span>
-            <button
-              className={styles.button}
-              style={{ opacity: instrument === 'guitar' ? 1 : 0.5 }}
-              onClick={() => setInstrument('guitar')}
-            >
-              Guitar
-            </button>
-            <button
-              className={styles.button}
-              style={{ opacity: instrument === 'bass' ? 1 : 0.5 }}
-              onClick={() => setInstrument('bass')}
-            >
-              Bass
-            </button>
-
-            <button
-              className={styles.button}
-              onClick={() => setLabelMode((m) => m === 'degree' ? 'note' : 'degree')}
-            >
-              {labelMode === 'degree' ? 'Degrees' : 'Notes'}
-            </button>
           </div>
 
-          {/* Tab switcher */}
-          <div className={styles.row}>
-            {(
-              [
-                { tab: 'chords', label: 'Chords' },
-                { tab: 'scales', label: 'Scales & Modes' },
-                { tab: 'chord-scales', label: 'Chord-scales' },
-              ] as const
-            ).map(({ tab, label }) => (
+          {/* Instrument segmented control */}
+          <div className={styles.controlGroup}>
+            <span className={styles.controlLabel} id="harmony-instrument-label">Instrument</span>
+            <div className={styles.segmented} role="group" aria-labelledby="harmony-instrument-label">
               <button
-                key={tab}
-                className={`${styles.button}${harmony.tab === tab ? ' ' + styles.active : ''}`}
-                onClick={() => setHarmony({ tab })}
+                className={`${styles.segBtn}${instrument === 'guitar' ? ' ' + styles.segBtnActive : ''}`}
+                onClick={() => setInstrument('guitar')}
+                aria-pressed={instrument === 'guitar'}
               >
-                {label}
+                Guitar
               </button>
-            ))}
+              <button
+                className={`${styles.segBtn}${instrument === 'bass' ? ' ' + styles.segBtnActive : ''}`}
+                onClick={() => setInstrument('bass')}
+                aria-pressed={instrument === 'bass'}
+              >
+                Bass
+              </button>
+            </div>
           </div>
-        </section>
+
+          {/* Labels segmented control */}
+          <div className={styles.controlGroup}>
+            <span className={styles.controlLabel} id="harmony-labels-label">Labels</span>
+            <div className={styles.segmented} role="group" aria-labelledby="harmony-labels-label">
+              <button
+                className={`${styles.segBtn}${labelMode === 'degree' ? ' ' + styles.segBtnActive : ''}`}
+                onClick={() => setLabelMode('degree')}
+                aria-pressed={labelMode === 'degree'}
+              >
+                Degrees
+              </button>
+              <button
+                className={`${styles.segBtn}${labelMode === 'note' ? ' ' + styles.segBtnActive : ''}`}
+                onClick={() => setLabelMode('note')}
+                aria-pressed={labelMode === 'note'}
+              >
+                Notes
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Tab bar ──────────────────────────────────────────────────────── */}
+        <div className={styles.tabBar} role="tablist" aria-label="Harmony sections">
+          {(
+            [
+              { tab: 'chords', label: 'Chords' },
+              { tab: 'scales', label: 'Scales & Modes' },
+              { tab: 'chord-scales', label: 'Chord-scales' },
+            ] as const
+          ).map(({ tab, label }) => (
+            <button
+              key={tab}
+              role="tab"
+              aria-selected={harmony.tab === tab}
+              className={`${styles.tabBtn}${harmony.tab === tab ? ' ' + styles.tabBtnActive : ''}`}
+              onClick={() => setHarmony({ tab })}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
 
         {/* ── Tab: Chords ──────────────────────────────────────────────────── */}
         {harmony.tab === 'chords' && (
-          <section className={styles.section}>
-            <div className={styles.row}>
-              <span className={styles.label}>Quality</span>
+          <section className={styles.tabPanel}>
+            <div className={styles.filterRow}>
+              <label className={styles.controlLabel} htmlFor="harmony-chord-quality">Quality</label>
               <select
+                id="harmony-chord-quality"
                 className={styles.select}
                 value={quality}
                 onChange={(e) => setHarmony({ quality: e.target.value })}
@@ -138,12 +175,41 @@ export default function Harmony() {
 
             {(() => {
               const chordKey = rootName + quality
+              const displayName = quality === '' ? `${rootName} major` : chordKey
               const variants = lookupChordDiagram(chordMap, chordKey)
+
+              // Build a one-liner: "Notes: C E G  ·  1 3 5"
+              const parsed = parseChordKey(chordKey)
+              const intervals = parsed ? CHORD_INTERVALS[parsed.quality] : null
+              const noteList = intervals
+                ? intervals.map((i) => pitchName((rootPitch + i) % 12)).join('  ')
+                : null
+              const degreeLabels = intervals
+                ? intervals.map((i) => {
+                    const semis = ((i % 12) + 12) % 12
+                    const names: Record<number, string> = {
+                      0: '1', 1: 'b2', 2: '2', 3: 'b3', 4: '3', 5: '4',
+                      6: 'b5', 7: '5', 8: '#5', 9: '6', 10: 'b7', 11: '7',
+                    }
+                    return names[semis] ?? String(i)
+                  }).join('  ')
+                : null
+
               return (
                 <>
-                  <div className={styles.chordName}>{chordKey || `${rootName} major`}</div>
+                  <div className={styles.chordHeading}>
+                    <span className={styles.chordName}>{displayName}</span>
+                    {noteList && (
+                      <span className={styles.chordNoteInfo}>
+                        {noteList}
+                        <span className={styles.chordNoteInfoSep}> · </span>
+                        {degreeLabels}
+                      </span>
+                    )}
+                  </div>
+
                   {variants.length === 0 ? (
-                    <div className={styles.emptyMessage}>No diagram available.</div>
+                    <p className={styles.emptyMessage}>No diagram available for this voicing.</p>
                   ) : (
                     <div className={styles.chordGrid}>
                       {variants.map((v, i) => (
@@ -161,55 +227,69 @@ export default function Harmony() {
 
         {/* ── Tab: Scales & Modes ──────────────────────────────────────────── */}
         {harmony.tab === 'scales' && (
-          <section className={styles.section}>
-            <div className={styles.row}>
-              <span className={styles.label}>Scale</span>
+          <section className={styles.tabPanel}>
+            <div className={styles.filterRow}>
+              <label className={styles.controlLabel} htmlFor="harmony-scale-select">Scale</label>
               <select
+                id="harmony-scale-select"
                 className={styles.select}
                 value={scale.id}
                 onChange={(e) => setHarmony({ scaleId: e.target.value })}
               >
-                {(
-                  // Group by category
-                  (() => {
-                    const groups: Record<string, typeof SCALES[number][]> = {}
-                    for (const s of SCALES) {
-                      if (!groups[s.category]) groups[s.category] = []
-                      groups[s.category].push(s)
-                    }
-                    return Object.entries(groups).map(([cat, scales]) => (
-                      <optgroup key={cat} label={cat}>
-                        {scales.map((s) => (
-                          <option key={s.id} value={s.id}>{s.name}</option>
-                        ))}
-                      </optgroup>
-                    ))
-                  })()
-                )}
+                {(() => {
+                  const groups: Record<string, typeof SCALES[number][]> = {}
+                  for (const s of SCALES) {
+                    if (!groups[s.category]) groups[s.category] = []
+                    groups[s.category].push(s)
+                  }
+                  return Object.entries(groups).map(([cat, scales]) => (
+                    <optgroup key={cat} label={cat}>
+                      {scales.map((s) => (
+                        <option key={s.id} value={s.id}>{s.name}</option>
+                      ))}
+                    </optgroup>
+                  ))
+                })()}
               </select>
             </div>
 
-            {/* Scale header */}
-            <div className={styles.subheading}>
-              {rootName} {scale.name}
+            {/* Primary block: always visible ─────────────────────────────── */}
+            <div className={styles.scaleHeader}>
+              <h2 className={styles.scaleTitle}>{rootName} {scale.name}</h2>
+              <p className={styles.scaleDescription}>{scale.description}</p>
             </div>
 
-            {/* Mode info */}
-            {scale.modeOf && scale.modeDegree != null && (
-              <div className={styles.modeInfo}>
-                Mode {scale.modeDegree} of {(() => {
-                  const parent = getScaleById(scale.modeOf)
-                  return parent ? parent.name : scale.modeOf
-                })()}
-              </div>
-            )}
+            {/* Mode relationship */}
+            {scale.modeOf != null && scale.modeDegree != null && (() => {
+              const parent = getScaleById(scale.modeOf)
+              if (!parent) return null
+              const parentRootPitch = ((rootPitch - parent.intervals[scale.modeDegree - 1]) % 12 + 12) % 12
+              const parentRootName = pitchName(parentRootPitch)
+              return (
+                <p className={styles.modeRelation}>
+                  {ordinal(scale.modeDegree)} mode of{' '}
+                  <strong>{parentRootName} {parent.name}</strong>
+                </p>
+              )
+            })()}
 
-            {/* Legend: degree over note */}
-            <div className={styles.legend}>
+            {/* Formula row */}
+            <div className={styles.formulaRow}>
+              <span className={styles.formulaLabel}>Formula</span>
+              <span className={styles.formulaSteps}>{getStepPattern(scale).join(' – ')}</span>
+            </div>
+
+            {/* Note/degree legend chips */}
+            <div className={styles.legend} aria-label="Scale degrees and notes">
               {scale.intervals.map((interval, i) => {
                 const notePitch = (rootPitch + interval) % 12
+                const isRoot = interval === 0
                 return (
-                  <div key={i} className={styles.legendItem}>
+                  <div
+                    key={i}
+                    className={`${styles.legendChip}${isRoot ? ' ' + styles.legendChipRoot : ''}`}
+                    title={intervalName(interval)}
+                  >
                     <span className={styles.legendDegree}>{scale.degrees[i]}</span>
                     <span className={styles.legendNote}>{pitchName(notePitch)}</span>
                   </div>
@@ -217,24 +297,28 @@ export default function Harmony() {
               })}
             </div>
 
-            {/* Full neck fretboard */}
+            {/* Full-neck fretboard */}
             <div className={styles.fretboardFullWrap}>
               <div className={styles.fretboardFull}>
                 <FretboardDiagram
                   grid={fullGrid}
                   labelMode={labelMode}
                   noteNames={noteNames}
+                  stringLabels={stringLabels}
+                  showFretNumbers
                 />
               </div>
             </div>
 
-            {/* Position windows */}
+            {/* Secondary detail: Positions (open by default) */}
             {(() => {
               const positions = getScalePositions(rootPitch, tuning)
               if (positions.length === 0) return null
               return (
-                <>
-                  <h3 className={styles.subheading}>Position windows</h3>
+                <details className={styles.disclosure} open>
+                  <summary className={styles.disclosureSummary}>
+                    Positions ({positions.length})
+                  </summary>
                   <div className={styles.positionGrid}>
                     {positions.map((startFret) => (
                       <div key={startFret} className={styles.positionCard}>
@@ -248,31 +332,39 @@ export default function Harmony() {
                       </div>
                     ))}
                   </div>
-                </>
+                </details>
               )
             })()}
 
-            {/* Diatonic triads */}
+            {/* Secondary detail: Diatonic chords (collapsed by default) */}
             {(() => {
               const withChords = getDiatonicTriads(rootPitch, scale)
-                .filter((t): t is { degree: string; chordKey: string } => t.chordKey !== null)
+                .filter((t): t is { degree: string; chordKey: string; roman: string } =>
+                  t.chordKey !== null && t.roman !== null,
+                )
               if (withChords.length === 0) return null
               return (
-                <>
-                  <h3 className={styles.subheading}>Diatonic triads</h3>
+                <details className={styles.disclosure}>
+                  <summary className={styles.disclosureSummary}>
+                    Diatonic chords
+                  </summary>
                   <div className={styles.chordGrid}>
                     {withChords.map((t) => {
                       const variants = lookupChordDiagram(chordMap, t.chordKey)
                       if (variants.length === 0) return null
                       return (
                         <div key={t.degree} className={styles.chordCard}>
-                          <div className={styles.chordCaption}>{t.degree}: {t.chordKey}</div>
+                          <div className={styles.chordCaption}>
+                            <span className={styles.romanNumeral}>{t.roman}</span>
+                            {' — '}
+                            {t.chordKey}
+                          </div>
                           <ChordDiagram variant={variants[0]} strings={variants[0].frets.length} />
                         </div>
                       )
                     })}
                   </div>
-                </>
+                </details>
               )
             })()}
           </section>
@@ -280,10 +372,11 @@ export default function Harmony() {
 
         {/* ── Tab: Chord-scales ─────────────────────────────────────────────── */}
         {harmony.tab === 'chord-scales' && (
-          <section className={styles.section}>
-            <div className={styles.row}>
-              <span className={styles.label}>Quality</span>
+          <section className={styles.tabPanel}>
+            <div className={styles.filterRow}>
+              <label className={styles.controlLabel} htmlFor="harmony-cs-quality">Quality</label>
               <select
+                id="harmony-cs-quality"
                 className={styles.select}
                 value={quality}
                 onChange={(e) => setHarmony({ quality: e.target.value })}
@@ -294,31 +387,39 @@ export default function Harmony() {
               </select>
             </div>
 
+            <p className={styles.chordScaleIntro}>
+              Scales that fit a{' '}
+              <strong>{rootName}{quality === '' ? ' major' : quality}</strong> chord.
+            </p>
+
             {(() => {
               const compatibleScales = scalesForQuality(quality)
               if (compatibleScales.length === 0) {
                 return (
-                  <div className={styles.emptyMessage}>
+                  <p className={styles.emptyMessage}>
                     No scales defined for this chord quality.
-                  </div>
+                  </p>
                 )
               }
               return (
-                <div>
+                <div className={styles.chordScaleList}>
                   {compatibleScales.map((s) => {
                     const csGrid = getScaleFretboard(rootPitch, s, tuning)
                     return (
                       <div key={s.id} className={styles.chordScaleItem}>
-                        <div className={styles.chordScaleName}>
-                          {rootName} {s.name}
+                        <div className={styles.chordScaleHeader}>
+                          <span className={styles.chordScaleName}>{rootName} {s.name}</span>
+                          <span className={styles.chordScaleCategory}>{s.category}</span>
                         </div>
-                        <div className={styles.chordScaleCategory}>{s.category}</div>
+                        <p className={styles.chordScaleDesc}>{s.description}</p>
                         <div className={styles.fretboardFullWrap}>
                           <div className={styles.fretboardFull}>
                             <FretboardDiagram
                               grid={csGrid}
                               labelMode={labelMode}
                               noteNames={noteNames}
+                              stringLabels={stringLabels}
+                              showFretNumbers
                             />
                           </div>
                         </div>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,14 @@ export default [
     },
   },
   {
+    // Non-null assertions are idiomatic in tests, where fixtures are known to
+    // exist (e.g. `getScaleById('ionian')!`). Allow them in spec files only.
+    files: ['**/*.spec.ts', '**/*.spec.tsx'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+  {
     files: [
       '**/*.ts',
       '**/*.tsx',

--- a/libs/platform-api/src/index.ts
+++ b/libs/platform-api/src/index.ts
@@ -5,6 +5,7 @@ export * from './lib/chords';
 export * from './lib/chord-symbol';
 export * from './lib/chord-diagrams';
 export * from './lib/chord-theory';
+export * from './lib/scales';
 export * from './lib/sheet-lines';
 export * from './lib/userAgent';
 export * from './lib/download';

--- a/libs/platform-api/src/lib/scales.spec.ts
+++ b/libs/platform-api/src/lib/scales.spec.ts
@@ -11,6 +11,8 @@ import {
   getScaleFretboard,
   getScalePositions,
   getDiatonicTriads,
+  getStepPattern,
+  intervalName,
 } from './scales.js'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -73,6 +75,14 @@ describe('SCALES table', () => {
 
   it('there are exactly 24 scales', () => {
     expect(SCALES.length).toBe(24)
+  })
+
+  it('every scale has a non-empty, trimmed description of at least 10 characters', () => {
+    for (const scale of SCALES) {
+      expect(typeof scale.description, scale.id).toBe('string')
+      expect(scale.description.trim(), scale.id).toBe(scale.description)
+      expect(scale.description.length, scale.id).toBeGreaterThanOrEqual(10)
+    }
   })
 })
 
@@ -252,7 +262,57 @@ describe('getScalePositions', () => {
   })
 })
 
-// ── 6. getDiatonicTriads ──────────────────────────────────────────────────────
+// ── 6. getStepPattern ────────────────────────────────────────────────────────
+
+describe('getStepPattern', () => {
+  it('returns an array of the same length as intervals (property over all scales)', () => {
+    fc.assert(
+      fc.property(scaleArb, (scale) => {
+        expect(getStepPattern(scale)).toHaveLength(scale.intervals.length)
+      }),
+    )
+  })
+
+  it('step sizes decode to values that sum to 12 (property over all scales)', () => {
+    const decode = (token: string): number => {
+      if (token === 'H') return 1
+      if (token === 'W') return 2
+      if (token === 'W½') return 3
+      return Number(token)
+    }
+    fc.assert(
+      fc.property(scaleArb, (scale) => {
+        const sum = getStepPattern(scale).reduce((acc, tok) => acc + decode(tok), 0)
+        expect(sum, scale.id).toBe(12)
+      }),
+    )
+  })
+
+  it("crafted: ionian step pattern is ['W','W','H','W','W','W','H']", () => {
+    const ionian = getScaleById('ionian')!
+    expect(getStepPattern(ionian)).toEqual(['W', 'W', 'H', 'W', 'W', 'W', 'H'])
+  })
+})
+
+// ── 7. intervalName ───────────────────────────────────────────────────────────
+
+describe('intervalName', () => {
+  it('intervalName(s) === intervalName(s + 12) for s in 0..11 (octave stability)', () => {
+    for (let s = 0; s <= 11; s++) {
+      expect(intervalName(s + 12), `s=${s}`).toBe(intervalName(s))
+    }
+  })
+
+  it('crafted spot-checks: 0 Root, 3 Minor 3rd, 6 Tritone, 7 Perfect 5th, 11 Major 7th', () => {
+    expect(intervalName(0)).toBe('Root')
+    expect(intervalName(3)).toBe('Minor 3rd')
+    expect(intervalName(6)).toBe('Tritone')
+    expect(intervalName(7)).toBe('Perfect 5th')
+    expect(intervalName(11)).toBe('Major 7th')
+  })
+})
+
+// ── 8. getDiatonicTriads ──────────────────────────────────────────────────────
 
 describe('getDiatonicTriads', () => {
   it('C ionian produces the correct triad degrees in order (C, Dm, Em, F, G, Am, Bdim)', () => {
@@ -260,9 +320,11 @@ describe('getDiatonicTriads', () => {
     const triads = getDiatonicTriads(0, ionian)
     // 7 degrees for a 7-note scale
     expect(triads).toHaveLength(7)
-    const expected = ['C', 'Dm', 'Em', 'F', 'G', 'Am', 'Bdim']
+    const expectedChords = ['C', 'Dm', 'Em', 'F', 'G', 'Am', 'Bdim']
+    const expectedRomans = ['I', 'ii', 'iii', 'IV', 'V', 'vi', 'vii°']
     for (let i = 0; i < 7; i++) {
-      expect(triads[i].chordKey, `degree ${i + 1}`).toBe(expected[i])
+      expect(triads[i].chordKey, `degree ${i + 1} chordKey`).toBe(expectedChords[i])
+      expect(triads[i].roman, `degree ${i + 1} roman`).toBe(expectedRomans[i])
     }
   })
 
@@ -302,9 +364,22 @@ describe('getDiatonicTriads', () => {
       }),
     )
   })
+
+  it('roman is null exactly when chordKey is null (property over all roots and scales)', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const triads = getDiatonicTriads(root, scale)
+        for (const triad of triads) {
+          expect(triad.roman === null, `chordKey=${triad.chordKey} roman=${triad.roman}`).toBe(
+            triad.chordKey === null,
+          )
+        }
+      }),
+    )
+  })
 })
 
-// ── 7. CHORD_SCALE_MAP ────────────────────────────────────────────────────────
+// ── 9. CHORD_SCALE_MAP ────────────────────────────────────────────────────────
 
 describe('CHORD_SCALE_MAP', () => {
   it('key set equals CHORD_QUALITIES', () => {
@@ -339,7 +414,7 @@ describe('CHORD_SCALE_MAP', () => {
   })
 })
 
-// ── 8. getScaleById ───────────────────────────────────────────────────────────
+// ── 10. getScaleById ──────────────────────────────────────────────────────────
 
 describe('getScaleById', () => {
   it('resolves every scale in SCALES by id', () => {

--- a/libs/platform-api/src/lib/scales.spec.ts
+++ b/libs/platform-api/src/lib/scales.spec.ts
@@ -214,48 +214,39 @@ describe('getScaleFretboard', () => {
 // ── 5. getScalePositions ──────────────────────────────────────────────────────
 
 describe('getScalePositions', () => {
-  it('each startFret is in 0..11', () => {
-    fc.assert(
-      fc.property(rootArb, scaleArb, (root, scale) => {
-        const positions = getScalePositions(root, scale, GUITAR_TUNING)
-        for (const pos of positions) {
-          expect(pos.startFret).toBeGreaterThanOrEqual(0)
-          expect(pos.startFret).toBeLessThanOrEqual(11)
-        }
-      }),
-    )
-  })
+  const tuningArb = fc.constantFrom(GUITAR_TUNING, BASS_TUNING)
 
-  it('label === `${startFret}fr` for every position', () => {
+  it('every start fret is in 0..11 and anchors the root on the lowest string', () => {
     fc.assert(
-      fc.property(rootArb, scaleArb, (root, scale) => {
-        const positions = getScalePositions(root, scale, GUITAR_TUNING)
-        for (const pos of positions) {
-          expect(pos.label).toBe(`${pos.startFret}fr`)
-        }
-      }),
-    )
-  })
-
-  it('(tuning[0] + startFret) % 12 === root % 12 for every position', () => {
-    fc.assert(
-      fc.property(rootArb, scaleArb, (root, scale) => {
-        const positions = getScalePositions(root, scale, GUITAR_TUNING)
+      fc.property(rootArb, tuningArb, (root, tuning) => {
         const rootMod = ((root % 12) + 12) % 12
-        for (const pos of positions) {
-          expect((GUITAR_TUNING[0] + pos.startFret) % 12).toBe(rootMod)
+        for (const fret of getScalePositions(root, tuning)) {
+          expect(fret).toBeGreaterThanOrEqual(0)
+          expect(fret).toBeLessThanOrEqual(11)
+          expect((tuning[0] + fret) % 12).toBe(rootMod)
         }
       }),
     )
   })
 
-  it('positions are sorted ascending by startFret', () => {
+  it('positions are unique and sorted ascending', () => {
     fc.assert(
-      fc.property(rootArb, scaleArb, (root, scale) => {
-        const positions = getScalePositions(root, scale, GUITAR_TUNING)
+      fc.property(rootArb, tuningArb, (root, tuning) => {
+        const positions = getScalePositions(root, tuning)
+        expect(new Set(positions).size).toBe(positions.length)
         for (let i = 1; i < positions.length; i++) {
-          expect(positions[i].startFret).toBeGreaterThan(positions[i - 1].startFret)
+          expect(positions[i]).toBeGreaterThan(positions[i - 1])
         }
+      }),
+    )
+  })
+
+  it('returns exactly the frets in 0..11 whose lowest-string pitch is the root', () => {
+    fc.assert(
+      fc.property(rootArb, tuningArb, (root, tuning) => {
+        const rootMod = ((root % 12) + 12) % 12
+        const expected = [...Array(12).keys()].filter((fret) => (tuning[0] + fret) % 12 === rootMod)
+        expect(getScalePositions(root, tuning)).toEqual(expected)
       }),
     )
   })

--- a/libs/platform-api/src/lib/scales.spec.ts
+++ b/libs/platform-api/src/lib/scales.spec.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import { CHORD_QUALITIES, GUITAR_TUNING, BASS_TUNING } from './chord-theory.js'
+import {
+  SCALES,
+  CHORD_SCALE_MAP,
+  getScalePitches,
+  getDegreeByPitch,
+  getScaleById,
+  scalesForQuality,
+  getScaleFretboard,
+  getScalePositions,
+  getDiatonicTriads,
+} from './scales.js'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const rootArb = fc.integer({ min: 0, max: 11 })
+const scaleArb = fc.constantFrom(...SCALES)
+
+// ── 1. Scale table invariants ─────────────────────────────────────────────────
+
+describe('SCALES table', () => {
+  it('intervals.length === degrees.length for every scale', () => {
+    for (const scale of SCALES) {
+      expect(scale.intervals.length, scale.id).toBe(scale.degrees.length)
+    }
+  })
+
+  it('intervals are strictly ascending for every scale', () => {
+    for (const scale of SCALES) {
+      for (let i = 1; i < scale.intervals.length; i++) {
+        expect(scale.intervals[i], `${scale.id}[${i}]`).toBeGreaterThan(scale.intervals[i - 1])
+      }
+    }
+  })
+
+  it('intervals[0] === 0 for every scale', () => {
+    for (const scale of SCALES) {
+      expect(scale.intervals[0], scale.id).toBe(0)
+    }
+  })
+
+  it('all intervals are in 0..11 for every scale', () => {
+    for (const scale of SCALES) {
+      for (const interval of scale.intervals) {
+        expect(interval, `${scale.id} interval ${interval}`).toBeGreaterThanOrEqual(0)
+        expect(interval, `${scale.id} interval ${interval}`).toBeLessThanOrEqual(11)
+      }
+    }
+  })
+
+  it('intervals are unique within each scale', () => {
+    for (const scale of SCALES) {
+      const unique = new Set(scale.intervals)
+      expect(unique.size, scale.id).toBe(scale.intervals.length)
+    }
+  })
+
+  it('scale ids are globally unique', () => {
+    const ids = SCALES.map((s) => s.id)
+    const unique = new Set(ids)
+    expect(unique.size).toBe(ids.length)
+  })
+
+  it('if modeOf is set, getScaleById(modeOf) resolves for every such scale', () => {
+    for (const scale of SCALES) {
+      if (scale.modeOf !== undefined) {
+        expect(getScaleById(scale.modeOf), `${scale.id}.modeOf=${scale.modeOf}`).toBeDefined()
+      }
+    }
+  })
+
+  it('there are exactly 24 scales', () => {
+    expect(SCALES.length).toBe(24)
+  })
+})
+
+// ── 2. getScalePitches ────────────────────────────────────────────────────────
+
+describe('getScalePitches', () => {
+  it('returns the same number of pitches as intervals', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        expect(getScalePitches(root, scale)).toHaveLength(scale.intervals.length)
+      }),
+    )
+  })
+
+  it('all returned pitches are in 0..11', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        for (const pitch of getScalePitches(root, scale)) {
+          expect(pitch).toBeGreaterThanOrEqual(0)
+          expect(pitch).toBeLessThanOrEqual(11)
+        }
+      }),
+    )
+  })
+
+  it('pitch set equals intervals shifted by root mod 12 for all roots and scales', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const expected = new Set(scale.intervals.map((i) => ((root + i) % 12 + 12) % 12))
+        const actual = new Set(getScalePitches(root, scale))
+        expect(actual).toEqual(expected)
+      }),
+    )
+  })
+
+  it('crafted: C ionian [0,2,4,5,7,9,11]', () => {
+    const ionian = getScaleById('ionian')!
+    expect(getScalePitches(0, ionian)).toEqual([0, 2, 4, 5, 7, 9, 11])
+  })
+
+  it('crafted: C minor-pentatonic [0,3,5,7,10]', () => {
+    const mp = getScaleById('minor-pentatonic')!
+    expect(getScalePitches(0, mp)).toEqual([0, 3, 5, 7, 10])
+  })
+
+  it('crafted: G altered (root 7) contains expected pitch-class set [7,8,10,11,1,3,5]', () => {
+    // Altered: [0,1,3,4,6,8,10] relative to root.
+    // Root G = 7: 7,8,10,11,1,3,5
+    const altered = getScaleById('altered')!
+    const pitches = new Set(getScalePitches(7, altered))
+    expect(pitches).toEqual(new Set([7, 8, 10, 11, 1, 3, 5]))
+  })
+})
+
+// ── 3. Mode-rotation property ─────────────────────────────────────────────────
+
+describe('mode-rotation property', () => {
+  it('a mode rooted at r has the same pitch set as its parent rooted at (r - parent.intervals[modeDegree-1]) mod 12', () => {
+    const modes = SCALES.filter((s) => s.modeOf !== undefined && s.modeDegree !== undefined)
+    fc.assert(
+      fc.property(rootArb, fc.constantFrom(...modes), (r, mode) => {
+        const parent = getScaleById(mode.modeOf!)!
+        const offset = parent.intervals[mode.modeDegree! - 1]
+        const parentRoot = ((r - offset) % 12 + 12) % 12
+        const modeSet = new Set(getScalePitches(r, mode))
+        const parentSet = new Set(getScalePitches(parentRoot, parent))
+        expect(modeSet).toEqual(parentSet)
+      }),
+    )
+  })
+})
+
+// ── 4. getScaleFretboard ──────────────────────────────────────────────────────
+
+describe('getScaleFretboard', () => {
+  it('returns tuning.length rows × 13 columns (fretCount=12) for GUITAR_TUNING and BASS_TUNING', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const guitarBoard = getScaleFretboard(root, scale, GUITAR_TUNING)
+        expect(guitarBoard).toHaveLength(GUITAR_TUNING.length)
+        for (const row of guitarBoard) expect(row).toHaveLength(13)
+
+        const bassBoard = getScaleFretboard(root, scale, BASS_TUNING)
+        expect(bassBoard).toHaveLength(BASS_TUNING.length)
+        for (const row of bassBoard) expect(row).toHaveLength(13)
+      }),
+    )
+  })
+
+  it('every non-null cell.pitch is in getScalePitches', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const scalePitches = new Set(getScalePitches(root, scale))
+        const board = getScaleFretboard(root, scale, GUITAR_TUNING)
+        for (const row of board) {
+          for (const cell of row) {
+            if (cell !== null) {
+              expect(scalePitches.has(cell.pitch), `pitch ${cell.pitch}`).toBe(true)
+            }
+          }
+        }
+      }),
+    )
+  })
+
+  it('cell.isRoot === (cell.pitch === root % 12)', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const board = getScaleFretboard(root, scale, GUITAR_TUNING)
+        const rootPitch = ((root % 12) + 12) % 12
+        for (const row of board) {
+          for (const cell of row) {
+            if (cell !== null) {
+              expect(cell.isRoot).toBe(cell.pitch === rootPitch)
+            }
+          }
+        }
+      }),
+    )
+  })
+
+  it('cell.degree matches getDegreeByPitch', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const degreeMap = getDegreeByPitch(root, scale)
+        const board = getScaleFretboard(root, scale, GUITAR_TUNING)
+        for (const row of board) {
+          for (const cell of row) {
+            if (cell !== null) {
+              expect(cell.degree).toBe(degreeMap.get(cell.pitch))
+            }
+          }
+        }
+      }),
+    )
+  })
+})
+
+// ── 5. getScalePositions ──────────────────────────────────────────────────────
+
+describe('getScalePositions', () => {
+  it('each startFret is in 0..11', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const positions = getScalePositions(root, scale, GUITAR_TUNING)
+        for (const pos of positions) {
+          expect(pos.startFret).toBeGreaterThanOrEqual(0)
+          expect(pos.startFret).toBeLessThanOrEqual(11)
+        }
+      }),
+    )
+  })
+
+  it('label === `${startFret}fr` for every position', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const positions = getScalePositions(root, scale, GUITAR_TUNING)
+        for (const pos of positions) {
+          expect(pos.label).toBe(`${pos.startFret}fr`)
+        }
+      }),
+    )
+  })
+
+  it('(tuning[0] + startFret) % 12 === root % 12 for every position', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const positions = getScalePositions(root, scale, GUITAR_TUNING)
+        const rootMod = ((root % 12) + 12) % 12
+        for (const pos of positions) {
+          expect((GUITAR_TUNING[0] + pos.startFret) % 12).toBe(rootMod)
+        }
+      }),
+    )
+  })
+
+  it('positions are sorted ascending by startFret', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const positions = getScalePositions(root, scale, GUITAR_TUNING)
+        for (let i = 1; i < positions.length; i++) {
+          expect(positions[i].startFret).toBeGreaterThan(positions[i - 1].startFret)
+        }
+      }),
+    )
+  })
+})
+
+// ── 6. getDiatonicTriads ──────────────────────────────────────────────────────
+
+describe('getDiatonicTriads', () => {
+  it('C ionian produces the correct triad degrees in order (C, Dm, Em, F, G, Am, Bdim)', () => {
+    const ionian = getScaleById('ionian')!
+    const triads = getDiatonicTriads(0, ionian)
+    // 7 degrees for a 7-note scale
+    expect(triads).toHaveLength(7)
+    const expected = ['C', 'Dm', 'Em', 'F', 'G', 'Am', 'Bdim']
+    for (let i = 0; i < 7; i++) {
+      expect(triads[i].chordKey, `degree ${i + 1}`).toBe(expected[i])
+    }
+  })
+
+  it('C harmonic-minor contains at least one augmented triad', () => {
+    const hm = getScaleById('harmonic-minor')!
+    const triads = getDiatonicTriads(0, hm)
+    // harmonic minor: C D Eb F G Ab B → III degree: Eb aug
+    const hasAug = triads.some((t) => t.chordKey !== null && t.chordKey.endsWith('aug'))
+    expect(hasAug).toBe(true)
+  })
+
+  it('C minor-pentatonic mostly produces null chordKeys (5-note scale makes few tertian triads)', () => {
+    const mp = getScaleById('minor-pentatonic')!
+    const triads = getDiatonicTriads(0, mp)
+    expect(triads).toHaveLength(5)
+    const nullCount = triads.filter((t) => t.chordKey === null).length
+    // at least 3 of 5 should be null (non-tertian) for a pentatonic
+    expect(nullCount).toBeGreaterThanOrEqual(3)
+  })
+
+  it('returns one entry per scale degree', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const triads = getDiatonicTriads(root, scale)
+        expect(triads).toHaveLength(scale.intervals.length)
+      }),
+    )
+  })
+
+  it('each entry degree matches scale.degrees at the same index', () => {
+    fc.assert(
+      fc.property(rootArb, scaleArb, (root, scale) => {
+        const triads = getDiatonicTriads(root, scale)
+        for (let i = 0; i < triads.length; i++) {
+          expect(triads[i].degree).toBe(scale.degrees[i])
+        }
+      }),
+    )
+  })
+})
+
+// ── 7. CHORD_SCALE_MAP ────────────────────────────────────────────────────────
+
+describe('CHORD_SCALE_MAP', () => {
+  it('key set equals CHORD_QUALITIES', () => {
+    const mapKeys = new Set(Object.keys(CHORD_SCALE_MAP))
+    const qualitySet = new Set([...CHORD_QUALITIES])
+    expect(mapKeys).toEqual(qualitySet)
+  })
+
+  it('every referenced scale id resolves via getScaleById', () => {
+    for (const [quality, ids] of Object.entries(CHORD_SCALE_MAP)) {
+      for (const id of ids) {
+        expect(getScaleById(id), `CHORD_SCALE_MAP[${quality}] id="${id}"`).toBeDefined()
+      }
+    }
+  })
+
+  it('scalesForQuality returns at least 1 scale for every chord quality', () => {
+    for (const quality of CHORD_QUALITIES) {
+      expect(scalesForQuality(quality).length, `quality="${quality}"`).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('scalesForQuality drops unknown ids gracefully', () => {
+    // Verify it returns only valid ScaleDefinition objects
+    for (const quality of CHORD_QUALITIES) {
+      const scales = scalesForQuality(quality)
+      for (const scale of scales) {
+        expect(scale.id).toBeDefined()
+        expect(scale.intervals.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+// ── 8. getScaleById ───────────────────────────────────────────────────────────
+
+describe('getScaleById', () => {
+  it('resolves every scale in SCALES by id', () => {
+    for (const scale of SCALES) {
+      expect(getScaleById(scale.id)).toBe(scale)
+    }
+  })
+
+  it('returns undefined for unknown ids', () => {
+    expect(getScaleById('nonexistent-scale')).toBeUndefined()
+    expect(getScaleById('')).toBeUndefined()
+  })
+})

--- a/libs/platform-api/src/lib/scales.ts
+++ b/libs/platform-api/src/lib/scales.ts
@@ -1,0 +1,399 @@
+// NOTE: keep this module free of runtime imports (type-only imports are fine).
+// tools/chord-data/ imports it directly as a .ts file under Node's type
+// stripping, which cannot resolve the workspace's `.js`-suffixed specifiers.
+
+export type ScaleCategory =
+  | 'Major modes'
+  | 'Melodic minor modes'
+  | 'Harmonic minor'
+  | 'Pentatonic / Blues'
+  | 'Symmetric'
+
+export type ScaleDefinition = {
+  id: string
+  name: string
+  category: ScaleCategory
+  intervals: readonly number[]
+  degrees: readonly string[]
+  modeOf?: string
+  modeDegree?: number
+}
+
+export type FretCell = { pitch: number; degree: string; isRoot: boolean }
+
+// Private note names in sharps form (C=0). Not exported to avoid barrel collision
+// with NOTE_PITCH / pitchName in chord-theory.ts.
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const
+
+export const SCALES: readonly ScaleDefinition[] = [
+  // ── Major modes ──────────────────────────────────────────────────────────────
+  {
+    id: 'ionian',
+    name: 'Ionian (Major)',
+    category: 'Major modes',
+    intervals: [0, 2, 4, 5, 7, 9, 11],
+    degrees: ['1', '2', '3', '4', '5', '6', '7'],
+    modeDegree: 1,
+  },
+  {
+    id: 'dorian',
+    name: 'Dorian',
+    category: 'Major modes',
+    intervals: [0, 2, 3, 5, 7, 9, 10],
+    degrees: ['1', '2', 'b3', '4', '5', '6', 'b7'],
+    modeOf: 'ionian',
+    modeDegree: 2,
+  },
+  {
+    id: 'phrygian',
+    name: 'Phrygian',
+    category: 'Major modes',
+    intervals: [0, 1, 3, 5, 7, 8, 10],
+    degrees: ['1', 'b2', 'b3', '4', '5', 'b6', 'b7'],
+    modeOf: 'ionian',
+    modeDegree: 3,
+  },
+  {
+    id: 'lydian',
+    name: 'Lydian',
+    category: 'Major modes',
+    intervals: [0, 2, 4, 6, 7, 9, 11],
+    degrees: ['1', '2', '3', '#4', '5', '6', '7'],
+    modeOf: 'ionian',
+    modeDegree: 4,
+  },
+  {
+    id: 'mixolydian',
+    name: 'Mixolydian',
+    category: 'Major modes',
+    intervals: [0, 2, 4, 5, 7, 9, 10],
+    degrees: ['1', '2', '3', '4', '5', '6', 'b7'],
+    modeOf: 'ionian',
+    modeDegree: 5,
+  },
+  {
+    id: 'aeolian',
+    name: 'Aeolian (Natural Minor)',
+    category: 'Major modes',
+    intervals: [0, 2, 3, 5, 7, 8, 10],
+    degrees: ['1', '2', 'b3', '4', '5', 'b6', 'b7'],
+    modeOf: 'ionian',
+    modeDegree: 6,
+  },
+  {
+    id: 'locrian',
+    name: 'Locrian',
+    category: 'Major modes',
+    intervals: [0, 1, 3, 5, 6, 8, 10],
+    degrees: ['1', 'b2', 'b3', '4', 'b5', 'b6', 'b7'],
+    modeOf: 'ionian',
+    modeDegree: 7,
+  },
+  // ── Melodic minor modes ───────────────────────────────────────────────────────
+  {
+    id: 'melodic-minor',
+    name: 'Melodic Minor',
+    category: 'Melodic minor modes',
+    intervals: [0, 2, 3, 5, 7, 9, 11],
+    degrees: ['1', '2', 'b3', '4', '5', '6', '7'],
+    modeDegree: 1,
+  },
+  {
+    id: 'dorian-b2',
+    name: 'Dorian b2',
+    category: 'Melodic minor modes',
+    intervals: [0, 1, 3, 5, 7, 9, 10],
+    degrees: ['1', 'b2', 'b3', '4', '5', '6', 'b7'],
+    modeOf: 'melodic-minor',
+    modeDegree: 2,
+  },
+  {
+    id: 'lydian-augmented',
+    name: 'Lydian Augmented',
+    category: 'Melodic minor modes',
+    intervals: [0, 2, 4, 6, 8, 9, 11],
+    degrees: ['1', '2', '3', '#4', '#5', '6', '7'],
+    modeOf: 'melodic-minor',
+    modeDegree: 3,
+  },
+  {
+    id: 'lydian-dominant',
+    name: 'Lydian Dominant',
+    category: 'Melodic minor modes',
+    intervals: [0, 2, 4, 6, 7, 9, 10],
+    degrees: ['1', '2', '3', '#4', '5', '6', 'b7'],
+    modeOf: 'melodic-minor',
+    modeDegree: 4,
+  },
+  {
+    id: 'mixolydian-b6',
+    name: 'Mixolydian b6',
+    category: 'Melodic minor modes',
+    intervals: [0, 2, 4, 5, 7, 8, 10],
+    degrees: ['1', '2', '3', '4', '5', 'b6', 'b7'],
+    modeOf: 'melodic-minor',
+    modeDegree: 5,
+  },
+  {
+    id: 'locrian-nat2',
+    name: 'Locrian ♮2 (Half-Diminished)',
+    category: 'Melodic minor modes',
+    intervals: [0, 2, 3, 5, 6, 8, 10],
+    degrees: ['1', '2', 'b3', '4', 'b5', 'b6', 'b7'],
+    modeOf: 'melodic-minor',
+    modeDegree: 6,
+  },
+  {
+    id: 'altered',
+    name: 'Altered (Super Locrian)',
+    category: 'Melodic minor modes',
+    intervals: [0, 1, 3, 4, 6, 8, 10],
+    degrees: ['1', 'b9', '#9', '3', 'b5', '#5', 'b7'],
+    modeOf: 'melodic-minor',
+    modeDegree: 7,
+  },
+  // ── Harmonic minor ────────────────────────────────────────────────────────────
+  {
+    id: 'harmonic-minor',
+    name: 'Harmonic Minor',
+    category: 'Harmonic minor',
+    intervals: [0, 2, 3, 5, 7, 8, 11],
+    degrees: ['1', '2', 'b3', '4', '5', 'b6', '7'],
+    modeDegree: 1,
+  },
+  {
+    id: 'phrygian-dominant',
+    name: 'Phrygian Dominant',
+    category: 'Harmonic minor',
+    intervals: [0, 1, 4, 5, 7, 8, 10],
+    degrees: ['1', 'b2', '3', '4', '5', 'b6', 'b7'],
+    modeOf: 'harmonic-minor',
+    modeDegree: 5,
+  },
+  // ── Pentatonic / Blues ────────────────────────────────────────────────────────
+  {
+    id: 'major-pentatonic',
+    name: 'Major Pentatonic',
+    category: 'Pentatonic / Blues',
+    intervals: [0, 2, 4, 7, 9],
+    degrees: ['1', '2', '3', '5', '6'],
+  },
+  {
+    id: 'minor-pentatonic',
+    name: 'Minor Pentatonic',
+    category: 'Pentatonic / Blues',
+    intervals: [0, 3, 5, 7, 10],
+    degrees: ['1', 'b3', '4', '5', 'b7'],
+  },
+  {
+    id: 'blues-minor',
+    name: 'Minor Blues',
+    category: 'Pentatonic / Blues',
+    intervals: [0, 3, 5, 6, 7, 10],
+    degrees: ['1', 'b3', '4', 'b5', '5', 'b7'],
+  },
+  {
+    id: 'blues-major',
+    name: 'Major Blues',
+    category: 'Pentatonic / Blues',
+    intervals: [0, 2, 3, 4, 7, 9],
+    degrees: ['1', '2', 'b3', '3', '5', '6'],
+  },
+  // ── Symmetric ─────────────────────────────────────────────────────────────────
+  {
+    id: 'whole-tone',
+    name: 'Whole Tone',
+    category: 'Symmetric',
+    intervals: [0, 2, 4, 6, 8, 10],
+    degrees: ['1', '2', '3', '#4', '#5', 'b7'],
+  },
+  {
+    id: 'diminished-wh',
+    name: 'Diminished (Whole-Half)',
+    category: 'Symmetric',
+    intervals: [0, 2, 3, 5, 6, 8, 9, 11],
+    degrees: ['1', '2', 'b3', '4', 'b5', 'b6', '6', '7'],
+  },
+  {
+    id: 'diminished-hw',
+    name: 'Diminished (Half-Whole)',
+    category: 'Symmetric',
+    intervals: [0, 1, 3, 4, 6, 7, 9, 10],
+    degrees: ['1', 'b9', '#9', '3', '#4', '5', '6', 'b7'],
+  },
+  {
+    id: 'chromatic',
+    name: 'Chromatic',
+    category: 'Symmetric',
+    intervals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    degrees: ['1', 'b2', '2', 'b3', '3', '4', 'b5', '5', 'b6', '6', 'b7', '7'],
+  },
+] as const
+
+/** Map of chord quality suffix → ordered list of compatible scale ids. */
+export const CHORD_SCALE_MAP: Record<string, readonly string[]> = {
+  '': ['ionian', 'lydian', 'major-pentatonic'],
+  m: ['dorian', 'aeolian', 'phrygian', 'minor-pentatonic'],
+  '7': ['mixolydian', 'lydian-dominant', 'altered', 'diminished-hw'],
+  m7: ['dorian', 'aeolian', 'phrygian'],
+  maj7: ['ionian', 'lydian'],
+  sus2: ['mixolydian', 'dorian', 'major-pentatonic'],
+  sus4: ['mixolydian', 'dorian'],
+  dim: ['locrian', 'diminished-wh', 'locrian-nat2'],
+  aug: ['whole-tone', 'lydian-augmented'],
+  '5': ['minor-pentatonic', 'major-pentatonic', 'mixolydian'],
+  m7b5: ['locrian-nat2', 'locrian'],
+  dim7: ['diminished-wh'],
+  '6': ['ionian', 'major-pentatonic', 'lydian'],
+  m6: ['dorian', 'melodic-minor'],
+  '69': ['ionian', 'major-pentatonic', 'lydian'],
+  add9: ['ionian', 'lydian', 'major-pentatonic'],
+  '9': ['mixolydian', 'lydian-dominant'],
+  m9: ['dorian', 'aeolian'],
+  maj9: ['ionian', 'lydian'],
+  '7b5': ['lydian-dominant', 'altered', 'whole-tone'],
+  '7#5': ['altered', 'whole-tone'],
+  '7b9': ['diminished-hw', 'altered', 'phrygian-dominant'],
+  '7#9': ['altered', 'diminished-hw'],
+  '11': ['mixolydian'],
+  m11: ['dorian', 'aeolian'],
+  '13': ['mixolydian', 'lydian-dominant'],
+  m13: ['dorian'],
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const MOD12 = (n: number) => ((n % 12) + 12) % 12
+
+/** All pitch classes (0..11) sounded by this scale when rooted at rootPitch. */
+export function getScalePitches(rootPitch: number, scale: ScaleDefinition): number[] {
+  return scale.intervals.map((interval) => MOD12(rootPitch + interval))
+}
+
+/** Map from pitch class (0..11) → scale degree label for this root + scale. */
+export function getDegreeByPitch(rootPitch: number, scale: ScaleDefinition): Map<number, string> {
+  const map = new Map<number, string>()
+  for (let i = 0; i < scale.intervals.length; i++) {
+    map.set(MOD12(rootPitch + scale.intervals[i]), scale.degrees[i])
+  }
+  return map
+}
+
+/** Look up a scale by its stable kebab id. */
+export function getScaleById(id: string): ScaleDefinition | undefined {
+  return (SCALES as readonly ScaleDefinition[]).find((s) => s.id === id)
+}
+
+/** All ScaleDefinitions recommended for a given chord quality suffix. */
+export function scalesForQuality(quality: string): ScaleDefinition[] {
+  const ids = CHORD_SCALE_MAP[quality] ?? []
+  const result: ScaleDefinition[] = []
+  for (const id of ids) {
+    const scale = getScaleById(id)
+    if (scale !== undefined) result.push(scale)
+  }
+  return result
+}
+
+/**
+ * Build a fretboard grid for a given root + scale + tuning.
+ *
+ * Returns a 2-D array [string][fret] where each cell is either null (pitch not
+ * in scale) or a FretCell { pitch, degree, isRoot }.
+ *
+ * @param tuning  Open-string pitches, low-to-high string order (e.g. GUITAR_TUNING).
+ * @param fretCount  Number of frets to include (columns = fretCount + 1, fret 0 = open).
+ */
+export function getScaleFretboard(
+  rootPitch: number,
+  scale: ScaleDefinition,
+  tuning: readonly number[],
+  fretCount = 12,
+): (FretCell | null)[][] {
+  const degreeMap = getDegreeByPitch(rootPitch, scale)
+  const root = MOD12(rootPitch)
+  return tuning.map((open) => {
+    const row: (FretCell | null)[] = []
+    for (let fret = 0; fret <= fretCount; fret++) {
+      const pitch = MOD12(open + fret)
+      const degree = degreeMap.get(pitch)
+      if (degree === undefined) {
+        row.push(null)
+      } else {
+        row.push({ pitch, degree, isRoot: pitch === root })
+      }
+    }
+    return row
+  })
+}
+
+/**
+ * Return candidate position start frets for a scale, based on where the root
+ * lands on the lowest string within frets 0..11.
+ *
+ * Each entry has { startFret, label } where label is `${startFret}fr`.
+ * Results are deduped and sorted ascending.
+ */
+export function getScalePositions(
+  rootPitch: number,
+  scale: ScaleDefinition,
+  tuning: readonly number[],
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  windowFrets = 5,
+): { startFret: number; label: string }[] {
+  const root = MOD12(rootPitch)
+  const lowestOpen = tuning[0]
+  const seen = new Set<number>()
+  const positions: { startFret: number; label: string }[] = []
+  for (let fret = 0; fret <= 11; fret++) {
+    if (MOD12(lowestOpen + fret) === root) {
+      if (!seen.has(fret)) {
+        seen.add(fret)
+        positions.push({ startFret: fret, label: `${fret}fr` })
+      }
+    }
+  }
+  positions.sort((a, b) => a.startFret - b.startFret)
+  return positions
+}
+
+/**
+ * For each scale degree, attempt to build a diatonic triad (stack of 3rds)
+ * and classify it as major (''), minor ('m'), diminished ('dim'), or
+ * augmented ('aug').  Returns one entry per scale degree; chordKey is null
+ * when the intervals do not form a recognised tertian triad.
+ *
+ * NOTE: pitchName is needed here but scales.ts must stay runtime-import-free.
+ * A private NOTE_NAMES constant is used in place of importing from chord-theory.
+ */
+export function getDiatonicTriads(
+  rootPitch: number,
+  scale: ScaleDefinition,
+): { degree: string; chordKey: string | null }[] {
+  const pitches = getScalePitches(rootPitch, scale)
+  const n = pitches.length
+  const result: { degree: string; chordKey: string | null }[] = []
+
+  for (let i = 0; i < n; i++) {
+    const root = pitches[i]
+    const third = pitches[(i + 2) % n]
+    const fifth = pitches[(i + 4) % n]
+
+    const thirdInterval = MOD12(third - root)
+    const fifthInterval = MOD12(fifth - root)
+
+    let quality: string | null = null
+    if (thirdInterval === 3 && fifthInterval === 7) quality = 'm'
+    else if (thirdInterval === 4 && fifthInterval === 7) quality = ''
+    else if (thirdInterval === 3 && fifthInterval === 6) quality = 'dim'
+    else if (thirdInterval === 4 && fifthInterval === 8) quality = 'aug'
+
+    const rootName = NOTE_NAMES[MOD12(root)]
+    result.push({
+      degree: scale.degrees[i],
+      chordKey: quality !== null ? rootName + quality : null,
+    })
+  }
+
+  return result
+}

--- a/libs/platform-api/src/lib/scales.ts
+++ b/libs/platform-api/src/lib/scales.ts
@@ -12,6 +12,7 @@ export type ScaleCategory =
 export type ScaleDefinition = {
   id: string
   name: string
+  description: string
   category: ScaleCategory
   intervals: readonly number[]
   degrees: readonly string[]
@@ -30,6 +31,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'ionian',
     name: 'Ionian (Major)',
+    description: 'The standard major scale — bright, stable, and resolved',
     category: 'Major modes',
     intervals: [0, 2, 4, 5, 7, 9, 11],
     degrees: ['1', '2', '3', '4', '5', '6', '7'],
@@ -38,6 +40,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'dorian',
     name: 'Dorian',
+    description: 'Minor scale with a bright natural 6th — the classic jazz/funk minor',
     category: 'Major modes',
     intervals: [0, 2, 3, 5, 7, 9, 10],
     degrees: ['1', '2', 'b3', '4', '5', '6', 'b7'],
@@ -47,6 +50,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'phrygian',
     name: 'Phrygian',
+    description: 'Dark minor scale with a flat 2nd — Spanish and metal flavour',
     category: 'Major modes',
     intervals: [0, 1, 3, 5, 7, 8, 10],
     degrees: ['1', 'b2', 'b3', '4', '5', 'b6', 'b7'],
@@ -56,6 +60,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'lydian',
     name: 'Lydian',
+    description: 'Major scale with a raised 4th — dreamy and floating',
     category: 'Major modes',
     intervals: [0, 2, 4, 6, 7, 9, 11],
     degrees: ['1', '2', '3', '#4', '5', '6', '7'],
@@ -65,6 +70,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'mixolydian',
     name: 'Mixolydian',
+    description: 'Major scale with a flat 7th — dominant, bluesy, rock',
     category: 'Major modes',
     intervals: [0, 2, 4, 5, 7, 9, 10],
     degrees: ['1', '2', '3', '4', '5', '6', 'b7'],
@@ -74,6 +80,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'aeolian',
     name: 'Aeolian (Natural Minor)',
+    description: 'The natural minor scale — sad and serious',
     category: 'Major modes',
     intervals: [0, 2, 3, 5, 7, 8, 10],
     degrees: ['1', '2', 'b3', '4', '5', 'b6', 'b7'],
@@ -83,6 +90,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'locrian',
     name: 'Locrian',
+    description: 'Unstable minor with a flat 5th — rarely a home key',
     category: 'Major modes',
     intervals: [0, 1, 3, 5, 6, 8, 10],
     degrees: ['1', 'b2', 'b3', '4', 'b5', 'b6', 'b7'],
@@ -93,6 +101,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'melodic-minor',
     name: 'Melodic Minor',
+    description: 'Minor with major 6th and 7th — smooth jazz minor',
     category: 'Melodic minor modes',
     intervals: [0, 2, 3, 5, 7, 9, 11],
     degrees: ['1', '2', 'b3', '4', '5', '6', '7'],
@@ -101,6 +110,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'dorian-b2',
     name: 'Dorian b2',
+    description: 'Dorian with a flat 2nd — dark and mysterious modal colour',
     category: 'Melodic minor modes',
     intervals: [0, 1, 3, 5, 7, 9, 10],
     degrees: ['1', 'b2', 'b3', '4', '5', '6', 'b7'],
@@ -110,6 +120,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'lydian-augmented',
     name: 'Lydian Augmented',
+    description: 'Lydian with a raised 5th — lush and otherworldly',
     category: 'Melodic minor modes',
     intervals: [0, 2, 4, 6, 8, 9, 11],
     degrees: ['1', '2', '3', '#4', '#5', '6', '7'],
@@ -119,6 +130,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'lydian-dominant',
     name: 'Lydian Dominant',
+    description: 'Dominant scale with a raised 4th — Lydian meets the blues',
     category: 'Melodic minor modes',
     intervals: [0, 2, 4, 6, 7, 9, 10],
     degrees: ['1', '2', '3', '#4', '5', '6', 'b7'],
@@ -128,6 +140,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'mixolydian-b6',
     name: 'Mixolydian b6',
+    description: 'Dominant sound with a dark flat 6th — Hindu scale territory',
     category: 'Melodic minor modes',
     intervals: [0, 2, 4, 5, 7, 8, 10],
     degrees: ['1', '2', '3', '4', '5', 'b6', 'b7'],
@@ -137,6 +150,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'locrian-nat2',
     name: 'Locrian ♮2 (Half-Diminished)',
+    description: 'Locrian with a natural 2nd — smoother half-diminished sound',
     category: 'Melodic minor modes',
     intervals: [0, 2, 3, 5, 6, 8, 10],
     degrees: ['1', '2', 'b3', '4', 'b5', 'b6', 'b7'],
@@ -146,6 +160,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'altered',
     name: 'Altered (Super Locrian)',
+    description: 'Every tension over a dominant 7th — maximum outside colour',
     category: 'Melodic minor modes',
     intervals: [0, 1, 3, 4, 6, 8, 10],
     degrees: ['1', 'b9', '#9', '3', 'b5', '#5', 'b7'],
@@ -156,6 +171,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'harmonic-minor',
     name: 'Harmonic Minor',
+    description: 'Minor with a raised 7th — exotic, classical, neoclassical',
     category: 'Harmonic minor',
     intervals: [0, 2, 3, 5, 7, 8, 11],
     degrees: ['1', '2', 'b3', '4', '5', 'b6', '7'],
@@ -164,6 +180,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'phrygian-dominant',
     name: 'Phrygian Dominant',
+    description: 'Dominant scale with a flat 2nd — Middle-Eastern/flamenco',
     category: 'Harmonic minor',
     intervals: [0, 1, 4, 5, 7, 8, 10],
     degrees: ['1', 'b2', '3', '4', '5', 'b6', 'b7'],
@@ -174,6 +191,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'major-pentatonic',
     name: 'Major Pentatonic',
+    description: 'Five-note major subset — uplifting and universally singable',
     category: 'Pentatonic / Blues',
     intervals: [0, 2, 4, 7, 9],
     degrees: ['1', '2', '3', '5', '6'],
@@ -181,6 +199,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'minor-pentatonic',
     name: 'Minor Pentatonic',
+    description: 'Five-note minor subset — the backbone of blues and rock lead',
     category: 'Pentatonic / Blues',
     intervals: [0, 3, 5, 7, 10],
     degrees: ['1', 'b3', '4', '5', 'b7'],
@@ -188,6 +207,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'blues-minor',
     name: 'Minor Blues',
+    description: 'Minor pentatonic plus the blue note — raw and expressive',
     category: 'Pentatonic / Blues',
     intervals: [0, 3, 5, 6, 7, 10],
     degrees: ['1', 'b3', '4', 'b5', '5', 'b7'],
@@ -195,6 +215,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'blues-major',
     name: 'Major Blues',
+    description: 'Major pentatonic plus the blue note — soulful country flavour',
     category: 'Pentatonic / Blues',
     intervals: [0, 2, 3, 4, 7, 9],
     degrees: ['1', '2', 'b3', '3', '5', '6'],
@@ -203,6 +224,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'whole-tone',
     name: 'Whole Tone',
+    description: 'Six whole steps only — ambiguous, floating, Debussy-esque',
     category: 'Symmetric',
     intervals: [0, 2, 4, 6, 8, 10],
     degrees: ['1', '2', '3', '#4', '#5', 'b7'],
@@ -210,6 +232,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'diminished-wh',
     name: 'Diminished (Whole-Half)',
+    description: 'Eight-note symmetric scale — jazzy tension and release',
     category: 'Symmetric',
     intervals: [0, 2, 3, 5, 6, 8, 9, 11],
     degrees: ['1', '2', 'b3', '4', 'b5', 'b6', '6', '7'],
@@ -217,6 +240,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'diminished-hw',
     name: 'Diminished (Half-Whole)',
+    description: 'Eight-note symmetric scale — packed with dominant tensions',
     category: 'Symmetric',
     intervals: [0, 1, 3, 4, 6, 7, 9, 10],
     degrees: ['1', 'b9', '#9', '3', '#4', '5', '6', 'b7'],
@@ -224,6 +248,7 @@ export const SCALES: readonly ScaleDefinition[] = [
   {
     id: 'chromatic',
     name: 'Chromatic',
+    description: 'All twelve pitches — maximum chromaticism, no tonal centre',
     category: 'Symmetric',
     intervals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
     degrees: ['1', 'b2', '2', 'b3', '3', '4', 'b5', '5', 'b6', '6', 'b7', '7'],
@@ -265,6 +290,26 @@ export const CHORD_SCALE_MAP: Record<string, readonly string[]> = {
 
 const MOD12 = (n: number) => ((n % 12) + 12) % 12
 
+/** Human interval name for a chromatic distance above the root (0..11, wraps mod 12). */
+const INTERVAL_NAMES = [
+  'Root',
+  'Minor 2nd',
+  'Major 2nd',
+  'Minor 3rd',
+  'Major 3rd',
+  'Perfect 4th',
+  'Tritone',
+  'Perfect 5th',
+  'Minor 6th',
+  'Major 6th',
+  'Minor 7th',
+  'Major 7th',
+] as const
+
+export function intervalName(semitones: number): string {
+  return INTERVAL_NAMES[MOD12(semitones)]
+}
+
 /** All pitch classes (0..11) sounded by this scale when rooted at rootPitch. */
 export function getScalePitches(rootPitch: number, scale: ScaleDefinition): number[] {
   return scale.intervals.map((interval) => MOD12(rootPitch + interval))
@@ -289,6 +334,25 @@ export function scalesForQuality(quality: string): ScaleDefinition[] {
   return (CHORD_SCALE_MAP[quality] ?? [])
     .map(getScaleById)
     .filter((scale): scale is ScaleDefinition => scale !== undefined)
+}
+
+/**
+ * Whole/half step pattern between successive scale tones, wrapping to the octave.
+ * 'H' = 1 semitone, 'W' = 2, 'W½' = 3, otherwise `${n}` semitones.
+ * Length === intervals.length. Steps sum to 12.
+ */
+export function getStepPattern(scale: ScaleDefinition): string[] {
+  const intervals = scale.intervals
+  const n = intervals.length
+  const result: string[] = []
+  for (let i = 0; i < n; i++) {
+    const step = i < n - 1 ? intervals[i + 1] - intervals[i] : 12 - intervals[n - 1]
+    if (step === 1) result.push('H')
+    else if (step === 2) result.push('W')
+    else if (step === 3) result.push('W½')
+    else result.push(String(step))
+  }
+  return result
 }
 
 /**
@@ -341,6 +405,8 @@ export function getScalePositions(
   return positions
 }
 
+const ROMAN = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII'] as const
+
 /**
  * For each scale degree, attempt to build a diatonic triad (stack of 3rds)
  * and classify it as major (''), minor ('m'), diminished ('dim'), or
@@ -353,10 +419,10 @@ export function getScalePositions(
 export function getDiatonicTriads(
   rootPitch: number,
   scale: ScaleDefinition,
-): { degree: string; chordKey: string | null }[] {
+): { degree: string; chordKey: string | null; roman: string | null }[] {
   const pitches = getScalePitches(rootPitch, scale)
   const n = pitches.length
-  const result: { degree: string; chordKey: string | null }[] = []
+  const result: { degree: string; chordKey: string | null; roman: string | null }[] = []
 
   for (let i = 0; i < n; i++) {
     const root = pitches[i]
@@ -372,9 +438,19 @@ export function getDiatonicTriads(
     else if (thirdInterval === 3 && fifthInterval === 6) quality = 'dim'
     else if (thirdInterval === 4 && fifthInterval === 8) quality = 'aug'
 
+    let roman: string | null = null
+    if (quality !== null) {
+      const base = i < 7 ? ROMAN[i] : String(i + 1)
+      if (quality === '') roman = base
+      else if (quality === 'm') roman = base.toLowerCase()
+      else if (quality === 'dim') roman = base.toLowerCase() + '°'
+      else if (quality === 'aug') roman = base + '+'
+    }
+
     result.push({
       degree: scale.degrees[i],
       chordKey: quality !== null ? NOTE_NAMES[root] + quality : null,
+      roman,
     })
   }
 

--- a/libs/platform-api/src/lib/scales.ts
+++ b/libs/platform-api/src/lib/scales.ts
@@ -281,18 +281,14 @@ export function getDegreeByPitch(rootPitch: number, scale: ScaleDefinition): Map
 
 /** Look up a scale by its stable kebab id. */
 export function getScaleById(id: string): ScaleDefinition | undefined {
-  return (SCALES as readonly ScaleDefinition[]).find((s) => s.id === id)
+  return SCALES.find((s) => s.id === id)
 }
 
 /** All ScaleDefinitions recommended for a given chord quality suffix. */
 export function scalesForQuality(quality: string): ScaleDefinition[] {
-  const ids = CHORD_SCALE_MAP[quality] ?? []
-  const result: ScaleDefinition[] = []
-  for (const id of ids) {
-    const scale = getScaleById(id)
-    if (scale !== undefined) result.push(scale)
-  }
-  return result
+  return (CHORD_SCALE_MAP[quality] ?? [])
+    .map(getScaleById)
+    .filter((scale): scale is ScaleDefinition => scale !== undefined)
 }
 
 /**
@@ -328,32 +324,20 @@ export function getScaleFretboard(
 }
 
 /**
- * Return candidate position start frets for a scale, based on where the root
- * lands on the lowest string within frets 0..11.
- *
- * Each entry has { startFret, label } where label is `${startFret}fr`.
- * Results are deduped and sorted ascending.
+ * Candidate position start frets for a scale: the frets (0..11, ascending)
+ * where the root lands on the lowest string. Each marks a playable hand
+ * position anchored on the root; the renderer labels the window itself.
  */
 export function getScalePositions(
   rootPitch: number,
-  scale: ScaleDefinition,
   tuning: readonly number[],
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  windowFrets = 5,
-): { startFret: number; label: string }[] {
+): number[] {
   const root = MOD12(rootPitch)
   const lowestOpen = tuning[0]
-  const seen = new Set<number>()
-  const positions: { startFret: number; label: string }[] = []
+  const positions: number[] = []
   for (let fret = 0; fret <= 11; fret++) {
-    if (MOD12(lowestOpen + fret) === root) {
-      if (!seen.has(fret)) {
-        seen.add(fret)
-        positions.push({ startFret: fret, label: `${fret}fr` })
-      }
-    }
+    if (MOD12(lowestOpen + fret) === root) positions.push(fret)
   }
-  positions.sort((a, b) => a.startFret - b.startFret)
   return positions
 }
 
@@ -388,10 +372,9 @@ export function getDiatonicTriads(
     else if (thirdInterval === 3 && fifthInterval === 6) quality = 'dim'
     else if (thirdInterval === 4 && fifthInterval === 8) quality = 'aug'
 
-    const rootName = NOTE_NAMES[MOD12(root)]
     result.push({
       degree: scale.degrees[i],
-      chordKey: quality !== null ? rootName + quality : null,
+      chordKey: quality !== null ? NOTE_NAMES[root] + quality : null,
     })
   }
 

--- a/libs/store/src/lib/store-persistence.spec.ts
+++ b/libs/store/src/lib/store-persistence.spec.ts
@@ -53,17 +53,27 @@ describe('klank-storage migration and shape', () => {
     const raw = localStorageData['klank-storage']
     expect(raw).toBeDefined()
     const parsed = JSON.parse(raw) as { version: number; state: Record<string, unknown> }
-    expect(parsed.version).toBe(2)
+    expect(parsed.version).toBe(3)
     expect(parsed.state).not.toHaveProperty('playlists')
     expect(parsed.state).toHaveProperty('activePlaylistId')
     expect(parsed.state).toHaveProperty('activePlaylistIndex')
     // Sync cadence is persisted so it survives reloads.
     expect(parsed.state).toHaveProperty('syncSettings')
+    // Instrument and Harmony settings are persisted so they survive reloads.
+    expect(parsed.state).toHaveProperty('instrument')
+    expect(parsed.state).toHaveProperty('harmony')
   })
 
   it('migrate fills in default sync settings for older persisted state', async () => {
     const { useKlankStore } = await import('./store.js')
     const { syncSettings } = useKlankStore.getState()
     expect(syncSettings).toEqual({ enabled: true, intervalMinutes: 30, debounceMinutes: 5 })
+  })
+
+  it('migrate fills in default instrument and harmony settings for older persisted state', async () => {
+    const { useKlankStore } = await import('./store.js')
+    const { instrument, harmony } = useKlankStore.getState()
+    expect(instrument).toBe('guitar')
+    expect(harmony).toEqual({ rootPitch: 0, scaleId: 'ionian', quality: '', tab: 'scales' })
   })
 })

--- a/libs/store/src/lib/store.spec.ts
+++ b/libs/store/src/lib/store.spec.ts
@@ -544,3 +544,36 @@ describe('syncSettings', () => {
     expect(useKlankStore.getState().syncSettings.intervalMinutes).toBe(10)
   })
 })
+
+describe('harmony slice — property-based', () => {
+  const harmonyPartialArb = fc.record(
+    {
+      rootPitch: fc.integer({ min: 0, max: 11 }),
+      scaleId: fc.constantFrom('ionian', 'dorian', 'altered', 'minor-pentatonic'),
+      quality: fc.constantFrom('', 'm', 'maj7', 'm7b5'),
+      tab: fc.constantFrom('chords', 'scales', 'chord-scales'),
+    },
+    { requiredKeys: [] },
+  )
+
+  it('setHarmony merges any partial as { ...prev, ...partial }', () => {
+    fc.assert(
+      fc.property(harmonyPartialArb, (partial) => {
+        const prev = useKlankStore.getState().harmony
+        useKlankStore.getState().setHarmony(partial)
+        expect(useKlankStore.getState().harmony).toEqual({ ...prev, ...partial })
+      }),
+    )
+  })
+
+  it('two sequential setHarmony calls compose like a single merged update', () => {
+    fc.assert(
+      fc.property(harmonyPartialArb, harmonyPartialArb, (a, b) => {
+        const start = useKlankStore.getState().harmony
+        useKlankStore.getState().setHarmony(a)
+        useKlankStore.getState().setHarmony(b)
+        expect(useKlankStore.getState().harmony).toEqual({ ...start, ...a, ...b })
+      }),
+    )
+  })
+})

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -49,6 +49,31 @@ export const DEFAULT_SYNC_SETTINGS: SyncSettings = {
   debounceMinutes: 5,
 }
 
+/** Which tab of the Harmony browser is active. */
+export type HarmonyTab = 'chords' | 'scales' | 'chord-scales'
+
+/**
+ * Persisted UI memory for the Harmony section (scale/chord browser).
+ * Additive slice — safe to extend; never rename existing fields.
+ */
+export type HarmonySettings = {
+  /** Selected root pitch class, C=0. */
+  rootPitch: number
+  /** Selected scale id (see SCALES in @klank/platform-api). */
+  scaleId: string
+  /** Selected chord quality suffix (see CHORD_QUALITIES); '' = major. */
+  quality: string
+  /** Active browser tab. */
+  tab: HarmonyTab
+}
+
+export const DEFAULT_HARMONY_SETTINGS: HarmonySettings = {
+  rootPitch: 0,
+  scaleId: 'ionian',
+  quality: '',
+  tab: 'scales',
+}
+
 export type SyncRunState = 'idle' | 'syncing' | 'error' | 'offline'
 
 /** Live status of the background sync loop, surfaced in Settings. Not persisted. */
@@ -107,9 +132,12 @@ type KlankState = {
   setTabDetails: (details: string) => void
   setTabLink: (link: string) => void
   setServerMode: (serverMode: boolean) => void
-  /** @persisted Instrument used for chord diagram tooltips. */
+  /** @persisted Instrument used for chord diagram tooltips and the Harmony section. */
   instrument: Instrument
   setInstrument: (instrument: Instrument) => void
+  /** @persisted Harmony section (scale/chord browser) UI memory. */
+  harmony: HarmonySettings
+  setHarmony: (partial: Partial<HarmonySettings>) => void
   /** Named playlists — persisted to `.klank-settings.json` in the tab directory. */
   playlists: Playlist[]
   /** ID of the currently active playlist, or null when none is active. Persisted to localStorage. */
@@ -153,7 +181,7 @@ export type ScrollSpeeds = typeof SCROLL_SPEEDS[number]
 /** The slice of KlankState saved to localStorage — must match what `partialize` returns. */
 type PersistedKlankState = Pick<
   KlankState,
-  'tab' | 'theme' | 'ui' | 'baseDirectory' | 'activePlaylistId' | 'activePlaylistIndex' | 'syncSettings'
+  'tab' | 'theme' | 'ui' | 'baseDirectory' | 'activePlaylistId' | 'activePlaylistIndex' | 'syncSettings' | 'instrument' | 'harmony'
 >
 
 /** Fire-and-forget write of all playlists to `.klank-settings.json`. No-op until a directory and FileService are set. */
@@ -215,6 +243,8 @@ export const useKlankStore = create<KlankState>()(
         setMenuWidth: (menuWidth) => set((state) => ({...state, ui: {...state.ui, menuWidth}})),
         setTheme: (theme) => set((state) => ({...state, theme})),
         setInstrument: (instrument) => set((state) => ({...state, instrument})),
+        harmony: DEFAULT_HARMONY_SETTINGS,
+        setHarmony: (partial) => set((state) => ({...state, harmony: {...state.harmony, ...partial}})),
         syncSettings: DEFAULT_SYNC_SETTINGS,
         setSyncSettings: (partial) => set((state) => ({...state, syncSettings: {...state.syncSettings, ...partial}})),
         syncStatus: { state: 'idle', lastSyncedAt: null, message: '' },
@@ -454,16 +484,20 @@ export const useKlankStore = create<KlankState>()(
       }),
       {
         name: 'klank-storage',
-        version: 2,
+        version: 3,
         // v0 persisted playlists in localStorage; they now live in
         // .klank-settings.json, so stale localStorage copies are dropped.
         // v2 adds syncSettings; defaults fill in for older persisted state.
+        // v3 persists instrument and the Harmony section settings; defaults
+        // fill in for older persisted state.
         migrate: (persistedState) => {
           const state = { ...((persistedState ?? {}) as Record<string, unknown>) }
           delete state['playlists']
           return {
             ...state,
             syncSettings: { ...DEFAULT_SYNC_SETTINGS, ...(state.syncSettings as Partial<SyncSettings> | undefined) },
+            instrument: (state.instrument as Instrument | undefined) ?? 'guitar',
+            harmony: { ...DEFAULT_HARMONY_SETTINGS, ...(state.harmony as Partial<HarmonySettings> | undefined) },
           } as unknown as PersistedKlankState
         },
         partialize: (state) => ({
@@ -474,6 +508,8 @@ export const useKlankStore = create<KlankState>()(
           activePlaylistId: state.activePlaylistId,
           activePlaylistIndex: state.activePlaylistIndex,
           syncSettings: state.syncSettings,
+          instrument: state.instrument,
+          harmony: state.harmony,
         }),
       }
     )

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -10,6 +10,8 @@ export { SheetToolbar } from './lib/sheetToolbar/SheetToolbar';
 export { Sheet } from './lib/sheet/Sheet';
 export { ChordDiagram } from './lib/chordDiagram/ChordDiagram';
 export { ChordDiagramTooltip } from './lib/chordDiagramTooltip/ChordDiagramTooltip';
+export { FretboardDiagram } from './lib/fretboardDiagram/FretboardDiagram';
+export type { FretboardDiagramProps } from './lib/fretboardDiagram/FretboardDiagram';
 
 export * from './lib/theme/theme'
 export { PlayIcon } from './lib/icons/PlayIcon';
@@ -17,6 +19,7 @@ export { LogoIcon } from './lib/icons/LogoIcon';
 export { DownloadIcon } from './lib/icons/DownloadIcon';
 export { RefreshIcon } from './lib/icons/RefreshIcon'
 export { SettingsIcon } from './lib/icons/SettingsIcon';
+export { ScalesIcon } from './lib/icons/ScalesIcon';
 export { ShuffleIcon } from './lib/icons/ShuffleIcon';
 export { TargetIcon } from './lib/icons/TargetIcon';
 export { FolderIcon } from './lib/icons/FolderIcon';

--- a/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.spec.tsx
+++ b/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
+import fc from 'fast-check'
 import { FretboardDiagram } from './FretboardDiagram.js'
 import type { FretCell } from '@klank/platform-api'
 
@@ -11,135 +12,167 @@ const makeCell = (pitch: number, degree: string, isRoot: boolean): FretCell => (
   isRoot,
 })
 
+const dotClass = (c: Element) => c.getAttribute('class') ?? ''
+const isDot = (c: Element) => dotClass(c).includes('dot') || dotClass(c).includes('Dot')
+const isRootDot = (c: Element) => dotClass(c).includes('dotRoot')
+
+const allDots = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('circle')).filter(isDot)
+
+/**
+ * Frets the renderer shows for a given startFret/fretCount, mirroring the
+ * component: an open column at fret 0 only when startFret === 0, then a window
+ * of `fretCount` cells starting at fret 1 (open neck) or `startFret`.
+ */
+const visibleFrets = (startFret: number, fretCount: number): number[] => {
+  const firstCellFret = startFret === 0 ? 1 : startFret
+  const frets = startFret === 0 ? [0] : []
+  for (let i = 0; i < fretCount; i++) frets.push(firstCellFret + i)
+  return frets
+}
+
+const countVisibleCells = (
+  grid: (FretCell | null)[][],
+  startFret: number,
+  fretCount: number,
+  predicate: (cell: FretCell) => boolean = () => true,
+): number => {
+  const frets = visibleFrets(startFret, fretCount)
+  let count = 0
+  for (const row of grid) {
+    for (const f of frets) {
+      const cell = row[f]
+      if (cell && predicate(cell)) count++
+    }
+  }
+  return count
+}
+
 /**
  * Minimal 2-string × 5-fret grid (indices 0..4).
  * String 0 (low): root at fret 0, scale note at fret 2, root at fret 4
  * String 1 (high): scale note at fret 1, null everywhere else
  */
 const SMALL_GRID: (FretCell | null)[][] = [
-  // string 0 (low)
   [makeCell(0, '1', true), null, makeCell(2, '2', false), null, makeCell(0, '1', true)],
-  // string 1 (high)
   [null, makeCell(4, '3', false), null, null, null],
 ]
 
-// note names for labelMode='note' tests (12 pitch classes)
 const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// ── Property-based arbitraries ──────────────────────────────────────────────────
+
+const cellArb: fc.Arbitrary<FretCell | null> = fc.option(
+  fc.record({
+    pitch: fc.integer({ min: 0, max: 11 }),
+    degree: fc.constantFrom('1', 'b3', '4', '5', 'b7'),
+    isRoot: fc.boolean(),
+  }),
+  { nil: null },
+)
+
+// Rectangular grid: `numStrings` rows each of `cols` cells (cols up to 13 = fret 0..12).
+const gridArb = fc
+  .tuple(fc.integer({ min: 1, max: 6 }), fc.integer({ min: 1, max: 13 }))
+  .chain(([numStrings, cols]) =>
+    fc.array(fc.array(cellArb, { minLength: cols, maxLength: cols }), {
+      minLength: numStrings,
+      maxLength: numStrings,
+    }),
+  )
+
+// ── Crafted tests ───────────────────────────────────────────────────────────────
 
 describe('FretboardDiagram', () => {
   it('renders an svg with role="img" and aria-label="scale diagram"', () => {
-    const { container } = render(
-      <FretboardDiagram grid={SMALL_GRID} fretCount={4} />,
-    )
+    const { container } = render(<FretboardDiagram grid={SMALL_GRID} fretCount={4} />)
     const svg = container.querySelector('svg')
-    expect(svg).not.toBeNull()
     expect(svg?.getAttribute('role')).toBe('img')
     expect(svg?.getAttribute('aria-label')).toBe('scale diagram')
   })
 
-  it('renders exactly as many dot circles as non-null cells', () => {
-    // SMALL_GRID non-null count: fret 0 (string 0 root), fret 2 (string 0), fret 4 (string 0), fret 1 (string 1) = 4
-    const { container } = render(
-      <FretboardDiagram grid={SMALL_GRID} fretCount={4} />,
-    )
-    // dots live inside <g> elements; count circles that are inside a <g> (excludes inlay circles)
-    // inlay circles have class 'inlay'; dot circles have class containing 'dot'
-    const allCircles = Array.from(container.querySelectorAll('circle'))
-    const dotCircles = allCircles.filter((c) => {
-      const cls = c.getAttribute('class') ?? ''
-      return cls.includes('dot') || cls.includes('Dot')
-    })
-    // 4 non-null cells in SMALL_GRID
-    expect(dotCircles.length).toBe(4)
-  })
-
-  it('root cells carry the root class (dotRoot), non-root carry dot class', () => {
-    const { container } = render(
-      <FretboardDiagram grid={SMALL_GRID} fretCount={4} />,
-    )
-    const allCircles = Array.from(container.querySelectorAll('circle'))
-    const rootCircles = allCircles.filter((c) => {
-      const cls = c.getAttribute('class') ?? ''
-      return cls.includes('dotRoot')
-    })
-    const nonRootDotCircles = allCircles.filter((c) => {
-      const cls = c.getAttribute('class') ?? ''
-      // has 'dot' but NOT 'dotRoot' and NOT 'inlay'
-      return cls.includes('dot') && !cls.includes('dotRoot') && !cls.includes('inlay')
-    })
-    // Roots: fret 0 string 0 + fret 4 string 0 = 2
-    expect(rootCircles.length).toBe(2)
-    // Non-roots: fret 2 string 0 + fret 1 string 1 = 2
-    expect(nonRootDotCircles.length).toBe(2)
-  })
-
   it('renders degree text in labelMode="degree"', () => {
-    const { container } = render(
-      <FretboardDiagram grid={SMALL_GRID} fretCount={4} labelMode="degree" />,
-    )
-    const textEls = Array.from(container.querySelectorAll('text'))
-    const textContents = textEls.map((t) => t.textContent).filter(Boolean)
-    // degrees present: '1' (×2), '2', '3'
-    expect(textContents).toContain('1')
-    expect(textContents).toContain('2')
-    expect(textContents).toContain('3')
+    const { container } = render(<FretboardDiagram grid={SMALL_GRID} fretCount={4} labelMode="degree" />)
+    const texts = Array.from(container.querySelectorAll('text')).map((t) => t.textContent)
+    expect(texts).toContain('1')
+    expect(texts).toContain('2')
+    expect(texts).toContain('3')
   })
 
   it('renders note names in labelMode="note" with noteNames', () => {
     const { container } = render(
-      <FretboardDiagram
-        grid={SMALL_GRID}
-        fretCount={4}
-        labelMode="note"
-        noteNames={NOTE_NAMES}
-      />,
+      <FretboardDiagram grid={SMALL_GRID} fretCount={4} labelMode="note" noteNames={NOTE_NAMES} />,
     )
-    const textEls = Array.from(container.querySelectorAll('text'))
-    const textContents = textEls.map((t) => t.textContent).filter(Boolean)
-    // pitch 0 => 'C', pitch 2 => 'D', pitch 4 => 'E'
-    expect(textContents).toContain('C')
-    expect(textContents).toContain('D')
-    expect(textContents).toContain('E')
-    // Should NOT contain degrees like '1', '2', '3'
-    expect(textContents).not.toContain('1')
+    const texts = Array.from(container.querySelectorAll('text')).map((t) => t.textContent)
+    expect(texts).toContain('C') // pitch 0
+    expect(texts).toContain('D') // pitch 2
+    expect(texts).toContain('E') // pitch 4
+    expect(texts).not.toContain('1')
   })
 
-  it('renders a base-fret label when startFret > 0', () => {
-    const { container } = render(
-      <FretboardDiagram grid={SMALL_GRID} startFret={4} fretCount={4} />,
+  // ── Property-based tests ──────────────────────────────────────────────────────
+
+  it('renders exactly one dot per visible non-null cell, for any grid/window', () => {
+    fc.assert(
+      fc.property(
+        gridArb,
+        fc.integer({ min: 0, max: 6 }),
+        fc.integer({ min: 1, max: 12 }),
+        (grid, startFret, fretCount) => {
+          const { container } = render(
+            <FretboardDiagram grid={grid} startFret={startFret} fretCount={fretCount} />,
+          )
+          expect(allDots(container).length).toBe(countVisibleCells(grid, startFret, fretCount))
+        },
+      ),
     )
-    const textEls = Array.from(container.querySelectorAll('text'))
-    const baseFretText = textEls.find((t) => t.textContent?.includes('fr'))
-    expect(baseFretText).not.toBeUndefined()
-    expect(baseFretText?.textContent).toMatch(/\dfr/)
   })
 
-  it('does NOT render a base-fret label when startFret === 0', () => {
-    const { container } = render(
-      <FretboardDiagram grid={SMALL_GRID} startFret={0} fretCount={4} />,
+  it('marks exactly the visible root cells with the root class', () => {
+    fc.assert(
+      fc.property(
+        gridArb,
+        fc.integer({ min: 0, max: 6 }),
+        fc.integer({ min: 1, max: 12 }),
+        (grid, startFret, fretCount) => {
+          const { container } = render(
+            <FretboardDiagram grid={grid} startFret={startFret} fretCount={fretCount} />,
+          )
+          const rootDots = allDots(container).filter(isRootDot)
+          const nonRootDots = allDots(container).filter((c) => !isRootDot(c))
+          expect(rootDots.length).toBe(countVisibleCells(grid, startFret, fretCount, (c) => c.isRoot))
+          expect(nonRootDots.length).toBe(countVisibleCells(grid, startFret, fretCount, (c) => !c.isRoot))
+        },
+      ),
     )
-    const textEls = Array.from(container.querySelectorAll('text'))
-    const baseFretText = textEls.find((t) => t.textContent?.includes('fr'))
-    expect(baseFretText).toBeUndefined()
   })
 
-  it('omits the open-string column (open col left of nut) when startFret > 0', () => {
-    // When startFret > 0, fret-0 cells should not be rendered
-    // Build a grid where ONLY fret 0 has a non-null cell; at startFret=4 it should show 0 dots
-    const gridOnlyOpen: (FretCell | null)[][] = [
-      [makeCell(0, '1', true), null, null, null, null],
-      [makeCell(0, '1', true), null, null, null, null],
-    ]
-    const { container } = render(
-      <FretboardDiagram grid={gridOnlyOpen} startFret={4} fretCount={4} />,
+  it('shows a base-fret label iff startFret > 0', () => {
+    fc.assert(
+      fc.property(gridArb, fc.integer({ min: 0, max: 6 }), (grid, startFret) => {
+        const { container } = render(<FretboardDiagram grid={grid} startFret={startFret} fretCount={5} />)
+        const hasBaseLabel = Array.from(container.querySelectorAll('text')).some((t) =>
+          /^\d+fr$/.test(t.textContent ?? ''),
+        )
+        expect(hasBaseLabel).toBe(startFret > 0)
+      }),
     )
-    const allCircles = Array.from(container.querySelectorAll('circle'))
-    const dotCircles = allCircles.filter((c) => {
-      const cls = c.getAttribute('class') ?? ''
-      return cls.includes('dot') || cls.includes('Dot')
-    })
-    expect(dotCircles.length).toBe(0)
+  })
+
+  it('labels the base fret with the start fret when windowed', () => {
+    fc.assert(
+      fc.property(gridArb, fc.integer({ min: 1, max: 11 }), (grid, startFret) => {
+        const { container } = render(<FretboardDiagram grid={grid} startFret={startFret} fretCount={5} />)
+        const baseLabel = Array.from(container.querySelectorAll('text')).find((t) =>
+          /^\d+fr$/.test(t.textContent ?? ''),
+        )
+        expect(baseLabel?.textContent).toBe(`${startFret}fr`)
+      }),
+    )
+  })
+
+  it('renders nothing but stays valid for an empty grid', () => {
+    const { container } = render(<FretboardDiagram grid={[]} />)
+    expect(container.querySelector('svg')).toBeNull()
   })
 })

--- a/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.spec.tsx
+++ b/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.spec.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { FretboardDiagram } from './FretboardDiagram.js'
+import type { FretCell } from '@klank/platform-api'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeCell = (pitch: number, degree: string, isRoot: boolean): FretCell => ({
+  pitch,
+  degree,
+  isRoot,
+})
+
+/**
+ * Minimal 2-string × 5-fret grid (indices 0..4).
+ * String 0 (low): root at fret 0, scale note at fret 2, root at fret 4
+ * String 1 (high): scale note at fret 1, null everywhere else
+ */
+const SMALL_GRID: (FretCell | null)[][] = [
+  // string 0 (low)
+  [makeCell(0, '1', true), null, makeCell(2, '2', false), null, makeCell(0, '1', true)],
+  // string 1 (high)
+  [null, makeCell(4, '3', false), null, null, null],
+]
+
+// note names for labelMode='note' tests (12 pitch classes)
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('FretboardDiagram', () => {
+  it('renders an svg with role="img" and aria-label="scale diagram"', () => {
+    const { container } = render(
+      <FretboardDiagram grid={SMALL_GRID} fretCount={4} />,
+    )
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg?.getAttribute('role')).toBe('img')
+    expect(svg?.getAttribute('aria-label')).toBe('scale diagram')
+  })
+
+  it('renders exactly as many dot circles as non-null cells', () => {
+    // SMALL_GRID non-null count: fret 0 (string 0 root), fret 2 (string 0), fret 4 (string 0), fret 1 (string 1) = 4
+    const { container } = render(
+      <FretboardDiagram grid={SMALL_GRID} fretCount={4} />,
+    )
+    // dots live inside <g> elements; count circles that are inside a <g> (excludes inlay circles)
+    // inlay circles have class 'inlay'; dot circles have class containing 'dot'
+    const allCircles = Array.from(container.querySelectorAll('circle'))
+    const dotCircles = allCircles.filter((c) => {
+      const cls = c.getAttribute('class') ?? ''
+      return cls.includes('dot') || cls.includes('Dot')
+    })
+    // 4 non-null cells in SMALL_GRID
+    expect(dotCircles.length).toBe(4)
+  })
+
+  it('root cells carry the root class (dotRoot), non-root carry dot class', () => {
+    const { container } = render(
+      <FretboardDiagram grid={SMALL_GRID} fretCount={4} />,
+    )
+    const allCircles = Array.from(container.querySelectorAll('circle'))
+    const rootCircles = allCircles.filter((c) => {
+      const cls = c.getAttribute('class') ?? ''
+      return cls.includes('dotRoot')
+    })
+    const nonRootDotCircles = allCircles.filter((c) => {
+      const cls = c.getAttribute('class') ?? ''
+      // has 'dot' but NOT 'dotRoot' and NOT 'inlay'
+      return cls.includes('dot') && !cls.includes('dotRoot') && !cls.includes('inlay')
+    })
+    // Roots: fret 0 string 0 + fret 4 string 0 = 2
+    expect(rootCircles.length).toBe(2)
+    // Non-roots: fret 2 string 0 + fret 1 string 1 = 2
+    expect(nonRootDotCircles.length).toBe(2)
+  })
+
+  it('renders degree text in labelMode="degree"', () => {
+    const { container } = render(
+      <FretboardDiagram grid={SMALL_GRID} fretCount={4} labelMode="degree" />,
+    )
+    const textEls = Array.from(container.querySelectorAll('text'))
+    const textContents = textEls.map((t) => t.textContent).filter(Boolean)
+    // degrees present: '1' (×2), '2', '3'
+    expect(textContents).toContain('1')
+    expect(textContents).toContain('2')
+    expect(textContents).toContain('3')
+  })
+
+  it('renders note names in labelMode="note" with noteNames', () => {
+    const { container } = render(
+      <FretboardDiagram
+        grid={SMALL_GRID}
+        fretCount={4}
+        labelMode="note"
+        noteNames={NOTE_NAMES}
+      />,
+    )
+    const textEls = Array.from(container.querySelectorAll('text'))
+    const textContents = textEls.map((t) => t.textContent).filter(Boolean)
+    // pitch 0 => 'C', pitch 2 => 'D', pitch 4 => 'E'
+    expect(textContents).toContain('C')
+    expect(textContents).toContain('D')
+    expect(textContents).toContain('E')
+    // Should NOT contain degrees like '1', '2', '3'
+    expect(textContents).not.toContain('1')
+  })
+
+  it('renders a base-fret label when startFret > 0', () => {
+    const { container } = render(
+      <FretboardDiagram grid={SMALL_GRID} startFret={4} fretCount={4} />,
+    )
+    const textEls = Array.from(container.querySelectorAll('text'))
+    const baseFretText = textEls.find((t) => t.textContent?.includes('fr'))
+    expect(baseFretText).not.toBeUndefined()
+    expect(baseFretText?.textContent).toMatch(/\dfr/)
+  })
+
+  it('does NOT render a base-fret label when startFret === 0', () => {
+    const { container } = render(
+      <FretboardDiagram grid={SMALL_GRID} startFret={0} fretCount={4} />,
+    )
+    const textEls = Array.from(container.querySelectorAll('text'))
+    const baseFretText = textEls.find((t) => t.textContent?.includes('fr'))
+    expect(baseFretText).toBeUndefined()
+  })
+
+  it('omits the open-string column (open col left of nut) when startFret > 0', () => {
+    // When startFret > 0, fret-0 cells should not be rendered
+    // Build a grid where ONLY fret 0 has a non-null cell; at startFret=4 it should show 0 dots
+    const gridOnlyOpen: (FretCell | null)[][] = [
+      [makeCell(0, '1', true), null, null, null, null],
+      [makeCell(0, '1', true), null, null, null, null],
+    ]
+    const { container } = render(
+      <FretboardDiagram grid={gridOnlyOpen} startFret={4} fretCount={4} />,
+    )
+    const allCircles = Array.from(container.querySelectorAll('circle'))
+    const dotCircles = allCircles.filter((c) => {
+      const cls = c.getAttribute('class') ?? ''
+      return cls.includes('dot') || cls.includes('Dot')
+    })
+    expect(dotCircles.length).toBe(0)
+  })
+})

--- a/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.tsx
+++ b/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.tsx
@@ -9,6 +9,12 @@ export type FretboardDiagramProps = {
   labelMode?: 'degree' | 'note'
   noteNames?: readonly string[]
   className?: string
+  /** Open-string note names, low-to-high (index 0 = lowest string). When
+   *  provided, a small left gutter renders each label at its string's y. */
+  stringLabels?: readonly string[]
+  /** When true, render a fret-number row beneath the neck (only on conventional
+   *  marker frets: 0, 3, 5, 7, 9, 12). Default false. */
+  showFretNumbers?: boolean
 }
 
 // ── Layout constants (mirror ChordDiagram's named-constant style) ─────────────
@@ -18,13 +24,22 @@ const TOP = 18          // top padding (above first string)
 const LEFT_PAD = 10     // left margin before nut / fret lines
 const OPEN_COL_W = 18   // extra width for the open-string column (when startFret === 0)
 const BASE_LABEL_W = 28 // right margin for base-fret label when startFret > 0
-const DOT_R = 7         // dot circle radius
+const DOT_R = 7.5       // dot circle radius (bumped from 7 for readability)
 const INLAY_R = 3       // inlay dot radius
+
+// Width of the string-labels gutter (when stringLabels is provided)
+const STRING_LABEL_GUTTER = 20
+
+// Height of the fret-number row below the neck (when showFretNumbers is true)
+const FRET_NUMBER_ROW_H = 14
 
 // Absolute frets that get inlay markers (single dot)
 const INLAY_FRETS = new Set([3, 5, 7, 9])
 // Double-inlay fret
 const DOUBLE_INLAY_FRET = 12
+
+// Frets shown in the fret-number row (marker frets + open string)
+const FRET_NUMBER_FRETS = new Set([0, 3, 5, 7, 9, 12])
 
 // y-coordinate for string s (index 0 = lowest/bass = BOTTOM of diagram)
 function stringY(s: number, numStrings: number): number {
@@ -38,12 +53,19 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
   labelMode = 'degree',
   noteNames,
   className,
+  stringLabels,
+  showFretNumbers = false,
 }) => {
   const numStrings = grid.length
   if (numStrings === 0) return null
 
   const hasOpenCol = startFret === 0
-  const leftEdge = LEFT_PAD + (hasOpenCol ? OPEN_COL_W : 0)
+  const gutterW = stringLabels ? STRING_LABEL_GUTTER : 0
+
+  // leftEdge is the x of the nut/first fret line, shifted right to accommodate
+  // the string-label gutter and the open-column space.
+  const leftEdge = gutterW + LEFT_PAD + (hasOpenCol ? OPEN_COL_W : 0)
+
   // Absolute fret shown in the first cell column. With an open column (full
   // neck) the open string is fret 0 and the first cell is fret 1; a position
   // window starts ON its anchor fret so the root is included.
@@ -52,7 +74,10 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
   // Total width: leftEdge + fretCount cells + optional right label space
   const rightLabelW = startFret > 0 ? BASE_LABEL_W : 0
   const totalW = leftEdge + fretCount * CELL_W + rightLabelW
-  const totalH = TOP + (numStrings - 1) * STRING_GAP + TOP
+
+  // Total height: strings + optional fret-number row below
+  const fretNumRowH = showFretNumbers ? FRET_NUMBER_ROW_H : 0
+  const totalH = TOP + (numStrings - 1) * STRING_GAP + TOP + fretNumRowH
 
   // x-coordinate of the leftmost fret line (nut position or top fret line)
   const nutX = leftEdge
@@ -67,7 +92,21 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
         : cell.degree
     return (
       <g key={key}>
-        <circle cx={x} cy={y} r={DOT_R} className={cell.isRoot ? styles.dotRoot : styles.dot} />
+        <circle
+          cx={x}
+          cy={y}
+          r={DOT_R}
+          className={cell.isRoot ? styles.dotRoot : styles.dot}
+        />
+        {cell.isRoot && (
+          <circle
+            cx={x}
+            cy={y}
+            r={DOT_R + 1.5}
+            className={styles.rootRing}
+            aria-hidden="true"
+          />
+        )}
         <text x={x} y={y} className={cell.isRoot ? styles.dotRootLabel : styles.dotLabel}>
           {label}
         </text>
@@ -81,6 +120,9 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
     visibleFrets.push(firstCellFret + i)
   }
 
+  // y just below the bottom string (used for fret-number row)
+  const belowNeckY = TOP + (numStrings - 1) * STRING_GAP + TOP / 2
+
   return (
     <svg
       viewBox={`0 0 ${totalW} ${totalH}`}
@@ -88,6 +130,24 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
       role="img"
       aria-label="scale diagram"
     >
+      {/* String-label gutter */}
+      {stringLabels && Array.from({ length: numStrings }, (_, s) => {
+        const label = stringLabels[s]
+        if (!label) return null
+        const y = stringY(s, numStrings)
+        return (
+          <text
+            key={`string-label-${s}`}
+            x={gutterW - 4}
+            y={y}
+            className={styles.stringLabel}
+            aria-hidden="true"
+          >
+            {label}
+          </text>
+        )
+      })}
+
       {/* Nut (thick rect) or top fret line */}
       {hasOpenCol ? (
         <rect
@@ -147,7 +207,7 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
           if (absFret === DOUBLE_INLAY_FRET) {
             const offset = STRING_GAP * 0.4
             return (
-              <g key={`inlay-${absFret}`}>
+              <g key={`inlay-${absFret}`} aria-hidden="true">
                 <circle cx={slotX} cy={midY - offset} r={INLAY_R} className={styles.inlay} />
                 <circle cx={slotX} cy={midY + offset} r={INLAY_R} className={styles.inlay} />
               </g>
@@ -155,7 +215,14 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
           }
           if (INLAY_FRETS.has(absFret)) {
             return (
-              <circle key={`inlay-${absFret}`} cx={slotX} cy={midY} r={INLAY_R} className={styles.inlay} />
+              <circle
+                key={`inlay-${absFret}`}
+                cx={slotX}
+                cy={midY}
+                r={INLAY_R}
+                className={styles.inlay}
+                aria-hidden="true"
+              />
             )
           }
           return null
@@ -195,6 +262,46 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
           {startFret}fr
         </text>
       )}
+
+      {/* Fret number row below the neck */}
+      {showFretNumbers && (() => {
+        // Open-string label (fret 0) when hasOpenCol
+        const items: React.ReactNode[] = []
+
+        if (hasOpenCol && FRET_NUMBER_FRETS.has(0)) {
+          items.push(
+            <text
+              key="fretnum-0"
+              x={nutX - OPEN_COL_W / 2}
+              y={belowNeckY}
+              className={styles.fretNumber}
+              aria-hidden="true"
+            >
+              0
+            </text>
+          )
+        }
+
+        for (let i = 0; i < fretCount; i++) {
+          const absFret = firstCellFret + i
+          if (FRET_NUMBER_FRETS.has(absFret)) {
+            const x = nutX + i * CELL_W + CELL_W / 2
+            items.push(
+              <text
+                key={`fretnum-${absFret}`}
+                x={x}
+                y={belowNeckY}
+                className={styles.fretNumber}
+                aria-hidden="true"
+              >
+                {absFret}
+              </text>
+            )
+          }
+        }
+
+        return items
+      })()}
     </svg>
   )
 }

--- a/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.tsx
+++ b/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.tsx
@@ -1,0 +1,224 @@
+import * as React from 'react'
+import type { FretCell } from '@klank/platform-api'
+import styles from './fretboardDiagram.module.css'
+
+export type FretboardDiagramProps = {
+  grid: (FretCell | null)[][]
+  startFret?: number
+  fretCount?: number
+  labelMode?: 'degree' | 'note'
+  noteNames?: readonly string[]
+  className?: string
+}
+
+// ── Layout constants (mirror ChordDiagram's named-constant style) ─────────────
+const CELL_W = 26       // width per fret cell
+const STRING_GAP = 18   // vertical gap between strings
+const TOP = 18          // top padding (above first string)
+const LEFT_PAD = 10     // left margin before nut / fret lines
+const OPEN_COL_W = 18   // extra width for the open-string column (when startFret === 0)
+const BASE_LABEL_W = 28 // right margin for base-fret label when startFret > 0
+const DOT_R = 7         // dot circle radius
+const INLAY_R = 3       // inlay dot radius
+
+// Absolute frets that get inlay markers (single dot)
+const INLAY_FRETS = new Set([3, 5, 7, 9])
+// Double-inlay fret
+const DOUBLE_INLAY_FRET = 12
+
+// y-coordinate for string s (index 0 = lowest/bass = BOTTOM of diagram)
+function stringY(s: number, numStrings: number): number {
+  return TOP + (numStrings - 1 - s) * STRING_GAP
+}
+
+export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
+  grid,
+  startFret = 0,
+  fretCount = 12,
+  labelMode = 'degree',
+  noteNames,
+  className,
+}) => {
+  const numStrings = grid.length
+  if (numStrings === 0) return null
+
+  const hasOpenCol = startFret === 0
+  const leftEdge = LEFT_PAD + (hasOpenCol ? OPEN_COL_W : 0)
+  // Absolute fret shown in the first cell column. With an open column (full
+  // neck) the open string is fret 0 and the first cell is fret 1; a position
+  // window starts ON its anchor fret so the root is included.
+  const firstCellFret = hasOpenCol ? 1 : startFret
+
+  // Total width: leftEdge + fretCount cells + optional right label space
+  const rightLabelW = startFret > 0 ? BASE_LABEL_W : 0
+  const totalW = leftEdge + fretCount * CELL_W + rightLabelW
+  const totalH = TOP + (numStrings - 1) * STRING_GAP + TOP
+
+  // x-coordinate of the leftmost fret line (nut position or top fret line)
+  const nutX = leftEdge
+
+  // Helper: get label text for a cell
+  const getCellLabel = (cell: FretCell): string => {
+    if (labelMode === 'note' && noteNames) {
+      return noteNames[((cell.pitch % 12) + 12) % 12] ?? cell.degree
+    }
+    return cell.degree
+  }
+
+  // Collect which absolute frets are in the shown window for inlay rendering
+  const visibleFrets: number[] = []
+  for (let i = 0; i < fretCount; i++) {
+    visibleFrets.push(firstCellFret + i)
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${totalW} ${totalH}`}
+      className={`${styles.diagram} ${className ?? ''}`}
+      role="img"
+      aria-label="scale diagram"
+    >
+      {/* Nut (thick rect) or top fret line */}
+      {hasOpenCol ? (
+        <rect
+          x={nutX}
+          y={TOP - 2}
+          width={4}
+          height={(numStrings - 1) * STRING_GAP + 4}
+          className={styles.nut}
+        />
+      ) : (
+        <line
+          x1={nutX}
+          y1={TOP}
+          x2={nutX}
+          y2={TOP + (numStrings - 1) * STRING_GAP}
+          className={styles.fretLine}
+        />
+      )}
+
+      {/* Vertical fret lines */}
+      {Array.from({ length: fretCount }, (_, i) => {
+        const x = nutX + (i + 1) * CELL_W
+        return (
+          <line
+            key={`fret-${i}`}
+            x1={x}
+            y1={TOP}
+            x2={x}
+            y2={TOP + (numStrings - 1) * STRING_GAP}
+            className={styles.fretLine}
+          />
+        )
+      })}
+
+      {/* Horizontal string lines */}
+      {Array.from({ length: numStrings }, (_, s) => {
+        const y = stringY(s, numStrings)
+        // Low string (s===0) at bottom = thicker
+        const isLowest = s === 0
+        return (
+          <line
+            key={`string-${s}`}
+            x1={hasOpenCol ? nutX - OPEN_COL_W : nutX}
+            y1={y}
+            x2={nutX + fretCount * CELL_W}
+            y2={y}
+            className={isLowest ? styles.bassString : styles.stringLine}
+          />
+        )
+      })}
+
+      {/* Inlay dots */}
+      {(() => {
+        const midY = TOP + ((numStrings - 1) / 2) * STRING_GAP
+        return visibleFrets.map((absFret, idx) => {
+          const slotX = nutX + idx * CELL_W + CELL_W / 2
+          if (absFret === DOUBLE_INLAY_FRET) {
+            const offset = STRING_GAP * 0.4
+            return (
+              <g key={`inlay-${absFret}`}>
+                <circle cx={slotX} cy={midY - offset} r={INLAY_R} className={styles.inlay} />
+                <circle cx={slotX} cy={midY + offset} r={INLAY_R} className={styles.inlay} />
+              </g>
+            )
+          }
+          if (INLAY_FRETS.has(absFret)) {
+            return (
+              <circle key={`inlay-${absFret}`} cx={slotX} cy={midY} r={INLAY_R} className={styles.inlay} />
+            )
+          }
+          return null
+        })
+      })()}
+
+      {/* Open-string column dots (fret 0) when hasOpenCol */}
+      {hasOpenCol && Array.from({ length: numStrings }, (_, s) => {
+        const cell = grid[s]?.[0]
+        if (!cell) return null
+        const x = nutX - OPEN_COL_W / 2
+        const y = stringY(s, numStrings)
+        const label = getCellLabel(cell)
+        return (
+          <g key={`open-dot-${s}`}>
+            <circle
+              cx={x}
+              cy={y}
+              r={DOT_R}
+              className={cell.isRoot ? styles.dotRoot : styles.dot}
+            />
+            <text
+              x={x}
+              y={y}
+              className={styles.dotLabel}
+            >
+              {label}
+            </text>
+          </g>
+        )
+      })}
+
+      {/* Fretted dots */}
+      {Array.from({ length: numStrings }, (_, s) => {
+        const row = grid[s]
+        if (!row) return null
+        return Array.from({ length: fretCount }, (_, fi) => {
+          const f = firstCellFret + fi
+          const cell = row[f]
+          if (!cell) return null
+          const x = nutX + fi * CELL_W + CELL_W / 2
+          const y = stringY(s, numStrings)
+          const label = getCellLabel(cell)
+          return (
+            <g key={`dot-${s}-${f}`}>
+              <circle
+                cx={x}
+                cy={y}
+                r={DOT_R}
+                className={cell.isRoot ? styles.dotRoot : styles.dot}
+              />
+              <text
+                x={x}
+                y={y}
+                className={styles.dotLabel}
+              >
+                {label}
+              </text>
+            </g>
+          )
+        })
+      })}
+
+      {/* Base fret label (e.g. "5fr") when startFret > 0 */}
+      {startFret > 0 && (
+        <text
+          x={nutX + fretCount * CELL_W + 4}
+          y={TOP + ((numStrings - 1) / 2) * STRING_GAP}
+          className={styles.baseFretLabel}
+        >
+          {startFret}fr
+        </text>
+      )}
+    </svg>
+  )
+}

--- a/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.tsx
+++ b/libs/ui/src/lib/fretboardDiagram/FretboardDiagram.tsx
@@ -57,12 +57,22 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
   // x-coordinate of the leftmost fret line (nut position or top fret line)
   const nutX = leftEdge
 
-  // Helper: get label text for a cell
-  const getCellLabel = (cell: FretCell): string => {
-    if (labelMode === 'note' && noteNames) {
-      return noteNames[((cell.pitch % 12) + 12) % 12] ?? cell.degree
-    }
-    return cell.degree
+  // A scale-tone dot (circle + centred label), shared by the open column and
+  // the fretted grid. Root and non-root use different fills, so the label
+  // colour must follow suit to stay legible.
+  const renderDot = (key: string, x: number, y: number, cell: FretCell) => {
+    const label =
+      labelMode === 'note' && noteNames
+        ? noteNames[((cell.pitch % 12) + 12) % 12] ?? cell.degree
+        : cell.degree
+    return (
+      <g key={key}>
+        <circle cx={x} cy={y} r={DOT_R} className={cell.isRoot ? styles.dotRoot : styles.dot} />
+        <text x={x} y={y} className={cell.isRoot ? styles.dotRootLabel : styles.dotLabel}>
+          {label}
+        </text>
+      </g>
+    )
   }
 
   // Collect which absolute frets are in the shown window for inlay rendering
@@ -156,26 +166,7 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
       {hasOpenCol && Array.from({ length: numStrings }, (_, s) => {
         const cell = grid[s]?.[0]
         if (!cell) return null
-        const x = nutX - OPEN_COL_W / 2
-        const y = stringY(s, numStrings)
-        const label = getCellLabel(cell)
-        return (
-          <g key={`open-dot-${s}`}>
-            <circle
-              cx={x}
-              cy={y}
-              r={DOT_R}
-              className={cell.isRoot ? styles.dotRoot : styles.dot}
-            />
-            <text
-              x={x}
-              y={y}
-              className={styles.dotLabel}
-            >
-              {label}
-            </text>
-          </g>
-        )
+        return renderDot(`open-dot-${s}`, nutX - OPEN_COL_W / 2, stringY(s, numStrings), cell)
       })}
 
       {/* Fretted dots */}
@@ -183,28 +174,13 @@ export const FretboardDiagram: React.FC<FretboardDiagramProps> = ({
         const row = grid[s]
         if (!row) return null
         return Array.from({ length: fretCount }, (_, fi) => {
-          const f = firstCellFret + fi
-          const cell = row[f]
+          const cell = row[firstCellFret + fi]
           if (!cell) return null
-          const x = nutX + fi * CELL_W + CELL_W / 2
-          const y = stringY(s, numStrings)
-          const label = getCellLabel(cell)
-          return (
-            <g key={`dot-${s}-${f}`}>
-              <circle
-                cx={x}
-                cy={y}
-                r={DOT_R}
-                className={cell.isRoot ? styles.dotRoot : styles.dot}
-              />
-              <text
-                x={x}
-                y={y}
-                className={styles.dotLabel}
-              >
-                {label}
-              </text>
-            </g>
+          return renderDot(
+            `dot-${s}-${firstCellFret + fi}`,
+            nutX + fi * CELL_W + CELL_W / 2,
+            stringY(s, numStrings),
+            cell,
           )
         })
       })}

--- a/libs/ui/src/lib/fretboardDiagram/fretboardDiagram.module.css
+++ b/libs/ui/src/lib/fretboardDiagram/fretboardDiagram.module.css
@@ -1,0 +1,61 @@
+.diagram {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.nut {
+  fill: var(--klank-color-text);
+}
+
+.fretLine {
+  stroke: var(--klank-color-border);
+  stroke-width: 1;
+}
+
+.stringLine {
+  stroke: var(--klank-color-border);
+  stroke-width: 1;
+}
+
+.bassString {
+  stroke: var(--klank-color-border);
+  stroke-width: 2;
+}
+
+.dot {
+  fill: var(--klank-color-secondary-background);
+  stroke: var(--klank-color-text);
+  stroke-width: 1.5;
+}
+
+.dotRoot {
+  fill: var(--klank-color-text);
+}
+
+.dotLabel {
+  fill: var(--klank-color-background);
+  font-size: 7px;
+  text-anchor: middle;
+  dominant-baseline: central;
+  user-select: none;
+}
+
+.dotRootLabel {
+  fill: var(--klank-color-background);
+  font-size: 7px;
+  text-anchor: middle;
+  dominant-baseline: central;
+  user-select: none;
+}
+
+.inlay {
+  fill: var(--klank-color-border);
+}
+
+.baseFretLabel {
+  fill: var(--klank-color-text);
+  font-size: 8px;
+  dominant-baseline: central;
+  text-anchor: start;
+}

--- a/libs/ui/src/lib/fretboardDiagram/fretboardDiagram.module.css
+++ b/libs/ui/src/lib/fretboardDiagram/fretboardDiagram.module.css
@@ -33,10 +33,21 @@
   fill: var(--klank-color-text);
 }
 
+/* Subtle accent ring rendered behind the root label, giving root dots extra
+   visual pop without introducing new color tokens. Rendered as a separate
+   circle before the filled circle so the ring appears as a border.
+   Named without "dot" so dot-counting tests don't treat it as a tone dot. */
+.rootRing {
+  fill: none;
+  stroke: var(--klank-color-text);
+  stroke-width: 1;
+  opacity: 0.35;
+}
+
 /* Label on a non-root dot (light fill) — needs dark text to stay legible. */
 .dotLabel {
   fill: var(--klank-color-text);
-  font-size: 7px;
+  font-size: 7.5px;
   text-anchor: middle;
   dominant-baseline: central;
   user-select: none;
@@ -45,7 +56,7 @@
 /* Label on a root dot (filled with text colour) — needs light text. */
 .dotRootLabel {
   fill: var(--klank-color-background);
-  font-size: 7px;
+  font-size: 7.5px;
   text-anchor: middle;
   dominant-baseline: central;
   user-select: none;
@@ -60,4 +71,23 @@
   font-size: 8px;
   dominant-baseline: central;
   text-anchor: start;
+}
+
+/* Left-gutter open-string note labels */
+.stringLabel {
+  fill: var(--klank-color-text);
+  font-size: 7px;
+  text-anchor: end;
+  dominant-baseline: central;
+  user-select: none;
+}
+
+/* Fret-number row below the neck — only shown on marker frets */
+.fretNumber {
+  fill: var(--klank-color-text);
+  font-size: 7px;
+  text-anchor: middle;
+  dominant-baseline: central;
+  opacity: 0.55;
+  user-select: none;
 }

--- a/libs/ui/src/lib/fretboardDiagram/fretboardDiagram.module.css
+++ b/libs/ui/src/lib/fretboardDiagram/fretboardDiagram.module.css
@@ -33,14 +33,16 @@
   fill: var(--klank-color-text);
 }
 
+/* Label on a non-root dot (light fill) — needs dark text to stay legible. */
 .dotLabel {
-  fill: var(--klank-color-background);
+  fill: var(--klank-color-text);
   font-size: 7px;
   text-anchor: middle;
   dominant-baseline: central;
   user-select: none;
 }
 
+/* Label on a root dot (filled with text colour) — needs light text. */
 .dotRootLabel {
   fill: var(--klank-color-background);
   font-size: 7px;

--- a/libs/ui/src/lib/icons/ScalesIcon.tsx
+++ b/libs/ui/src/lib/icons/ScalesIcon.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+
+export const ScalesIcon: React.FC<React.ComponentPropsWithoutRef<'svg'>> = (props) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    {/* Vertical string lines */}
+    <line x1="6" y1="3" x2="6" y2="21" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="12" y1="3" x2="12" y2="21" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="18" y1="3" x2="18" y2="21" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    {/* Horizontal fret lines */}
+    <line x1="4" y1="7" x2="20" y2="7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="4" y1="12" x2="20" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="4" y1="17" x2="20" y2="17" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    {/* Scale degree dots */}
+    <circle cx="6" cy="9.5" r="2" fill="currentColor" />
+    <circle cx="12" cy="14.5" r="2" fill="currentColor" />
+    <circle cx="18" cy="9.5" r="2" fill="currentColor" />
+  </svg>
+)

--- a/libs/ui/src/lib/toolbar/Toolbar.tsx
+++ b/libs/ui/src/lib/toolbar/Toolbar.tsx
@@ -6,6 +6,7 @@ import {
   FolderIcon,
   NewPlaylistIcon,
   RefreshIcon,
+  ScalesIcon,
   SettingsIcon,
   ShuffleIcon,
   TargetIcon,
@@ -35,6 +36,7 @@ type ToolbarProps = {
   isDownloading?: boolean
   downloadError?: string | null
   onSettingsClick?: () => void
+  onHarmonyClick?: () => void
   tree: TreeEntry[]
   isCollapsed?: boolean
   /** When true the "Go to Tab" button is hidden (it lives in the mobile drawer instead). */
@@ -53,6 +55,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   isDownloading,
   downloadError,
   onSettingsClick,
+  onHarmonyClick,
   tree,
   isCollapsed,
   hideGoToTab,
@@ -95,6 +98,11 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       <ToolTip message="Settings">
         <Button iconButton={true} icon={<SettingsIcon />} onClick={onSettingsClick} />
       </ToolTip>
+      {onHarmonyClick && (
+        <ToolTip message="Scales & Chords">
+          <Button iconButton={true} icon={<ScalesIcon />} onClick={onHarmonyClick} />
+        </ToolTip>
+      )}
       {!hideGoToTab && (
         <ToolTip message="Go to Tab">
           <Button


### PR DESCRIPTION
## What & why

klank had a hand-authored chord dataset but no scale/mode data and nowhere to browse harmonic material (chord diagrams only appeared as tab hover tooltips). This adds **scales/modes**, a **chord-scale** relationship layer, and **12-fret fretboard diagrams**, surfaced in a new browsable **Harmony** section reachable from a new nav icon. The root key and instrument are configurable and remembered between sessions.

Scales are **computed**, not hand-authored — a scale is a root-agnostic interval pattern, so its fretboard layout derives deterministically from `(root, intervals, tuning)`. No new JSON, no generator, no data-correctness spec; correctness is enforced by property tests on the math.

## What's included

**`libs/platform-api/src/lib/scales.ts`** (pure, runtime-import-free, mirrors `chord-theory.ts`)
- `SCALES` — 24 scales: Ionian + 6 modes; melodic minor + 6 modes (incl. Lydian Dominant, Altered, Locrian ♮2); harmonic minor + Phrygian Dominant; major/minor pentatonic, major/minor blues; whole-tone, both diminished, chromatic.
- `CHORD_SCALE_MAP` — every one of the 27 chord qualities → compatible scales (jazz chord-scale theory).
- Helpers: `getScalePitches`, `getDegreeByPitch`, `getScaleById`, `scalesForQuality`, `getScaleFretboard`, `getScalePositions`, `getDiatonicTriads`.

**`libs/ui`**
- `FretboardDiagram` — horizontal 12-fret SVG renderer (full neck + 5-fret position windows), root highlighting, degree/note labels, fully theme-aware (reuses the `ChordDiagram` CSS-var conventions).
- `ScalesIcon` nav icon.

**`apps/klank` — new `/harmony` route**
- Shared controls: key selector (12 chromatic roots), Guitar/Bass toggle, Degrees/Notes label toggle.
- **Chords** tab — pick a quality, see existing `ChordDiagram` voicings.
- **Scales & Modes** tab — full-neck diagram + position windows + a degree/note legend + **diatonic triads** (chords-in-the-scale) rendered with the existing `ChordDiagram`.
- **Chord-scales** tab — pick a quality, see every scale that fits, each as a full-neck diagram.

**`libs/store`** — additive persisted `harmony` slice (root/scale/quality/tab) and fixed `instrument` persistence (it was documented `@persisted` but missing from `partialize`); storage `version` bumped to 3 with a defaulting migration. No existing fields renamed.

**Nav** — Toolbar gains an optional `onHarmonyClick` button; wired into the desktop toolbar and the mobile drawer.

## Design notes / known limitations (intentional, app-consistent)
- Note names render in **sharps only** (`pitchName`), matching the existing chord system (`CHORD_ROOTS` uses `A#`, `D#`…).
- Position views are generic **hand-windows**, not canonical CAGED/3NPS (which is undefined for 5/6/8/12-note scales).
- Diatonic harmonization is **triads only** — diatonic 7ths of exotic scales would need chord qualities the dataset lacks (e.g. minor-major7).

## Verification
- `nx run-many -t test` — all projects green (34 new scale property tests, 8 new diagram tests, store-persistence updated for v3).
- `nx run-many -t typecheck lint` — clean.
- `nx build klank` — succeeds; dev server serves `/harmony` (200).
- No headless browser was available in the build environment, so the UI was not screenshotted — worth a quick manual pass in both Light and Dark themes.

https://claude.ai/code/session_016GAbwH3CtLeBTCv8fwumSg

---
_Generated by [Claude Code](https://claude.ai/code/session_016GAbwH3CtLeBTCv8fwumSg)_