### PR TITLE
Add Jam mode: LAN sync of active tab + scroll position

### DIFF
--- a/apps/klank/app/app.tsx
+++ b/apps/klank/app/app.tsx
@@ -10,6 +10,7 @@ import {
 import { Menu } from './components/menu/Menu'
 import { Player } from './components/player/Player'
 import { useGitSync } from './useGitSync'
+import { useJam } from './useJam'
 import { SettingsPanel } from './routes/settings'
 import { HarmonyPanel } from './routes/harmony'
 
@@ -38,6 +39,9 @@ export function App() {
 
   // Background git sync: refresh the file tree when a sync pulls remote changes.
   useGitSync(() => setNeedsUpdate(true))
+
+  // Manage the guest WebSocket lifecycle for Jam mode.
+  useJam()
 
   useEffect(() => {
     setServerMode(!isTauri)

--- a/apps/klank/app/components/player/Player.tsx
+++ b/apps/klank/app/components/player/Player.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import styles from './player.module.css'
 import { Sheet, SheetToolbar, EditIcon } from '@klank/ui'
 import { useKlankStore } from '@klank/store'
+import { createJamHost, type JamHost, type JamSnapshot } from '@klank/platform-api'
 
-type SheetProps = {} & React.ComponentPropsWithRef<'section'>
+type PlayerProps = {} & React.ComponentPropsWithRef<'section'>
 
-export const Player: React.FC<SheetProps> = ({ ...props }) => {
+export const Player: React.FC<PlayerProps> = ({ ...props }) => {
   const setTabFontSize = useKlankStore().setTabFontSize
   const fontSize = useKlankStore().tab.fontSize
   const transpose = useKlankStore().tab.transpose
@@ -24,11 +25,25 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
   const mode = useKlankStore().mode
   const setMode = useKlankStore().setMode
   const instrument = useKlankStore().instrument
+
+  // Jam state
+  const jamRole = useKlankStore((s) => s.jam.role)
+  const jamSnapshot = useKlankStore((s) => s.jam.snapshot)
+  const jamHostAddress = useKlankStore((s) => s.jam.hostAddress)
+
   const [tabData, setTabData] = useState<string | undefined>()
   const [editedContent, setEditedContent] = useState<string>('')
   const [isMobile, setIsMobile] = useState(
     typeof window !== 'undefined' && window.innerWidth <= 599
   )
+
+  // Latest scroll fraction from Sheet — kept in a ref so broadcast doesn't
+  // need to re-subscribe every time the fraction changes.
+  const scrollFractionRef = useRef<number>(0)
+
+  // JamHost instance — created once when the component mounts; the host
+  // server is started/stopped from Settings, here we only use `.broadcast`.
+  const jamHostRef = useRef<JamHost | null>(null)
 
   const activePlaylist = playlists.find((p) => p.id === activePlaylistId)
   const playlistNav = activePlaylist && activePlaylistIndex !== null ? {
@@ -37,6 +52,9 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
     onPrev: prevInPlaylist,
     onNext: nextInPlaylist,
   } : undefined
+
+  // Song name derived the same way the toolbar does.
+  const songName = tabPath?.split(/[/\\]/)?.slice(-1)[0]?.slice(0, -8) ?? ''
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth <= 599)
@@ -51,6 +69,29 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
       setEditedContent(data)
     })
   }, [tabPath, fileService])
+
+  // Acquire (or reuse) the JamHost instance when entering host mode.
+  useEffect(() => {
+    if (jamRole !== 'host') return
+    if (jamHostRef.current) return
+    createJamHost().then((host) => { jamHostRef.current = host })
+  }, [jamRole])
+
+  // Broadcast a snapshot whenever tab content or settings change (host only).
+  useEffect(() => {
+    if (jamRole !== 'host' || !jamHostRef.current) return
+    const snapshot: JamSnapshot = {
+      v: 1,
+      name: songName,
+      content: tabData ?? '',
+      transpose,
+      fontSize,
+      scrollSpeed: tabScrollSpeed,
+      scrolling: isScrolling,
+      fraction: scrollFractionRef.current,
+    }
+    jamHostRef.current.broadcast(snapshot)
+  }, [jamRole, tabData, transpose, fontSize, tabScrollSpeed, isScrolling, songName])
 
   const handleEditToggle = async () => {
     if (mode === 'Edit') {
@@ -67,6 +108,53 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
     }
   }
 
+  // Callback passed to Sheet when hosting — updates the ref and broadcasts.
+  const handleScrollFraction = (fraction: number) => {
+    scrollFractionRef.current = fraction
+    if (!jamHostRef.current) return
+    const snapshot: JamSnapshot = {
+      v: 1,
+      name: songName,
+      content: tabData ?? '',
+      transpose,
+      fontSize,
+      scrollSpeed: tabScrollSpeed,
+      scrolling: isScrolling,
+      fraction,
+    }
+    jamHostRef.current.broadcast(snapshot)
+  }
+
+  // ── Guest render ──────────────────────────────────────────────────────────
+  if (jamRole === 'guest') {
+    const snap = jamSnapshot
+    return (
+      <section className={styles.container} {...props}>
+        <div className={styles.guestHeader}>
+          <span className={styles.guestLabel}>
+            {snap?.name ? snap.name : 'Jam'}
+          </span>
+          <span className={styles.guestStatus}>
+            Following {jamHostAddress}
+          </span>
+        </div>
+        <Sheet
+          tabScrollSpeed={snap?.scrollSpeed ?? 1}
+          isScrolling={false}
+          setTabIsScrolling={() => { /* guests don't own playback */ }}
+          tabData={snap?.content ?? ''}
+          transpose={snap?.transpose ?? 0}
+          instrument={instrument}
+          isMobile={isMobile}
+          scrollFraction={snap?.fraction ?? 0}
+          style={{ fontSize: `${snap?.fontSize ?? 12}px` }}
+        />
+      </section>
+    )
+  }
+
+  // ── Normal (off) + host render ─────────────────────────────────────────────
+  // When hosting the UI is identical; the only addition is onScrollFraction.
   return (
     <section className={styles.container} {...props}>
       {mode === 'Edit' && (
@@ -77,10 +165,7 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
       )}
       <SheetToolbar
         fontSize={fontSize}
-        songName={tabPath
-          ?.split(/[/\\]/)
-          ?.slice(-1)[0]
-          ?.slice(0, -8)}
+        songName={songName}
         transpose={transpose}
         tabScrollSpeed={tabScrollSpeed}
         isScrolling={isScrolling}
@@ -109,9 +194,9 @@ export const Player: React.FC<SheetProps> = ({ ...props }) => {
           instrument={instrument}
           isMobile={isMobile}
           style={{ fontSize: `${fontSize}px` }}
+          onScrollFraction={jamRole === 'host' ? handleScrollFraction : undefined}
         />
       )}
     </section>
   )
 }
-

--- a/apps/klank/app/components/player/Player.tsx
+++ b/apps/klank/app/components/player/Player.tsx
@@ -140,7 +140,7 @@ export const Player: React.FC<PlayerProps> = ({ ...props }) => {
         </div>
         <Sheet
           tabScrollSpeed={snap?.scrollSpeed ?? 1}
-          isScrolling={false}
+          isScrolling={snap?.scrolling ?? false}
           setTabIsScrolling={() => { /* guests don't own playback */ }}
           tabData={snap?.content ?? ''}
           transpose={snap?.transpose ?? 0}

--- a/apps/klank/app/components/player/player.module.css
+++ b/apps/klank/app/components/player/player.module.css
@@ -1,3 +1,29 @@
+/* ── Jam guest header ─────────────────────────────────────────────────────── */
+.guestHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--klank-color-border);
+  background: var(--klank-color-secondary-background);
+  flex-shrink: 0;
+}
+
+.guestLabel {
+  font-weight: 600;
+  font-size: 0.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.guestStatus {
+  font-size: 0.75rem;
+  opacity: 0.6;
+  white-space: nowrap;
+}
+
+/* ── Normal container ──────────────────────────────────────────────────────── */
 .container {
   display: grid;
   grid-template-rows: auto 1fr;

--- a/apps/klank/app/routes/settings.module.css
+++ b/apps/klank/app/routes/settings.module.css
@@ -183,3 +183,25 @@
   }
 }
 
+/* ── Jam mode ─────────────────────────────────────────────────────────────── */
+
+.jamStatus {
+  font-size: 0.875rem;
+  font-weight: 600;
+  flex: 1;
+}
+
+/* Stacks multiple share URLs with a copy button each */
+.jamUrls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.jamUrlRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -1,6 +1,6 @@
 import styles from './settings.module.css'
 import { useEffect, useRef, useState } from 'react'
-import { createGitService, getAppVersion, isMobileDevice, type BranchInfo, type GitService } from '@klank/platform-api'
+import { createGitService, createJamHost, getAppVersion, isMobileDevice, type BranchInfo, type GitService, type JamHost } from '@klank/platform-api'
 import { useKlankStore, type SyncStatus } from '@klank/store'
 import { runGitSync } from '../useGitSync'
 
