### PR TITLE
fix: derive release version from latest GitHub release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,19 @@ jobs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
       - id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VER="2.0.${{ github.run_number }}"
+          # Find the latest published (non-prerelease) release and bump the patch.
+          # Falls back to v2.0.0 if no releases exist yet.
+          LATEST=$(gh release view --repo "$GITHUB_REPOSITORY" --latest --json tagName --jq '.tagName' 2>/dev/null || echo "v2.0.0")
+          LATEST="${LATEST#v}"
+          MAJOR=$(echo "$LATEST" | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | cut -d. -f3)
+          VER="${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "VERSION=$VER" >> "$GITHUB_OUTPUT"
-          echo "Building version: $VER"
+          echo "Building version: $VER (bumped from v$LATEST)"
 
   # -----------------------------------------------------------------------
   # Windows installers (NSIS + MSI).


### PR DESCRIPTION
## Problem

`release.yml` was computing the version as `2.0.${{ github.run_number }}`. `github.run_number` is a per-workflow counter that starts at 1 for each workflow file. This means:

- If the workflow is ever recreated/renamed, the counter resets and can produce a version lower than what's already published
- If an older workflow run is re-run via the GitHub UI, it reuses its original (lower) run_number and produces a duplicate or regressed version

This is how `v2.0.1` was published when `v2.0.2` already existed.

## Fix

The version job now calls `gh release view --latest` to find the most recently published (non-prerelease) release tag, then bumps the patch by 1:

```bash
LATEST=$(gh release view --repo "$GITHUB_REPOSITORY" --latest --json tagName --jq '.tagName' 2>/dev/null || echo "v2.0.0")
# strip v prefix, split, increment patch
VER="${MAJOR}.${MINOR}.$((PATCH + 1))"
```

With the current latest release being `v2.0.1`, the next release will produce `v2.0.2`. The version always moves forward from whatever was last published, regardless of workflow run history.

Falls back to `v2.0.0` (producing `v2.0.1`) if no releases exist yet.

## Test plan

- [ ] Trigger the release workflow from this branch and confirm the version step logs `Building version: 2.0.2 (bumped from v2.0.1)`
- [ ] Confirm the published release tag is `v2.0.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hci2yG2KMcSzPQvpoSnwx

---
_Generated by [Claude Code](https://claude.ai/code/session_015hci2yG2KMcSzPQvpoSnwx)_