### PR TITLE
fix(sync): throttle focus/resize autosync and hide the Windows credential-helper console

### DIFF
--- a/apps/klank/app/useGitSync.ts
+++ b/apps/klank/app/useGitSync.ts
@@ -74,6 +74,10 @@ export function useGitSync(onChanged?: () => void): void {
   const gitRef = useRef<GitService | null>(null)
   const runningRef = useRef(false)
   const queuedRef = useRef(false)
+  // Epoch ms of the last sync we kicked off. Lets opportunistic triggers
+  // (window focus/visibility) throttle themselves to the configured interval
+  // instead of re-syncing on every focus or resize.
+  const lastSyncAtRef = useRef(0)
   // Always-latest sync implementation, so the stable `trigger` never goes stale.
   const runSyncRef = useRef<() => Promise<void>>(async () => undefined)
   const onChangedRef = useRef(onChanged)
@@ -101,6 +105,7 @@ export function useGitSync(onChanged?: () => void): void {
       return
     }
     runningRef.current = true
+    lastSyncAtRef.current = Date.now()
     try {
       await runGitSync(git, baseDirectory, fileService, onChangedRef.current)
     } finally {
@@ -142,12 +147,20 @@ export function useGitSync(onChanged?: () => void): void {
     }
   }, [enabled, debounceMinutes, trigger])
 
-  // Sync when the user returns to the app.
+  // Sync when the user returns to the app — but throttled to the configured
+  // interval. Focus/visibility (and window resize/move, which the webview
+  // surfaces as a focus event) fire constantly; without this gate every one of
+  // them would start a sync. The periodic timer and post-edit debounce above
+  // still sync on their own cadence.
   useEffect(() => {
     if (!enabled || typeof window === 'undefined') return
-    const onFocus = () => trigger()
+    const gapMs = clampMinutes(intervalMinutes, 1, 30) * MINUTE_MS
+    const maybeTrigger = () => {
+      if (Date.now() - lastSyncAtRef.current >= gapMs) trigger()
+    }
+    const onFocus = () => maybeTrigger()
     const onVisible = () => {
-      if (document.visibilityState === 'visible') trigger()
+      if (document.visibilityState === 'visible') maybeTrigger()
     }
     window.addEventListener('focus', onFocus)
     document.addEventListener('visibilitychange', onVisible)
@@ -155,5 +168,5 @@ export function useGitSync(onChanged?: () => void): void {
       window.removeEventListener('focus', onFocus)
       document.removeEventListener('visibilitychange', onVisible)
     }
-  }, [enabled, trigger])
+  }, [enabled, intervalMinutes, trigger])
 }

--- a/apps/klank/src-tauri/src/git.rs
+++ b/apps/klank/src-tauri/src/git.rs
@@ -173,6 +173,68 @@ fn probe_system_credentials(dir: &str) -> Result<(), Error> {
     Ok(())
 }
 
+/// Resolves credentials through the user's configured git credential helper
+/// (GCM, osxkeychain, …) via `git credential fill`.
+///
+/// We shell out ourselves rather than use git2's `Cred::credential_helper`
+/// because git2 spawns the helper subprocess with a visible console on Windows,
+/// which flashes a terminal window on every sync. Spawning it here lets us pass
+/// `CREATE_NO_WINDOW` so it stays invisible. `GIT_TERMINAL_PROMPT=0` keeps git
+/// from blocking on an interactive prompt when no helper is configured — it just
+/// exits non-zero and we fall through, exactly like the old code path. `git` is
+/// always present on desktop (the system-credential opt-in presupposes a
+/// configured git helper); on Android the spawn fails and we fall through.
+fn helper_credentials(url: &str, username: Option<&str>) -> Result<Cred, Error> {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let mut cmd = Command::new("git");
+    cmd.args(["credential", "fill"])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| Error::from_str(&e.to_string()))?;
+    // `git credential fill` parses a `url=` line into protocol/host/path itself.
+    let mut input = format!("url={url}\n");
+    if let Some(u) = username.filter(|u| !u.is_empty()) {
+        input.push_str(&format!("username={u}\n"));
+    }
+    input.push('\n');
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| Error::from_str("could not open git credential stdin"))?
+        .write_all(input.as_bytes())
+        .map_err(|e| Error::from_str(&e.to_string()))?;
+    let out = child.wait_with_output().map_err(|e| Error::from_str(&e.to_string()))?;
+    if !out.status.success() {
+        return Err(Error::from_str("git credential helper returned no credentials"));
+    }
+
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut user = None;
+    let mut pass = None;
+    for line in text.lines() {
+        if let Some(v) = line.strip_prefix("username=") {
+            user = Some(v.to_string());
+        } else if let Some(v) = line.strip_prefix("password=") {
+            pass = Some(v.to_string());
+        }
+    }
+    match (user, pass) {
+        (Some(u), Some(p)) => Cred::userpass_plaintext(&u, &p),
+        _ => Err(Error::from_str("git credential helper did not return a username/password")),
+    }
+}
+
 /// Builds credential callbacks: PAT first (Android + as an override), then the
 /// system credential helper (desktop).
 fn callbacks(app: tauri::AppHandle) -> RemoteCallbacks<'static> {
@@ -187,10 +249,8 @@ fn callbacks(app: tauri::AppHandle) -> RemoteCallbacks<'static> {
                     return Cred::userpass_plaintext(username.unwrap_or("git"), &token);
                 }
             }