@@ -65,6 +65,57 @@ export function SettingsPanel() {
   const syncSettings = useKlankStore().syncSettings
   const setSyncSettings = useKlankStore().setSyncSettings
   const syncStatus = useKlankStore().syncStatus
+
+  // Jam store slice
+  const jamRole = useKlankStore((s) => s.jam.role)
+  const jamUrls = useKlankStore((s) => s.jam.urls)
+  const jamConnected = useKlankStore((s) => s.jam.connected)
+  const jamHostAddress = useKlankStore((s) => s.jam.hostAddress)
+  const setJamHosting = useKlankStore((s) => s.setJamHosting)
+  const setJamGuest = useKlankStore((s) => s.setJamGuest)
+  const setJamOff = useKlankStore((s) => s.setJamOff)
+
+  // Single JamHost instance shared across host actions in this panel.
+  const jamHostRef = useRef<JamHost | null>(null)
+  const [joinAddress, setJoinAddress] = useState('')
+  const [jamBusy, setJamBusy] = useState(false)
+
+  const getOrCreateJamHost = async (): Promise<JamHost> => {
+    if (!jamHostRef.current) {
+      jamHostRef.current = await createJamHost()
+    }
+    return jamHostRef.current
+  }
+
+  const handleStartHosting = async () => {
+    if (jamBusy) return
+    setJamBusy(true)
+    try {
+      const host = await getOrCreateJamHost()
+      const info = await host.start()
+      setJamHosting(info)
+    } finally {
+      setJamBusy(false)
+    }
+  }
+
+  const handleStopHosting = async () => {
+    if (jamBusy) return
+    setJamBusy(true)
+    try {
+      const host = await getOrCreateJamHost()
+      await host.stop()
+      setJamOff()
+    } finally {
+      setJamBusy(false)
+    }
+  }
+
+  const handleJoinJam = () => {
+    const addr = joinAddress.trim()
+    if (!addr) return
+    setJamGuest(addr)
+  }
 
   const gitRef = useRef<GitService | null>(null)
   const [isRepo, setIsRepo] = useState<boolean | null>(null)
@@ -433,6 +484,85 @@ export function SettingsPanel() {
                 </div>
               )}
             </>
