### PR TITLE
docs: document Harmony panel, Jam mode, Android, and git sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,15 +31,19 @@ pnpm nx run klank:tauri:build
 
 ```
 apps/klank/app/                     React Router 7 app - routes, components, root layout
+apps/klank/app/routes/settings.tsx  Settings panel - rendered inline by app.tsx via activeView, not a router route
+apps/klank/app/routes/harmony.tsx   Harmony panel - scales/modes/chord-scale browser, rendered inline via activeView
+apps/klank/app/routes/about.tsx     Unused NX boilerplate stub, registered at /about in routes.tsx
 apps/klank/app/components/menu/     Left sidebar: directory tree, search bar
 apps/klank/app/components/player/   Center pane: tab display, toolbar, playback controls
-apps/klank/src-tauri/src/lib.rs     Rust entry - registers scrape_ug + git_* commands
+apps/klank/src-tauri/src/lib.rs     Rust entry - registers scrape_ug + git_* + jam_* commands
 apps/klank/src-tauri/src/import/    Tab-import pipeline (stages, orchestrator, progress)
 apps/klank/src-tauri/src/git.rs     In-app git engine (libgit2) - git_pull/commit/push/clone/…
+apps/klank/src-tauri/src/jam.rs     LAN jam-session host - jam_start/stop/broadcast/status, serves jam-lite.html
 apps/klank/src-tauri/capabilities/  Tauri permission declarations (JSON) - one file per window
 libs/ui/src/                        Shared React components (@klank/ui)
 libs/store/src/lib/store.ts         Zustand store with persisted TabSetting (@klank/store)
-libs/platform-api/src/lib/          FileService, git (invoke-based), chords, download, userAgent (@klank/platform-api)
+libs/platform-api/src/lib/          FileService, git, jam, chords/scales/chord-theory, download, userAgent (@klank/platform-api)
 libs/audio/src/                     Metronome + tuner logic and Web Audio engines (@klank/audio)
 docs/agents/                        Agent architecture + setup conventions
 .claude/agents/                     Subagent identities (self-contained, routed by description)

--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ Klank is a Tauri desktop application for viewing, downloading, and editing guita
 - Full-text search with highlighted matches in the file tree
 - Chord highlighting within tab content with hover fingering diagrams (guitar/bass selectable)
 - Semitone transposition with chromatic chord rewriting
+- Harmony panel — scale and mode browser with fretboard diagrams, diatonic chord-scale lookup, and chord-diagram rendering for guitar/bass
 - Auto-scroll with adjustable speed
 - Playlists — create named playlists, add tabs, reorder with drag-and-drop, and navigate sequentially; persisted to `.klank-settings.json` in the tab directory
+- Jam mode — host a LAN session that broadcasts the active tab, transpose, and live scroll position to other devices on the network
 - Download tabs directly from Ultimate Guitar via built-in scraper
+- In-app git sync — pull/commit/push the tab directory from the Settings panel, with token or system-credential authentication
 - Right-click context menu on file tree entries for tab deletion (with confirmation modal)
 - Light and Dark theme including icons and native chrome
 - App version displayed on the Settings page
 - Metronome — look-ahead Web Audio scheduler with BPM control, tap-tempo, time signature, accent, and subdivisions; beat indicator updates live. Press `m` to open, arrow keys to nudge BPM, `Esc` to close.
 - Tuner — plays reference tones for each open string (guitar standard / drop-D / half-step-down, bass standard / 5-string); listen-only, no microphone required. Press `t` to open.
+- Android build, alongside desktop, via Tauri's mobile target
 - Keyboard shortcuts for navigation and playback
 
 ## Tech Stack
@@ -46,6 +50,7 @@ pnpm tauri:dev
 |---------|-------------|
 | `pnpm dev` | Vite dev server only (React, no Tauri shell), port 4200 |
 | `pnpm tauri:dev` | Full Tauri desktop app with hot reload |
+| `pnpm tauri:android:dev` | Run on Android (emulator/device) |
 | `pnpm build` | Production Vite build |
 | `pnpm test` | Vitest across all libs |
 | `pnpm lint` | ESLint across workspace |


### PR DESCRIPTION
## Summary
- README's feature list was missing the Harmony panel (scales/modes/chord-scale browser), Jam mode (LAN sync of active tab + scroll position), in-app git sync, and Android build support — all already shipped but undocumented.
- AGENTS.md's Project Structure table didn't list `apps/klank/src-tauri/src/jam.rs`, didn't reflect that `routes/settings.tsx` and `routes/harmony.tsx` are inline panels (not router routes) rather than the `/about` boilerplate stub, and `lib.rs`/`platform-api` descriptions hadn't been updated for the `jam_*` commands and scales/chord-theory modules.

## Test plan
- [x] Verified every claim against source: `lib.rs` `generate_handler!` list, `routes.tsx`, `app.tsx` wiring of `SettingsPanel`/`HarmonyPanel`, `jam.rs`/`jam.ts`, `build-android.yml`
- [x] No code changes — docs only, no build/test impact


---
_Generated by [Claude Code](https://claude.ai/code/session_01UekN9bojC22mASVjfadvVx)_