-            if let Ok(config) = git2::Config::open_default() {
-                if let Ok(cred) = Cred::credential_helper(&config, url, username) {
-                    return Ok(cred);
-                }
+            if let Ok(cred) = helper_credentials(url, username) {
+                return Ok(cred);
             }
         }
         if allowed.contains(CredentialType::DEFAULT) {
@@ -209,10 +269,8 @@ fn callbacks_system_only() -> RemoteCallbacks<'static> {
     let mut cb = RemoteCallbacks::new();
     cb.credentials(move |url, username, allowed| {
         if allowed.contains(CredentialType::USER_PASS_PLAINTEXT) {
-            if let Ok(config) = git2::Config::open_default() {
-                if let Ok(cred) = Cred::credential_helper(&config, url, username) {
-                    return Ok(cred);
-                }
+            if let Ok(cred) = helper_credentials(url, username) {
+                return Ok(cred);
             }
         }
         if allowed.contains(CredentialType::DEFAULT) {

--- a/apps/klank/tests/useGitSync.spec.ts
+++ b/apps/klank/tests/useGitSync.spec.ts
@@ -1,9 +1,17 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
 import { useKlankStore, type SyncStatus } from '@klank/store'
-import type { FileService, GitService, SyncResult } from '@klank/platform-api'
+import { createGitService, type FileService, type GitService, type SyncResult } from '@klank/platform-api'
 import { clampMinutes, runGitSync, useGitSync } from '../app/useGitSync'
 import { describeSyncStatus } from '../app/routes/settings'
+
+// `createGitService` reaches into Tauri IPC, which jsdom can't provide. Default
+// to "not in Tauri" (rejects, leaving gitRef null) so the scheduling-guard tests
+// match production browser behaviour; individual tests override it.
+vi.mock('@klank/platform-api', async (importActual) => {
+  const actual = await importActual<typeof import('@klank/platform-api')>()
+  return { ...actual, createGitService: vi.fn(async () => { throw new Error('no tauri') }) }
+})
 
 const baseDir = '/tabs'
 
@@ -147,6 +155,11 @@ describe('describeSyncStatus', () => {
 })
 
 describe('useGitSync scheduling guard', () => {
+  // Default to "not in Tauri" so gitRef stays null and no real sync fires;
+  // re-set here because the afterEach restore clears the implementation.
+  beforeEach(() => {
+    vi.mocked(createGitService).mockImplementation(async () => { throw new Error('no tauri') })
+  })
   afterEach(() => vi.restoreAllMocks())
 
   it('clamps a corrupt persisted interval so setInterval never receives NaN', () => {
@@ -181,6 +194,38 @@ describe('useGitSync scheduling guard', () => {
     const spy = vi.spyOn(globalThis, 'setInterval')
     const { unmount } = renderHook(() => useGitSync())
     expect(spy).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('throttles focus-driven syncs to the configured interval', async () => {
+    const sync = vi.fn(async () => okResult())
+    vi.mocked(createGitService).mockResolvedValue(makeGit({ sync }))
+    useKlankStore.setState({
+      baseDirectory: '/tabs',
+      syncSettings: { enabled: true, intervalMinutes: 30, debounceMinutes: 5 },
+    })
+
+    const base = 1_700_000_000_000
+    const now = vi.spyOn(Date, 'now')
+    now.mockReturnValue(base)
+    const { unmount } = renderHook(() => useGitSync())
+    // Let the async createGitService resolve so gitRef is wired up.
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)) })
+
+    // First focus has no prior sync to throttle against → syncs.
+    await act(async () => { window.dispatchEvent(new Event('focus')) })
+    expect(sync).toHaveBeenCalledTimes(1)
+
+    // A focus event 10 min later is inside the 30-min window → ignored.
+    now.mockReturnValue(base + 10 * 60_000)
+    await act(async () => { window.dispatchEvent(new Event('focus')) })
+    expect(sync).toHaveBeenCalledTimes(1)
+
+    // A focus event past the interval → syncs again.
+    now.mockReturnValue(base + 31 * 60_000)
+    await act(async () => { window.dispatchEvent(new Event('focus')) })
+    expect(sync).toHaveBeenCalledTimes(2)
+
     unmount()
   })
 })


### PR DESCRIPTION
Follow-up to the autosync freeze fix (#36). Two issues surfaced once autosync was running on desktop.

## 1. Over-syncing on focus / resize
The `focus` and `visibilitychange` handlers in `useGitSync.ts` synced on **every** event. Returning to the window — and resizing or moving it, which the Tauri webview surfaces as a `focus` event — re-synced constantly instead of respecting the configured interval.

**Fix:** track the timestamp of the last sync (`lastSyncAtRef`, set whenever any sync starts) and gate the focus/visibility handlers so they only sync when at least `intervalMinutes` (default 30) has elapsed. The periodic timer and the post-edit debounce are untouched and still fire on their own cadence. Side benefit: `focus` + `visibilitychange` both fire on a single return-to-app and now collapse into one sync instead of two.

## 2. Console windows on Windows
git2's `Cred::credential_helper` spawns the OS credential helper (GCM, etc.) as a subprocess with a visible console on Windows — twice per sync (fetch + push) — flashing a terminal window each time. Only affects the no-PAT / system-credentials path.

**Fix:** resolve credentials via `git credential fill` spawned ourselves with `CREATE_NO_WINDOW` (`#[cfg(windows)]`) so it stays invisible, plus `GIT_TERMINAL_PROMPT=0` so git never blocks on an interactive prompt (it just errors and we fall through, exactly like the old path). It still delegates to whatever helper the user has configured. The PAT path is unchanged.

## Tests
- `useGitSync.spec.ts`: added a throttle test (focus within the interval does not sync; focus past it does). 16/16 pass.

## Caveat
The desktop Rust build couldn't run in the sandbox (GTK system libs unavailable — same limitation as #36), so **CI / a Windows desktop build should confirm** `helper_credentials` compiles and that no console window flashes during sync.

https://claude.ai/code/session_01DDxAX6H7X27pSubnX3gHkY

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDxAX6H7X27pSubnX3gHkY)_