+          )}
+        </section>
+        {/* ── Jam mode ──────────────────────────────────────────────────── */}
+        <section className={styles.section}>
+          <h2>Jam mode</h2>
+
+          {jamRole === 'off' && (
+            <>
+              <div className={styles.row}>
+                <span className={styles.label}>Host</span>
+                <button className={styles.button} onClick={handleStartHosting} disabled={jamBusy}>
+                  Host a jam
+                </button>
+              </div>
+              <div className={styles.row}>
+                <span className={styles.label}>Join</span>
+                <input
+                  className={styles.commitInput}
+                  type="text"
+                  placeholder="192.168.1.5:7070"
+                  value={joinAddress}
+                  onChange={(e) => setJoinAddress(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleJoinJam()}
+                  aria-label="Host address"
+                />
+                <button
+                  className={styles.button}
+                  onClick={handleJoinJam}
+                  disabled={!joinAddress.trim()}
+                >
+                  Join
+                </button>
+              </div>
+            </>
+          )}
+
+          {jamRole === 'host' && (
+            <>
+              <div className={styles.row}>
+                <span className={styles.label}>Status</span>
+                <span className={styles.jamStatus}>Hosting</span>
+                <button className={styles.button} onClick={handleStopHosting} disabled={jamBusy}>
+                  Stop hosting
+                </button>
+              </div>
+              {jamUrls.length > 0 && (
+                <div className={styles.row}>
+                  <span className={styles.label}>Share</span>
+                  <div className={styles.jamUrls}>
+                    {jamUrls.map((url) => (
+                      <div key={url} className={styles.jamUrlRow}>
+                        <span className={styles.dirPath} title={url}>{url}</span>
+                        <button
+                          className={styles.button}
+                          onClick={() => navigator.clipboard?.writeText(url)}
+                          aria-label={`Copy ${url}`}
+                        >
+                          Copy
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <span className={styles.infoMessage}>
+                Others on your network can open these URLs in a browser, or join with the app using the ip:port.
+              </span>
+            </>
+          )}
+
+          {jamRole === 'guest' && (
+            <div className={styles.row}>
+              <span className={styles.label}>
+                {jamConnected ? `Connected to ${jamHostAddress}` : `Connecting to ${jamHostAddress}…`}
+              </span>
+              <button className={styles.button} onClick={setJamOff}>
+                Leave
+              </button>
+            </div>
           )}
         </section>
       </div>

--- a/apps/klank/app/useJam.ts
+++ b/apps/klank/app/useJam.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+import { useKlankStore } from '@klank/store'
+import { connectJam, type JamConnection } from '@klank/platform-api'
+
+/**
+ * Manages the guest WebSocket lifecycle.
+ *
+ * - When role === 'guest' and hostAddress is set, opens a WebSocket connection
+ *   via connectJam and pipes snapshots + connection status into the store.
+ * - Switches activeView to 'tab' on becoming a guest so the Sheet is visible.
+ * - Closes the connection on cleanup or when leaving guest mode.
+ *
+ * Mount this hook once in App — it has no UI of its own.
+ */
+export function useJam(): void {
+  const role = useKlankStore((s) => s.jam.role)
+  const hostAddress = useKlankStore((s) => s.jam.hostAddress)
+  const setJamSnapshot = useKlankStore((s) => s.setJamSnapshot)
+  const setJamConnected = useKlankStore((s) => s.setJamConnected)
+  const setActiveView = useKlankStore((s) => s.setActiveView)
+
+  // Stable ref so the effect closure always holds the current connection.
+  const connectionRef = useRef<JamConnection | null>(null)
+
+  useEffect(() => {
+    if (role !== 'guest' || !hostAddress) return
+
+    // Show the tab sheet while connected as a guest.
+    setActiveView('tab')
+
+    const connection = connectJam(hostAddress, {
+      onSnapshot: setJamSnapshot,
+      onStatus: setJamConnected,
+    })
+    connectionRef.current = connection
+
+    return () => {
+      connection.close()
+      connectionRef.current = null
+    }
+  }, [role, hostAddress, setJamSnapshot, setJamConnected, setActiveView])
+}

--- a/apps/klank/src-tauri/Cargo.lock
+++ b/apps/klank/src-tauri/Cargo.lock
@@ -7,6 +7,7 @@ name = "Klank"
 version = "2.0.0"
 dependencies = [
  "async-trait",
+ "axum",
  "chrono",
  "git2",
  "html-escape",
@@ -162,6 +163,59 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -702,6 +756,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-url"
@@ -1572,6 +1632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1651,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2083,6 +2150,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md5"
@@ -3490,6 +3563,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,6 +4342,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,6 +4582,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/apps/klank/src-tauri/Cargo.toml
+++ b/apps/klank/src-tauri/Cargo.toml
@@ -22,7 +22,8 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.11.2", features = [] }
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { version = "1", features = ["sync", "time", "net", "rt-multi-thread", "io-util"] }
+axum = { version = "0.7", default-features = false, features = ["ws", "http1", "tokio"] }
 tauri-plugin-log = "2.0.0"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2.0"

--- a/apps/klank/src-tauri/capabilities/default.json
+++ b/apps/klank/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "dialog:default",
     "allow-scrape-ug",
     "allow-git",
+    "allow-jam",
     {
       "identifier": "fs:read-all",
       "allow": [

--- a/apps/klank/src-tauri/gen/android/app/build.gradle.kts
+++ b/apps/klank/src-tauri/gen/android/app/build.gradle.kts
@@ -35,6 +35,11 @@ android {
             // `tauri:android:dev` incremental builds are unaffected.
         }
         getByName("release") {
+            // Jam mode connects a guest WebView to the host over plain ws:// on a
+            // bare LAN IP, which has no TLS cert — so cleartext must be permitted
+            // even in release. The app makes no other cleartext requests (UG
+            // scraping is HTTPS), so the exposure is limited to LAN jam traffic.
+            manifestPlaceholders["usesCleartextTraffic"] = "true"
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(

--- a/apps/klank/src-tauri/permissions/allow-jam.toml
+++ b/apps/klank/src-tauri/permissions/allow-jam.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-jam"
+description = "Allows the main window to use the Jam mode LAN-sync commands."
+commands.allow = [
+  "jam_start",
+  "jam_stop",
+  "jam_broadcast",
+  "jam_status",
+]

--- a/apps/klank/src-tauri/src/jam-lite.html
+++ b/apps/klank/src-tauri/src/jam-lite.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Klank Jam</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; background: #111; color: #e8e8e8; font-family: ui-monospace, 'Cascadia Code', 'Fira Mono', monospace; }
+  #header {
+    position: fixed; top: 0; left: 0; right: 0;
+    display: flex; align-items: center; gap: 10px;
+    padding: 8px 16px;
+    background: #1a1a1a; border-bottom: 1px solid #333;
+    z-index: 10; font-size: 13px; line-height: 1;
+  }
+  #dot {
+    width: 8px; height: 8px; border-radius: 50%; background: #555; flex-shrink: 0;
+    transition: background 0.3s;
+  }
+  #dot.connected { background: #4caf50; }
+  #dot.reconnecting { background: #f59e0b; }
+  #name { font-weight: 600; color: #ddd; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #sheet {
+    position: absolute; top: 36px; left: 0; right: 0; bottom: 0;
+    overflow-y: auto; overflow-x: auto;
+    padding: 20px 24px 40px;
+  }
+  pre {
+    white-space: pre; line-height: 1.55; tab-size: 4;
+    color: #e8e8e8; font-family: inherit;
+    margin: 0;
+  }
+</style>
+</head>
+<body>
+<div id="header">
+  <div id="dot"></div>
+  <span id="name">Klank Jam</span>
+</div>
+<div id="sheet"><pre id="content"></pre></div>
+<script>
+(function () {
+  var dot = document.getElementById('dot');
+  var nameEl = document.getElementById('name');
+  var pre = document.getElementById('content');
+  var sheet = document.getElementById('sheet');
+  var ws = null;
+  var closed = false;
+  var delay = 1000;
+  var reconnectTimer = null;
+  var lastContent = null;
+
+  function setStatus(st) {
+    dot.className = st;
+  }
+
+  function applySnapshot(s) {
+    if (s.name) nameEl.textContent = s.name;
+    // Only rewrite the text node when content actually changes — snapshots
+    // stream ~15/sec during scroll, and reflowing a large tab each time janks.
+    if (typeof s.content === 'string' && s.content !== lastContent) {
+      pre.textContent = s.content;
+      lastContent = s.content;
+    }
+    var fs = Math.max(10, s.fontSize || 14);
+    pre.style.fontSize = fs + 'px';
+    if (typeof s.fraction === 'number') {
+      var el = sheet;
+      var scrollable = el.scrollHeight - el.clientHeight;
+      if (scrollable > 0) el.scrollTop = s.fraction * scrollable;
+    }
+  }
+
+  function connect() {
+    if (closed) return;
+    ws = new WebSocket('ws://' + location.host + '/jam');
+    ws.onopen = function () {
+      setStatus('connected');
+      delay = 1000;
+    };
+    ws.onmessage = function (evt) {
+      try { applySnapshot(JSON.parse(evt.data)); } catch (_) {}
+    };
+    ws.onclose = function () {
+      setStatus('reconnecting');
+      if (!closed) reconnectTimer = setTimeout(connect, delay = Math.min(delay * 2, 5000));
+    };
+    ws.onerror = function () {
+      ws.close();
+    };
+  }
+
+  connect();
+})();
+</script>
+</body>
+</html>

--- a/apps/klank/src-tauri/src/jam.rs
+++ b/apps/klank/src-tauri/src/jam.rs
@@ -1,0 +1,224 @@
+//! Jam mode: host shares tab content + scroll state over a local LAN WebSocket
+//! server; guests (app or browser) subscribe and receive live snapshots.
+//!
+//! The axum HTTP+WS server runs on a background tokio task. A `watch` channel
+//! holds the latest snapshot JSON so new subscribers receive it immediately.
+
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    response::{Html, IntoResponse},
+    routing::get,
+    Router,
+};
+use serde::Serialize;
+use std::net::SocketAddr;
+use std::sync::Mutex;
+use tokio::sync::{oneshot, watch};
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+/// Shared state managed by Tauri (.manage()).
+pub struct JamState {
+    /// The latest snapshot JSON broadcast by the host.
+    pub tx: watch::Sender<String>,
+    /// Running server info; None when stopped.
+    inner: Mutex<Option<RunningServer>>,
+}
+
+struct RunningServer {
+    port: u16,
+    urls: Vec<String>,
+    /// Dropping / sending on this kills the axum server.
+    shutdown: oneshot::Sender<()>,
+}
+
+impl Default for JamState {
+    fn default() -> Self {
+        let (tx, _) = watch::channel("{}".to_string());
+        Self {
+            tx,
+            inner: Mutex::new(None),
+        }
+    }
+}
+
+// ── Return types ──────────────────────────────────────────────────────────────
+
+#[derive(Serialize, Clone)]
+pub struct JamInfo {
+    pub port: u16,
+    pub urls: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct JamStatus {
+    pub hosting: bool,
+    pub port: Option<u16>,
+    pub urls: Vec<String>,
+}
+
+// ── LAN IP detection ─────────────────────────────────────────────────────────
+
+fn lan_ip() -> Option<std::net::IpAddr> {
+    let s = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    s.connect("8.8.8.8:80").ok()?;
+    Some(s.local_addr().ok()?.ip())
+}
+
+// ── axum app ─────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct AppState {
+    tx: watch::Sender<String>,
+}
+
+async fn root_handler() -> impl IntoResponse {
+    Html(include_str!("jam-lite.html"))
+}
+
+async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, state.tx))
+}
+
+async fn handle_socket(mut socket: WebSocket, tx: watch::Sender<String>) {
+    let mut rx = tx.subscribe();
+
+    // Send current snapshot immediately.
+    let current = rx.borrow().clone();
+    if socket.send(Message::Text(current.into())).await.is_err() {
+        return;
+    }
+
+    loop {
+        tokio::select! {
+            // New snapshot from host.
+            changed = rx.changed() => {
+                if changed.is_err() { break; }
+                let snapshot = rx.borrow().clone();
+                if socket.send(Message::Text(snapshot.into())).await.is_err() {
+                    break;
+                }
+            }
+            // Drain inbound messages; detect close.
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(_)) => {} // ignore
+                    _ => break,
+                }
+            }
+        }
+    }
+}
+
+fn build_router(tx: watch::Sender<String>) -> Router {
+    let state = AppState { tx };
+    Router::new()
+        .route("/", get(root_handler))
+        .route("/jam", get(ws_handler))
+        .with_state(state)
+}
+
+// ── Tauri commands ────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn jam_start(
+    state: tauri::State<'_, JamState>,
+) -> Result<JamInfo, String> {
+    // Stop any existing server first (idempotent).
+    jam_stop_inner(&state);
+
+    // Bind listener — prefer 7070, fall back to OS-assigned.
+    let listener = match tokio::net::TcpListener::bind("0.0.0.0:7070").await {
+        Ok(l) => l,
+        Err(_) => tokio::net::TcpListener::bind("0.0.0.0:0")
+            .await
+            .map_err(|e| format!("Failed to bind: {e}"))?,
+    };
+
+    let addr: SocketAddr = listener.local_addr().map_err(|e| e.to_string())?;
+    let port = addr.port();
+
+    let urls = match lan_ip() {
+        Some(ip) => vec![format!("http://{}:{}", ip, port)],
+        None => vec![],
+    };
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let router = build_router(state.tx.clone());
+
+    tauri::async_runtime::spawn(async move {
+        let _ = axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+
+    let info = JamInfo {
+        port,
+        urls: urls.clone(),
+    };
+
+    {
+        let mut guard = state.inner.lock().map_err(|e| e.to_string())?;
+        *guard = Some(RunningServer {
+            port,
+            urls,
+            shutdown: shutdown_tx,
+        });
+    }
+
+    Ok(info)
+}
+
+fn jam_stop_inner(state: &tauri::State<'_, JamState>) {
+    if let Ok(mut guard) = state.inner.lock() {
+        if let Some(server) = guard.take() {
+            // Sending triggers graceful shutdown; ignore errors (already gone).
+            let _ = server.shutdown.send(());
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn jam_stop(state: tauri::State<'_, JamState>) -> Result<(), String> {
+    jam_stop_inner(&state);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn jam_broadcast(
+    state: tauri::State<'_, JamState>,
+    snapshot: String,
+) -> Result<(), String> {
+    // Ignore send errors (no active receivers is fine).
+    let _ = state.tx.send(snapshot);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn jam_status(state: tauri::State<'_, JamState>) -> JamStatus {
+    match state.inner.lock() {
+        Ok(guard) => match guard.as_ref() {
+            Some(s) => JamStatus {
+                hosting: true,
+                port: Some(s.port),
+                urls: s.urls.clone(),
+            },
+            None => JamStatus {
+                hosting: false,
+                port: None,
+                urls: vec![],
+            },
+        },
+        Err(_) => JamStatus {
+            hosting: false,
+            port: None,
+            urls: vec![],
+        },
+    }
+}

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 //! the [`import`] module).
 mod git;
 mod import;
+mod jam;
 
 use import::ImportProgress;
 use tauri::ipc::Channel;
@@ -27,7 +28,8 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_ug_scraper::init());
+        .plugin(tauri_plugin_ug_scraper::init())
+        .manage(jam::JamState::default());
 
     // The hidden-webview import stage (and its IPC) is desktop-only; Android
     // uses the mobile API / website stages and (next) a dedicated plugin. Git
@@ -54,7 +56,11 @@ pub fn run() {
             git::git_is_authenticated,
             git::git_system_credentials_enabled,
             git::git_use_system_credentials,
-            git::git_disable_system_credentials
+            git::git_disable_system_credentials,
+            jam::jam_start,
+            jam::jam_stop,
+            jam::jam_broadcast,
+            jam::jam_status
         ]);
     #[cfg(not(desktop))]
     let builder = builder.invoke_handler(tauri::generate_handler![
@@ -74,7 +80,11 @@ pub fn run() {
         git::git_is_authenticated,
         git::git_system_credentials_enabled,
         git::git_use_system_credentials,
-        git::git_disable_system_credentials
+        git::git_disable_system_credentials,
+        jam::jam_start,
+        jam::jam_stop,
+        jam::jam_broadcast,
+        jam::jam_status
     ]);
 
     builder

--- a/apps/klank/src-tauri/tauri.conf.json
+++ b/apps/klank/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost; connect-src 'self' ws: wss: http:"
     }
   },
   "bundle": {

--- a/libs/platform-api/src/index.ts
+++ b/libs/platform-api/src/index.ts
@@ -10,3 +10,4 @@ export * from './lib/sheet-lines';
 export * from './lib/userAgent';
 export * from './lib/download';
 export * from './lib/app';
+export * from './lib/jam';

--- a/libs/platform-api/src/lib/fs.spec.ts
+++ b/libs/platform-api/src/lib/fs.spec.ts
@@ -427,3 +427,48 @@ describe('tab-setting writes preserve playlists', () => {
     expect(written['playlists']).toEqual([stored])
   })
 })
+
+describe('readDirectoryRecursively', () => {
+  const readDir = pluginFs.readDir as Mock
+  const tabFilter = (f: { isDirectory: boolean; name: string }) =>
+    f.isDirectory || f.name.endsWith('.tab.txt')
+  const file = (name: string) => ({ name, isDirectory: false, isFile: true, isSymlink: false })
+  const folder = (name: string) => ({ name, isDirectory: true, isFile: false, isSymlink: false })
+
+  beforeEach(() => vi.clearAllMocks())
+
+  // On mobile the base dir is the app sandbox root, which also holds the WebView
+  // profile + caches. Descending into those is what used to throw and empty the
+  // tree, so they must be skipped entirely.
+  it('skips app-internal directories (app_webview/cache/...) instead of scanning them', async () => {
+    readDir.mockImplementation(async (dir: string) => {
+      if (dir === '/data/app') return [file('A - Song.tab.txt'), folder('cache'), folder('app_webview'), folder('set')]
+      if (dir === '/data/app/set') return [file('B - Song.tab.txt')]
+      throw new Error(`unexpected readDir into ${dir}`)
+    })
+    const service = await getService()
+
+    const tree = JSON.stringify(await service.readDirectoryRecursively('/data/app', tabFilter))
+
+    expect(tree).toContain('A - Song.tab.txt')
+    expect(tree).toContain('B - Song.tab.txt')
+    expect(readDir).not.toHaveBeenCalledWith('/data/app/cache')
+    expect(readDir).not.toHaveBeenCalledWith('/data/app/app_webview')
+  })
+
+  // The actual bug: one unreadable subdir rejected the whole scan → empty tree.
+  it('skips an unreadable subdirectory instead of failing the whole scan', async () => {
+    readDir.mockImplementation(async (dir: string) => {
+      if (dir === '/data/app') return [file('A - Song.tab.txt'), folder('broken'), folder('set')]
+      if (dir === '/data/app/broken') throw new Error('EACCES')
+      if (dir === '/data/app/set') return [file('B - Song.tab.txt')]
+      return []
+    })
+    const service = await getService()
+
+    const tree = JSON.stringify(await service.readDirectoryRecursively('/data/app', tabFilter))
+
+    expect(tree).toContain('A - Song.tab.txt')
+    expect(tree).toContain('B - Song.tab.txt')
+  })
+})

--- a/libs/platform-api/src/lib/fs.ts
+++ b/libs/platform-api/src/lib/fs.ts
@@ -171,7 +171,7 @@ type LegacyKlankEntry = {
 }
 
 const createTauriFileService = async (): Promise<FileService> => {
-  const { BaseDirectory, readDir, readTextFile, writeTextFile, create, exists, remove } = await import(
+  const { readDir, readTextFile, writeTextFile, create, exists, remove } = await import(
     '@tauri-apps/plugin-fs'
   )
   const { appLocalDataDir, join } = await import('@tauri-apps/api/path')
@@ -204,32 +204,44 @@ const createTauriFileService = async (): Promise<FileService> => {
     settingsFileLock = run.catch(() => undefined)
     return run
   }
+  // On mobile the tab directory is the app's private data root, which also holds
+  // the WebView profile, HTTP/code caches, prefs, logs, etc. Tabs live alongside
+  // these, so the scan must NOT descend into them: the Chromium cache tree is
+  // huge and, on some devices, a `readDir` inside it throws — which used to
+  // reject the whole scan and leave the file tree empty after the cache grew
+  // (a relaunch-only, device-specific failure). A user-chosen tab folder on
+  // desktop never contains these names, so skipping them is a no-op there.
+  const INTERNAL_DIRS = new Set([
+    'app_webview', 'cache', 'code_cache', 'shared_prefs',
+    'no_backup', 'logs', 'app_textures', 'files',
+  ])
+
   const processEntriesRecursively = async (
     parent: string,
     entries: FileTree,
     filter: (name: File) => boolean
   ): Promise<FileTree> => {
+    const kept = entries.filter(
+      (file) =>
+        filter(file) &&
+        !(file.isDirectory && (INTERNAL_DIRS.has(file.name) || file.name.startsWith('.')))
+    )
     return Promise.all(
-      entries
-        .filter((file) => filter(file))
-        .flatMap(async (entry) => {
-          const dir = await join(parent, entry.name)
-          if (entry.isDirectory) {
-            return {
-              ...entry,
-              path: dir,
-              children: await processEntriesRecursively(
-                dir,
-                await readDir(dir, { baseDir: BaseDirectory.AppLocalData }),
-                filter
-              ),
-            }
+      kept.map(async (entry) => {
+        const dir = await join(parent, entry.name)
+        if (entry.isDirectory) {
+          // A subdirectory we can't read must never fail the whole scan — skip
+          // it (no children) so every other tab still loads.
+          let children: FileTree = []
+          try {
+            children = await processEntriesRecursively(dir, await readDir(dir), filter)
+          } catch {
+            children = []
           }
-          return {
-            ...entry,
-            path: dir,
-          }
-        })
+          return { ...entry, path: dir, children }
+        }
+        return { ...entry, path: dir }
+      })
     )
   }
 

--- a/libs/platform-api/src/lib/jam.spec.ts
+++ b/libs/platform-api/src/lib/jam.spec.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+
+// createJamHost calls invoke from @tauri-apps/api/core; mock it before import.
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+
+import { invoke } from '@tauri-apps/api/core'
+import { connectJam, createJamHost, type JamSnapshot } from './jam.js'
+
+const invokeMock = invoke as Mock
+
+const snapshot = (overrides: Partial<JamSnapshot> = {}): JamSnapshot => ({
+  v: 1,
+  name: 'Song',
+  content: 'tab',
+  transpose: 0,
+  fontSize: 12,
+  scrollSpeed: 1,
+  scrolling: false,
+  fraction: 0,
+  ...overrides,
+})
+
+describe('createJamHost', () => {
+  beforeEach(() => invokeMock.mockReset())
+
+  it('start invokes jam_start and returns the host info', async () => {
+    invokeMock.mockResolvedValue({ port: 7070, urls: ['http://x:7070'] })
+    const host = await createJamHost()
+    expect(await host.start()).toEqual({ port: 7070, urls: ['http://x:7070'] })
+    expect(invokeMock).toHaveBeenCalledWith('jam_start')
+  })
+
+  it('stop invokes jam_stop', async () => {
+    invokeMock.mockResolvedValue(undefined)
+    await (await createJamHost()).stop()
+    expect(invokeMock).toHaveBeenCalledWith('jam_stop')
+  })
+
+  it('broadcast sends the snapshot as a JSON string argument', async () => {
+    invokeMock.mockResolvedValue(undefined)
+    const s = snapshot({ fraction: 0.5, transpose: 3 })
+    await (await createJamHost()).broadcast(s)
+    expect(invokeMock).toHaveBeenCalledWith('jam_broadcast', { snapshot: JSON.stringify(s) })
+  })
+
+  it('status invokes jam_status and passes the result through', async () => {
+    invokeMock.mockResolvedValue({ hosting: true, port: 7070, urls: [] })
+    expect(await (await createJamHost()).status()).toEqual({ hosting: true, port: 7070, urls: [] })
+    expect(invokeMock).toHaveBeenCalledWith('jam_status')
+  })
+})
+
+// Minimal controllable WebSocket double — handlers are fired explicitly so the
+// reconnect timing is deterministic under fake timers.
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  url: string
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  close = vi.fn()
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+}
+
+describe('connectJam', () => {
+  let originalWS: typeof globalThis.WebSocket
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    originalWS = globalThis.WebSocket
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket)
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.stubGlobal('WebSocket', originalWS)
+  })
+
+  it('opens ws://<address>/jam', () => {
+    connectJam('192.168.1.5:7070', { onSnapshot: vi.fn() })
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(FakeWebSocket.instances[0].url).toBe('ws://192.168.1.5:7070/jam')
+  })
+
+  it('reports connected on open and parses snapshot frames', () => {
+    const onSnapshot = vi.fn()
+    const onStatus = vi.fn()
+    connectJam('host:7070', { onSnapshot, onStatus })
+    const ws = FakeWebSocket.instances[0]
+    ws.onopen?.()
+    expect(onStatus).toHaveBeenCalledWith(true)
+    const s = snapshot({ fraction: 0.25 })
+    ws.onmessage?.({ data: JSON.stringify(s) })
+    expect(onSnapshot).toHaveBeenCalledWith(s)
+  })
+
+  it('ignores malformed frames', () => {
+    const onSnapshot = vi.fn()
+    connectJam('host:7070', { onSnapshot })
+    FakeWebSocket.instances[0].onmessage?.({ data: 'not-json{' })
+    expect(onSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('reconnects after an unexpected close', () => {
+    const onStatus = vi.fn()
+    connectJam('host:7070', { onSnapshot: vi.fn(), onStatus })
+    FakeWebSocket.instances[0].onclose?.()
+    expect(onStatus).toHaveBeenCalledWith(false)
+    vi.advanceTimersByTime(1000)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+  })
+
+  it('close() stops reconnection', () => {
+    const conn = connectJam('host:7070', { onSnapshot: vi.fn() })
+    conn.close()
+    expect(FakeWebSocket.instances[0].close).toHaveBeenCalled()
+    // A late socket-close after close() must not schedule a new connection.
+    FakeWebSocket.instances[0].onclose?.()
+    vi.advanceTimersByTime(10000)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+})

--- a/libs/platform-api/src/lib/jam.ts
+++ b/libs/platform-api/src/lib/jam.ts
@@ -1,0 +1,100 @@
+import { invoke } from '@tauri-apps/api/core'
+
+export type JamSnapshot = {
+  v: 1
+  name: string
+  content: string
+  transpose: number
+  fontSize: number
+  scrollSpeed: number
+  scrolling: boolean
+  fraction: number // 0..1 normalized scroll position
+}
+
+export type JamInfo = { port: number; urls: string[] }
+
+export type JamStatus = { hosting: boolean; port: number | null; urls: string[] }
+
+export type JamHost = {
+  start: () => Promise<JamInfo>
+  stop: () => Promise<void>
+  broadcast: (snapshot: JamSnapshot) => Promise<void>
+  status: () => Promise<JamStatus>
+}
+
+export const createJamHost = async (): Promise<JamHost> => ({
+  start: () => invoke<JamInfo>('jam_start'),
+  stop: () => invoke<void>('jam_stop'),
+  broadcast: (snapshot: JamSnapshot) =>
+    invoke<void>('jam_broadcast', { snapshot: JSON.stringify(snapshot) }),
+  status: () => invoke<JamStatus>('jam_status'),
+})
+
+// ── Guest / client side ───────────────────────────────────────────────────────
+
+export type JamClientHandlers = {
+  onSnapshot: (s: JamSnapshot) => void
+  onStatus?: (connected: boolean) => void
+}
+
+export type JamConnection = { close: () => void }
+
+/**
+ * Connect to a Jam host as a guest. Works in both the Tauri webview and plain
+ * browsers. `address` is `host:port` e.g. `"192.168.1.5:7070"`.
+ *
+ * Auto-reconnects with exponential backoff (1 s → 5 s cap) until `close()` is
+ * called.
+ */
+export const connectJam = (
+  address: string,
+  handlers: JamClientHandlers,
+): JamConnection => {
+  let stopped = false
+  let ws: WebSocket | null = null
+  let delay = 1000
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  function connect() {
+    if (stopped) return
+    ws = new WebSocket(`ws://${address}/jam`)
+
+    ws.onopen = () => {
+      delay = 1000
+      handlers.onStatus?.(true)
+    }
+
+    ws.onmessage = (evt) => {
+      try {
+        const snapshot = JSON.parse(evt.data as string) as JamSnapshot
+        handlers.onSnapshot(snapshot)
+      } catch {
+        // ignore malformed frames
+      }
+    }
+
+    ws.onclose = () => {
+      handlers.onStatus?.(false)
+      if (!stopped) {
+        timer = setTimeout(() => {
+          delay = Math.min(delay * 2, 5000)
+          connect()
+        }, delay)
+      }
+    }
+
+    ws.onerror = () => {
+      ws?.close()
+    }
+  }
+
+  connect()
+
+  return {
+    close() {
+      stopped = true
+      if (timer !== null) clearTimeout(timer)
+      ws?.close()
+    },
+  }
+}

--- a/libs/store/src/lib/jam.spec.ts
+++ b/libs/store/src/lib/jam.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub localStorage before store import — the persist middleware reads it on init.
+const localStorageData: Record<string, string> = {}
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn((key: string) => localStorageData[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { localStorageData[key] = value }),
+  removeItem: vi.fn((key: string) => { delete localStorageData[key] }),
+  clear: vi.fn(() => { Object.keys(localStorageData).forEach((k) => delete localStorageData[k]) }),
+  length: 0,
+  key: vi.fn(() => null),
+})
+
+import { useKlankStore, type JamSnapshot } from './store.js'
+
+const snapshot = (overrides: Partial<JamSnapshot> = {}): JamSnapshot => ({
+  v: 1,
+  name: 'Song',
+  content: 'A C G',
+  transpose: 0,
+  fontSize: 12,
+  scrollSpeed: 1,
+  scrolling: false,
+  fraction: 0,
+  ...overrides,
+})
+
+const OFF = { role: 'off', port: null, urls: [], hostAddress: '', connected: false, snapshot: null }
+
+describe('jam store slice', () => {
+  beforeEach(() => useKlankStore.getState().setJamOff())
+
+  it('defaults to off', () => {
+    expect(useKlankStore.getState().jam).toEqual(OFF)
+  })
+
+  it('setJamHosting → host role carrying port + urls', () => {
+    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://192.168.1.5:7070'] })
+    const { jam } = useKlankStore.getState()
+    expect(jam.role).toBe('host')
+    expect(jam.port).toBe(7070)
+    expect(jam.urls).toEqual(['http://192.168.1.5:7070'])
+  })
+
+  it('setJamGuest → guest role and clears any prior connection/snapshot', () => {
+    useKlankStore.getState().setJamSnapshot(snapshot())
+    useKlankStore.getState().setJamConnected(true)
+    useKlankStore.getState().setJamGuest('192.168.1.5:7070')
+    const { jam } = useKlankStore.getState()
+    expect(jam.role).toBe('guest')
+    expect(jam.hostAddress).toBe('192.168.1.5:7070')
+    expect(jam.connected).toBe(false)
+    expect(jam.snapshot).toBeNull()
+  })
+
+  it('setJamConnected toggles connection without changing role', () => {
+    useKlankStore.getState().setJamGuest('host:7070')
+    useKlankStore.getState().setJamConnected(true)
+    expect(useKlankStore.getState().jam.connected).toBe(true)
+    expect(useKlankStore.getState().jam.role).toBe('guest')
+  })
+
+  it('setJamSnapshot stores the latest snapshot verbatim', () => {
+    const s = snapshot({ fraction: 0.42, name: 'Wish You Were Here', transpose: -2 })
+    useKlankStore.getState().setJamSnapshot(s)
+    expect(useKlankStore.getState().jam.snapshot).toEqual(s)
+  })
+
+  it('setJamOff fully resets from host', () => {
+    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://x:7070'] })
+    useKlankStore.getState().setJamOff()
+    expect(useKlankStore.getState().jam).toEqual(OFF)
+  })
+
+  it('setJamOff fully resets from guest', () => {
+    useKlankStore.getState().setJamGuest('host:7070')
+    useKlankStore.getState().setJamConnected(true)
+    useKlankStore.getState().setJamSnapshot(snapshot())
+    useKlankStore.getState().setJamOff()
+    expect(useKlankStore.getState().jam).toEqual(OFF)
+  })
+})

--- a/libs/store/src/lib/store-persistence.spec.ts
+++ b/libs/store/src/lib/store-persistence.spec.ts
@@ -66,6 +66,18 @@ describe('klank-storage migration and shape', () => {
     expect(parsed.state).toHaveProperty('customTunings')
   })
 
+  it('never persists the ephemeral jam slice', async () => {
+    const { useKlankStore } = await import('./store.js')
+
+    // Enter host mode (and force a persisted write so the entry is fresh).
+    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://192.168.50.50:7070'] })
+    useKlankStore.getState().setTheme('Dark')
+
+    const parsed = JSON.parse(localStorageData['klank-storage']) as { state: Record<string, unknown> }
+    expect(parsed.state).not.toHaveProperty('jam')
+    expect(JSON.stringify(parsed)).not.toContain('192.168.50.50')
+  })
+
   it('migrate fills in default sync settings for older persisted state', async () => {
     const { useKlankStore } = await import('./store.js')
     const { syncSettings } = useKlankStore.getState()

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -1,10 +1,32 @@
 import {create} from 'zustand'
 import {devtools, persist} from 'zustand/middleware'
 import type {} from '@redux-devtools/extension'
-import { FileService, PerTabSettings, type Instrument, type Playlist, type SyncErrorKind } from '@klank/platform-api'
+import { FileService, PerTabSettings, type Instrument, type JamSnapshot, type Playlist, type SyncErrorKind } from '@klank/platform-api'
 import type { CustomTuning } from '@klank/audio'
 
-export type { Instrument, Playlist, CustomTuning }
+// JamSnapshot is defined once in @klank/platform-api; re-exported here so jam
+// consumers can import it alongside the store.
+export type { Instrument, Playlist, CustomTuning, JamSnapshot }
+
+/** Whether this client is currently hosting, following as a guest, or off. */
+export type JamRole = 'off' | 'host' | 'guest'
+
+/**
+ * Ephemeral jam state — NOT persisted (excluded from `partialize`).
+ * Resets to defaults on every app launch.
+ */
+export type JamState = {
+  role: JamRole
+  // host
+  port: number | null
+  urls: string[]
+  // guest
+  /** "ip:port" string the user typed, e.g. "192.168.1.5:7070". */
+  hostAddress: string
+  connected: boolean
+  /** Latest snapshot received from the host (guest only). */
+  snapshot: JamSnapshot | null
+}
 
 export type Mode = "Read" | "Edit"
 export type Theme = "Light" | "Dark"
@@ -182,6 +204,21 @@ type KlankState = {
   customTunings: CustomTuning[]
   addCustomTuning: (tuning: CustomTuning) => void
   deleteCustomTuning: (id: string) => void
+  /**
+   * Ephemeral jam state. Not persisted — excluded from `partialize`.
+   * Use setters below to transition between roles.
+   */
+  jam: JamState
+  /** Called when this client becomes the host after jam server starts. */
+  setJamHosting: (info: { port: number; urls: string[] }) => void
+  /** Called when the user chooses to join as a guest. Sets address, clears snapshot. */
+  setJamGuest: (hostAddress: string) => void
+  /** Resets jam to the default off state. */
+  setJamOff: () => void
+  /** Updates guest WebSocket connection status. */
+  setJamConnected: (connected: boolean) => void
+  /** Stores the latest snapshot received from the host. */
+  setJamSnapshot: (snapshot: JamSnapshot) => void
 }
 
 /** All valid scroll speed levels (0–9, displayed as 1–10). */
@@ -268,6 +305,28 @@ export const useKlankStore = create<KlankState>()(
         customTunings: [],
         addCustomTuning: (tuning) => set((state) => ({...state, customTunings: [...state.customTunings, tuning]})),
         deleteCustomTuning: (id) => set((state) => ({...state, customTunings: state.customTunings.filter((t) => t.id !== id)})),
+        // ── Jam slice (ephemeral — not in partialize) ──────────────────────────
+        jam: { role: 'off', port: null, urls: [], hostAddress: '', connected: false, snapshot: null },
+        setJamHosting: (info) => set((state) => ({
+          ...state,
+          jam: { ...state.jam, role: 'host', port: info.port, urls: info.urls },
+        })),
+        setJamGuest: (hostAddress) => set((state) => ({
+          ...state,
+          jam: { ...state.jam, role: 'guest', hostAddress, connected: false, snapshot: null },
+        })),
+        setJamOff: () => set((state) => ({
+          ...state,
+          jam: { role: 'off', port: null, urls: [], hostAddress: '', connected: false, snapshot: null },
+        })),
+        setJamConnected: (connected) => set((state) => ({
+          ...state,
+          jam: { ...state.jam, connected },
+        })),
+        setJamSnapshot: (snapshot) => set((state) => ({
+          ...state,
+          jam: { ...state.jam, snapshot },
+        })),
         setTabPath: (path) => set((state) => {
           const saved = state.tabSettingByPath[path]
           const tab: TabSetting = {

--- a/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
+++ b/libs/ui/src/lib/fileTreeView/fileTreeview.module.css
@@ -11,8 +11,10 @@
 .noItems {
   display: flex;
   justify-content: center;
-  align-items: center;
-  height: 100%;
+  padding: 2rem 1rem;
+  color: var(--klank-color-text);
+  opacity: 0.45;
+  font-style: italic;
 }
 
 .artistName {

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -6,6 +6,13 @@ import {
   type SheetLine,
 } from '@klank/platform-api'
 import { ChordDiagramTooltip } from '../chordDiagramTooltip/ChordDiagramTooltip.js'
+import { clamp01, shouldSnap, smoothFraction } from './scrollFollow.js'
+
+// ── Guest-follower tunables ───────────────────────────────────────────────────
+const FOLLOW_TAU = 0.15          // easing time-constant (seconds)
+const FOLLOW_SNAP_THRESHOLD = 0.3 // |Δfraction| above which we snap, not ease
+const FOLLOW_EPS = 0.0005        // convergence threshold — below this, stop the RAF
+const FOLLOW_MAX_DT = 0.1        // clamp per-frame dt so a backgrounded tab can't jump
 
 const renderLine = (
   line: string,
@@ -300,14 +307,121 @@ export const Sheet: React.FC<SheetProps> = ({
     }
   }, [tabData])
 
-  // ── Guest follower: drive scrollTop from the prop ─────────────────────────
+  // ── Guest follower: smooth-easing RAF toward the host's scroll position ──────
+  //
+  // Refs so the RAF callback always reads the latest values without triggering
+  // re-renders or effect restarts.
+  const followTargetRef = useRef<number>(0)      // latest host scrollFraction
+  const followDisplayRef = useRef<number>(0)     // current rendered fraction
+  const followRafRef = useRef<number>(0)         // RAF id (0 = not running)
+  const followLastTimeRef = useRef<number | null>(null)
+  const followHostScrollingRef = useRef<boolean>(false) // is the HOST scrolling
+
+  // Keep target + host-scrolling refs in sync with the props every render, so
+  // the long-lived RAF closure always reads current values without restarting.
+  if (scrollFraction !== undefined) {
+    followTargetRef.current = scrollFraction
+    followHostScrollingRef.current = isScrolling
+  }
+
+  // Helper: start (or restart) the follower RAF.  Seeds displayFraction from
+  // the container's actual scrollTop so re-sync eases from the current position.
+  const startFollowRaf = useRef<(() => void) | null>(null)
+
   useEffect(() => {
     if (scrollFraction === undefined) return
+
+    const container = containerRef.current
+    if (!container) return
+
+    // Seed display from where the container currently sits so re-syncs ease
+    // from wherever the guest scrolled to rather than jumping.
+    const seedDisplay = () => {
+      const maxScroll = container.scrollHeight - container.clientHeight
+      followDisplayRef.current = maxScroll > 0
+        ? clamp01(container.scrollTop / maxScroll)
+        : 0
+    }
+
+    const startRaf = () => {
+      if (followRafRef.current) return // already running
+      seedDisplay()
+      followLastTimeRef.current = null
+
+      const step = (timestamp: number) => {
+        const target = followTargetRef.current
+        let display = followDisplayRef.current
+
+        // Compute per-frame dt, clamped so a backgrounded tab doesn't jump.
+        let dt = 0
+        if (followLastTimeRef.current !== null) {
+          dt = Math.min((timestamp - followLastTimeRef.current) / 1000, FOLLOW_MAX_DT)
+        }
+        followLastTimeRef.current = timestamp
+
+        // Big-jump snap: if the gap is large, teleport instead of easing.
+        if (shouldSnap(display, target, FOLLOW_SNAP_THRESHOLD)) {
+          display = target
+        } else {
+          display = clamp01(smoothFraction(display, target, dt, FOLLOW_TAU))
+        }
+        followDisplayRef.current = display
+
+        // Apply to DOM — recompute maxScroll each frame so resize/font changes
+        // are handled without restarting the effect.
+        const maxScroll = container.scrollHeight - container.clientHeight
+        container.scrollTop = maxScroll > 0 ? display * maxScroll : 0
+
+        // Stop the loop only when the host is NOT scrolling AND we've converged.
+        // While the host IS scrolling the RAF keeps running every frame so a
+        // guest who peeks away gets smoothly pulled back.
+        const converged = Math.abs(target - display) < FOLLOW_EPS
+        if (!followHostScrollingRef.current && converged) {
+          followRafRef.current = 0
+          return
+        }
+
+        followRafRef.current = requestAnimationFrame(step)
+      }
+
+      followRafRef.current = requestAnimationFrame(step)
+    }
+
+    // Expose startRaf so the target/isScrolling watchers below can trigger it.
+    startFollowRaf.current = startRaf
+
+    // Start immediately.
+    startRaf()
+
+    return () => {
+      if (followRafRef.current) {
+        cancelAnimationFrame(followRafRef.current)
+        followRafRef.current = 0
+      }
+      startFollowRaf.current = null
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrollFraction !== undefined]) // only (re)mount when follower mode is entered/left
+
+  // Restart the RAF when the host target changes or isScrolling flips on —
+  // either event means the guest should re-converge.
+  useEffect(() => {
+    if (scrollFraction === undefined) return
+    if (startFollowRaf.current) startFollowRaf.current()
+  }, [scrollFraction, isScrolling])
+
+  // On tab change in follower mode: snap immediately (don't slide across new doc).
+  useEffect(() => {
+    if (scrollFraction === undefined) return
+    followDisplayRef.current = scrollFraction
+    followTargetRef.current = scrollFraction
     const container = containerRef.current
     if (!container) return
     const maxScroll = container.scrollHeight - container.clientHeight
     container.scrollTop = maxScroll > 0 ? scrollFraction * maxScroll : 0
-  }, [scrollFraction, tabData])
+  // tabData change is the trigger; scrollFraction is read for the initial position.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabData])
 
   // ── Host / standalone: manual-scroll reporting on native scroll event ─────
   useEffect(() => {

--- a/libs/ui/src/lib/sheet/Sheet.tsx
+++ b/libs/ui/src/lib/sheet/Sheet.tsx
@@ -212,6 +212,19 @@ type SheetProps = {
   /** When true, chord-line + lyric-line pairs are rendered as wrappable
    *  inline segments instead of two separate block lines. */
   isMobile?: boolean
+  /**
+   * HOST reporting. When provided, called with the normalised scroll position
+   * (0..1) whenever the host scrolls. Throttled to ~15 calls/sec internally.
+   * Has no effect when `scrollFraction` is also provided (follower mode).
+   */
+  onScrollFraction?: (fraction: number) => void
+  /**
+   * GUEST follower. When provided, Sheet is a passive read-only follower:
+   * - The local autoscroll RAF is disabled.
+   * - Container scrollTop is driven by this value (0..1) on every change.
+   * When undefined, behaviour is unchanged (host / standalone mode).
+   */
+  scrollFraction?: number
 } & React.ComponentPropsWithRef<'pre'>
 
 export const Sheet: React.FC<SheetProps> = ({
@@ -222,6 +235,8 @@ export const Sheet: React.FC<SheetProps> = ({
   setTabIsScrolling,
   instrument,
   isMobile = false,
+  onScrollFraction,
+  scrollFraction,
   ...props
 }) => {
   const containerRef = useRef<HTMLPreElement>(null)
@@ -231,6 +246,8 @@ export const Sheet: React.FC<SheetProps> = ({
   const measureRef = useRef<HTMLSpanElement>(null)
   // How many monospace characters fit across the sheet, used to reflow tab.
   const [colsPerRow, setColsPerRow] = useState<number>(Number.POSITIVE_INFINITY)
+  // Last time onScrollFraction was called — used to throttle to ~15/sec.
+  const lastFractionEmitRef = useRef<number>(0)
 
   useEffect(() => {
     const container = containerRef.current
@@ -283,10 +300,48 @@ export const Sheet: React.FC<SheetProps> = ({
     }
   }, [tabData])
 
+  // ── Guest follower: drive scrollTop from the prop ─────────────────────────
+  useEffect(() => {
+    if (scrollFraction === undefined) return
+    const container = containerRef.current
+    if (!container) return
+    const maxScroll = container.scrollHeight - container.clientHeight
+    container.scrollTop = maxScroll > 0 ? scrollFraction * maxScroll : 0
+  }, [scrollFraction, tabData])
+
+  // ── Host / standalone: manual-scroll reporting on native scroll event ─────
+  useEffect(() => {
+    // Only active when we have a reporter and are NOT in follower mode.
+    if (!onScrollFraction || scrollFraction !== undefined) return
+    // Only active while the autoscroll RAF is NOT running (when it runs,
+    // reporting happens inside `step` below).
+    if (isScrolling) return
+
+    const container = containerRef.current
+    if (!container) return
+
+    const THROTTLE_MS = 1000 / 15 // ~15/sec
+
+    const handleScroll = () => {
+      const now = performance.now()
+      if (now - lastFractionEmitRef.current < THROTTLE_MS) return
+      lastFractionEmitRef.current = now
+      const maxScroll = container.scrollHeight - container.clientHeight
+      onScrollFraction(maxScroll > 0 ? Math.min(1, Math.max(0, container.scrollTop / maxScroll)) : 0)
+    }
+
+    container.addEventListener('scroll', handleScroll, { passive: true })
+    return () => container.removeEventListener('scroll', handleScroll)
+  }, [onScrollFraction, scrollFraction, isScrolling])
+
+  // ── Autoscroll RAF ─────────────────────────────────────────────────────────
   useEffect(() => {
     const container = containerRef.current
     const content = contentRef.current
     if (!container || !content) return
+
+    // Guests are passive followers — never run the local autoscroll RAF.
+    if (scrollFraction !== undefined) return
 
     if (!isScrolling) return
 
@@ -305,6 +360,8 @@ export const Sheet: React.FC<SheetProps> = ({
     container.style.overflowY = 'hidden'
     content.style.transform = `translateY(-${virtualY.current}px)`
 
+    const THROTTLE_MS = 1000 / 15 // ~15/sec
+
     const onWheel = (e: WheelEvent) => {
       e.preventDefault()
       const pixelDelta =
@@ -314,6 +371,15 @@ export const Sheet: React.FC<SheetProps> = ({
             ? e.deltaY * container.clientHeight
             : e.deltaY
       virtualY.current = Math.max(0, Math.min(virtualY.current + pixelDelta, getMaxScroll()))
+      // Report manual wheel adjustment to the host callback (throttled).
+      if (onScrollFraction) {
+        const now = performance.now()
+        if (now - lastFractionEmitRef.current >= THROTTLE_MS) {
+          lastFractionEmitRef.current = now
+          const maxScroll = getMaxScroll()
+          onScrollFraction(maxScroll > 0 ? Math.min(1, Math.max(0, virtualY.current / maxScroll)) : 0)
+        }
+      }
     }
     container.addEventListener('wheel', onWheel, { passive: false })
 
@@ -340,6 +406,15 @@ export const Sheet: React.FC<SheetProps> = ({
 
       content.style.transform = `translateY(-${virtualY.current}px)`
 
+      // Report scroll fraction to host callback (throttled to ~15/sec).
+      if (onScrollFraction) {
+        const now = performance.now()
+        if (now - lastFractionEmitRef.current >= THROTTLE_MS) {
+          lastFractionEmitRef.current = now
+          onScrollFraction(maxScroll > 0 ? Math.min(1, Math.max(0, virtualY.current / maxScroll)) : 0)
+        }
+      }
+
       if (virtualY.current < maxScroll) {
         rafId = requestAnimationFrame(step)
       } else {
@@ -356,7 +431,7 @@ export const Sheet: React.FC<SheetProps> = ({
       container.style.overflowY = ''
       container.scrollTop = pos
     }
-  }, [isScrolling, tabScrollSpeed, setTabIsScrolling])
+  }, [isScrolling, tabScrollSpeed, setTabIsScrolling, onScrollFraction, scrollFraction])
 
   // Line classification runs `classifySheetLine` over the whole tab — memoize
   // so toolbar-driven re-renders don't re-parse large sheets.

--- a/libs/ui/src/lib/sheet/scrollFollow.spec.ts
+++ b/libs/ui/src/lib/sheet/scrollFollow.spec.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import fc from 'fast-check'
+import { clamp01, shouldSnap, smoothFraction } from './scrollFollow.js'
+
+// ─── clamp01 ─────────────────────────────────────────────────────────────────
+
+describe('clamp01', () => {
+  it('returns 0 for values below 0', () => {
+    expect(clamp01(-1)).toBe(0)
+    expect(clamp01(-100)).toBe(0)
+  })
+
+  it('returns 1 for values above 1', () => {
+    expect(clamp01(2)).toBe(1)
+    expect(clamp01(100)).toBe(1)
+  })
+
+  it('returns identity for values in [0, 1]', () => {
+    expect(clamp01(0)).toBe(0)
+    expect(clamp01(0.5)).toBe(0.5)
+    expect(clamp01(1)).toBe(1)
+  })
+
+  it('property: output is always in [0, 1]', () => {
+    fc.assert(
+      fc.property(fc.double({ noNaN: true, min: -1e6, max: 1e6 }), (x) => {
+        const r = clamp01(x)
+        return r >= 0 && r <= 1
+      }),
+    )
+  })
+})
+
+// ─── shouldSnap ──────────────────────────────────────────────────────────────
+
+describe('shouldSnap', () => {
+  const THRESHOLD = 0.3
+
+  it('returns true when gap exceeds threshold', () => {
+    expect(shouldSnap(0, 0.5, THRESHOLD)).toBe(true)
+    expect(shouldSnap(1, 0.3, THRESHOLD)).toBe(true)   // exactly 0.3 is NOT > threshold
+  })
+
+  it('returns false when gap is at or below threshold', () => {
+    expect(shouldSnap(0, 0.3, THRESHOLD)).toBe(false)   // exactly equal → false
+    expect(shouldSnap(0, 0.29, THRESHOLD)).toBe(false)
+    expect(shouldSnap(0.5, 0.5, THRESHOLD)).toBe(false)
+  })
+
+  it('is symmetric (absolute value)', () => {
+    expect(shouldSnap(0.8, 0.1, THRESHOLD)).toBe(shouldSnap(0.1, 0.8, THRESHOLD))
+  })
+
+  it('property: symmetric in current/target', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ noNaN: true, min: 0, max: 1 }),
+        fc.double({ noNaN: true, min: 0, max: 1 }),
+        fc.double({ noNaN: true, min: 0, max: 1 }),
+        (a, b, threshold) => {
+          return shouldSnap(a, b, threshold) === shouldSnap(b, a, threshold)
+        },
+      ),
+    )
+  })
+})
+
+// ─── smoothFraction ──────────────────────────────────────────────────────────
+
+describe('smoothFraction', () => {
+  const TAU = 0.15
+  const ONE_FRAME = 1 / 60 // ~16.7 ms
+
+  it('returns target when current == target', () => {
+    expect(smoothFraction(0.5, 0.5, ONE_FRAME, TAU)).toBeCloseTo(0.5)
+  })
+
+  it('moves toward target (not away)', () => {
+    const next = smoothFraction(0, 1, ONE_FRAME, TAU)
+    expect(next).toBeGreaterThan(0)
+    expect(next).toBeLessThan(1)
+  })
+
+  it('never overshoots for a single frame', () => {
+    // Moving up
+    expect(smoothFraction(0, 1, ONE_FRAME, TAU)).toBeLessThanOrEqual(1)
+    // Moving down
+    expect(smoothFraction(1, 0, ONE_FRAME, TAU)).toBeGreaterThanOrEqual(0)
+  })
+
+  it('converges monotonically over several steps', () => {
+    let val = 0
+    const target = 0.8
+    for (let i = 0; i < 20; i++) {
+      const next = smoothFraction(val, target, ONE_FRAME, TAU)
+      // Gap must strictly shrink
+      expect(Math.abs(target - next)).toBeLessThan(Math.abs(target - val))
+      val = next
+    }
+  })
+
+  it('returns target immediately when tau is 0', () => {
+    expect(smoothFraction(0, 0.7, ONE_FRAME, 0)).toBe(0.7)
+  })
+
+  it('property: output stays within [current, target] range', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ noNaN: true, min: 0, max: 1 }),
+        fc.double({ noNaN: true, min: 0, max: 1 }),
+        fc.double({ noNaN: true, min: 0.001, max: 0.1 }), // realistic dt in seconds
+        (current, target, dt) => {
+          const result = smoothFraction(current, target, dt, TAU)
+          const lo = Math.min(current, target)
+          const hi = Math.max(current, target)
+          // Allow tiny floating-point slack
+          return result >= lo - 1e-12 && result <= hi + 1e-12
+        },
+      ),
+    )
+  })
+
+  it('property: reduces the gap from target', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ noNaN: true, min: 0, max: 1 }),
+        fc.double({ noNaN: true, min: 0, max: 1 }),
+        fc.double({ noNaN: true, min: 0.001, max: 0.1 }),
+        (current, target, dt) => {
+          if (Math.abs(current - target) < 1e-10) return true // already converged
+          const result = smoothFraction(current, target, dt, TAU)
+          return Math.abs(result - target) < Math.abs(current - target)
+        },
+      ),
+    )
+  })
+})

--- a/libs/ui/src/lib/sheet/scrollFollow.ts
+++ b/libs/ui/src/lib/sheet/scrollFollow.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure helpers for the guest scroll-follower in Sheet.
+ * Kept separate so they can be unit-tested without a DOM.
+ */
+
+/**
+ * Exponential ease toward target.
+ * current + (target - current) * (1 - e^(-dt/tau))
+ *
+ * @param current  Current display fraction [0, 1]
+ * @param target   Host target fraction [0, 1]
+ * @param dtSeconds  Frame delta in seconds (should be clamped by caller)
+ * @param tau      Time constant in seconds — smaller = faster catch-up
+ */
+export function smoothFraction(
+  current: number,
+  target: number,
+  dtSeconds: number,
+  tau: number,
+): number {
+  if (tau <= 0) return target
+  return current + (target - current) * (1 - Math.exp(-dtSeconds / tau))
+}
+
+/**
+ * Returns true when the gap is large enough that we should snap
+ * immediately instead of easing (e.g. a seek or tab change).
+ */
+export function shouldSnap(
+  current: number,
+  target: number,
+  threshold: number,
+): boolean {
+  return Math.abs(target - current) > threshold
+}
+
+/** Clamp x to [0, 1]. */
+export function clamp01(x: number): number {
+  return Math.min(1, Math.max(0, x))
+}


### PR DESCRIPTION
## Jam mode

A **host** shares the active tab — its content, transpose / font size / scroll speed, and **live scroll position** — over the local network. Other devices stay in sync:

- **Guests with the app** join by entering the host's `ip:port` and follow along in a read-only synced view (full chord rendering, follows the host's scroll).
- **Guests without the app** open the host's URL in a browser and get a lightweight tab view — no install needed.

Works on **desktop and Android**.

### How it works
The host's Rust backend runs an embedded **axum HTTP + WebSocket** server. The host pushes a JSON *snapshot* on every relevant change; a `tokio::sync::watch` channel holds the latest snapshot so newly-joined guests catch up immediately. Scroll position is sent as a **normalized `0..1` fraction** of content height, so it maps correctly across devices with different screen sizes and font sizes.

- `GET /` → self-contained lite browser view (`jam-lite.html`)
- `GET /jam` → WebSocket snapshot stream
- Binds `0.0.0.0:7070`, falling back to an OS-assigned port; LAN IP discovered via the UDP-connect trick (no new dependency for that).
- Access: **open on LAN** for v1 (no room code).

### Backend (`apps/klank/src-tauri`)
- `jam.rs` + `jam-lite.html` (XSS-safe — assigns `textContent` only).
- `jam_start` / `jam_stop` / `jam_broadcast` / `jam_status` commands, registered for **both** desktop and mobile; `allow-jam` permission + capability wiring.
- CSP gains `connect-src` for `ws`/`wss` so guests can connect.
- Android **release** builds permit cleartext so the guest's `ws://<lan-ip>` connection isn't blocked on-device (debug already allowed it; the app makes no other cleartext requests — UG scraping is HTTPS).
- New dep: `axum` 0.7 (`ws`, `http1`, `tokio`); extended `tokio` features.

### Frontend
- `platform-api/jam.ts`: `createJamHost` (Tauri `invoke` wrappers) + `connectJam` (native `WebSocket` guest client with reconnect/backoff).
- Store: ephemeral `jam` slice (role / host / guest), **excluded from persistence**.
- `Sheet`: two optional props — `onScrollFraction` (host reports position) and `scrollFraction` (guest follower). Existing behavior is unchanged when both are omitted.
- `Player` broadcasts snapshots when hosting and renders the synced view when a guest; **Settings** gains a *Jam mode* section to host / join / leave (with copyable share URLs).

### Tests
- Store jam slice behavior + persistence-exclusion.
- `jam.ts` host wrappers (incl. JSON serialization of the broadcast payload) and the guest client's connect / parse / reconnect / `close()` behavior.

### Validation
`typecheck`, `lint`, and the full `vitest` suite pass across all projects; `cargo check` passes (a bind helper bug was fixed during integration); the production Vite build succeeds.

https://claude.ai/code/session_01GzoF2NDD6pccgDpwgfQoAT