### PR TITLE
feat(jam): cancel button, connected-user count, LAN discovery, and settings UX

### DIFF
--- a/apps/klank/app/components/player/Player.tsx
+++ b/apps/klank/app/components/player/Player.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import styles from './player.module.css'
-import { Sheet, SheetToolbar, EditIcon } from '@klank/ui'
+import { Sheet, SheetToolbar, EditIcon, CloseIcon } from '@klank/ui'
 import { useKlankStore } from '@klank/store'
 import { createJamHost, type JamHost, type JamSnapshot } from '@klank/platform-api'
 
@@ -30,6 +30,8 @@ export const Player: React.FC<PlayerProps> = ({ ...props }) => {
   const jamRole = useKlankStore((s) => s.jam.role)
   const jamSnapshot = useKlankStore((s) => s.jam.snapshot)
   const jamHostAddress = useKlankStore((s) => s.jam.hostAddress)
+  const jamClients = useKlankStore((s) => s.jam.clients)
+  const jamConnected = useKlankStore((s) => s.jam.connected)
 
   const [tabData, setTabData] = useState<string | undefined>()
   const [editedContent, setEditedContent] = useState<string>('')
@@ -108,6 +110,12 @@ export const Player: React.FC<PlayerProps> = ({ ...props }) => {
     }
   }
 
+  // Discard unsaved edits and leave edit mode without writing to disk.
+  const handleEditCancel = () => {
+    setEditedContent(tabData ?? '')
+    setMode('Read')
+  }
+
   // Callback passed to Sheet when hosting — updates the ref and broadcasts.
   const handleScrollFraction = (fraction: number) => {
     scrollFractionRef.current = fraction
@@ -137,6 +145,11 @@ export const Player: React.FC<PlayerProps> = ({ ...props }) => {
           <span className={styles.guestStatus}>
             Following {jamHostAddress}
           </span>
+          {jamConnected && jamClients > 0 && (
+            <span className={styles.jamCount} title="People connected to this jam">
+              ● {jamClients} connected
+            </span>
+          )}
         </div>
         <Sheet
           tabScrollSpeed={snap?.scrollSpeed ?? 1}
@@ -158,10 +171,16 @@ export const Player: React.FC<PlayerProps> = ({ ...props }) => {
   return (
     <section className={styles.container} {...props}>
       {mode === 'Edit' && (
-        <button className={styles.floatingSave} onClick={handleEditToggle} aria-label="Save">
-          <EditIcon />
-          <span>Save</span>
-        </button>
+        <div className={styles.floatingActions}>
+          <button className={styles.floatingCancel} onClick={handleEditCancel} aria-label="Cancel">
+            <CloseIcon />
+            <span>Cancel</span>
+          </button>
+          <button className={styles.floatingSave} onClick={handleEditToggle} aria-label="Save">
+            <EditIcon />
+            <span>Save</span>
+          </button>
+        </div>
       )}
       <SheetToolbar
         fontSize={fontSize}

--- a/apps/klank/app/components/player/player.module.css
+++ b/apps/klank/app/components/player/player.module.css
@@ -36,7 +36,9 @@
   padding-right: var(--safe-right);
   padding-bottom: var(--safe-bottom);
 
-  > div {
+  /* floatingActions is excluded — it must keep its own position:fixed
+     (this rule's higher specificity would otherwise override it). */
+  > div:not(.floatingActions) {
     position: relative;
     z-index: 2;
   }

--- a/apps/klank/app/components/player/player.module.css
+++ b/apps/klank/app/components/player/player.module.css
@@ -57,16 +57,21 @@
   box-sizing: border-box;
 }
 
-.floatingSave {
+.floatingActions {
   position: fixed;
   bottom: calc(2rem + var(--safe-bottom));
   right: calc(2rem + var(--safe-right));
   z-index: 100;
   display: flex;
   align-items: center;
+  gap: 0.75rem;
+}
+
+.floatingSave,
+.floatingCancel {
+  display: flex;
+  align-items: center;
   gap: 0.5rem;
-  background: var(--klank-color-text);
-  color: var(--klank-color-background);
   border: none;
   border-radius: 999px;
   padding: 0.75rem 1.5rem;
@@ -87,12 +92,31 @@
   }
 }
 
+.floatingSave {
+  background: var(--klank-color-text);
+  color: var(--klank-color-background);
+}
+
+.floatingCancel {
+  background: var(--klank-color-secondary-background);
+  color: var(--klank-color-text);
+  border: 1px solid var(--klank-color-border);
+}
+
 @media (max-width: 599px) {
-  .floatingSave {
+  .floatingActions {
     /* On mobile the toolbar is at the bottom — float above it */
     bottom: calc(4.5rem + var(--safe-bottom));
     right: calc(1rem + var(--safe-right));
   }
+}
+
+/* Connected-guest count shown in the jam guest header. */
+.jamCount {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--klank-color-success);
+  white-space: nowrap;
 }
 
 @media (max-width: 599px) {

--- a/apps/klank/app/components/player/player.module.css
+++ b/apps/klank/app/components/player/player.module.css
@@ -139,8 +139,9 @@
 
   /* Cancel the desktop z-index:2 on the SheetToolbar (direct div child).
      Without this, SheetToolbar creates a stacking context that can paint
-     above the mobile drawer overlay (z-index: 200). */
-  .container > div {
+     above the mobile drawer overlay (z-index: 200). Excludes floatingActions,
+     which relies on position:fixed to float above the toolbar. */
+  .container > div:not(.floatingActions) {
     position: static;
     z-index: auto;
   }

--- a/apps/klank/app/routes/settings.module.css
+++ b/apps/klank/app/routes/settings.module.css
@@ -205,3 +205,43 @@
   gap: 8px;
 }
 
+/* Row heading with an inline action (e.g. "Nearby jams" + Refresh). */
+.jamSubhead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+/* Discovered-jam list. */
+.jamList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.jamListRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.jamListName {
+  font-size: 0.875rem;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.jamListAddress {
+  font-size: 0.8rem;
+  font-family: monospace;
+  opacity: 0.6;
+  white-space: nowrap;
+}
+

--- a/apps/klank/app/routes/settings.tsx
+++ b/apps/klank/app/routes/settings.tsx
@@ -1,6 +1,6 @@
 import styles from './settings.module.css'
 import { useEffect, useRef, useState } from 'react'
-import { createGitService, createJamHost, getAppVersion, isMobileDevice, type BranchInfo, type GitService, type JamHost } from '@klank/platform-api'
+import { createGitService, createJamHost, discoverJams, getAppVersion, isMobileDevice, type BranchInfo, type DiscoveredJam, type GitService, type JamHost } from '@klank/platform-api'
 import { useKlankStore, type SyncStatus } from '@klank/store'
 import { runGitSync } from '../useGitSync'
 
@@ -71,14 +71,55 @@ export function SettingsPanel() {
   const jamUrls = useKlankStore((s) => s.jam.urls)
   const jamConnected = useKlankStore((s) => s.jam.connected)
   const jamHostAddress = useKlankStore((s) => s.jam.hostAddress)
+  const hostedJamName = useKlankStore((s) => s.jam.name)
+  const jamClients = useKlankStore((s) => s.jam.clients)
   const setJamHosting = useKlankStore((s) => s.setJamHosting)
   const setJamGuest = useKlankStore((s) => s.setJamGuest)
   const setJamOff = useKlankStore((s) => s.setJamOff)
+  const setJamClients = useKlankStore((s) => s.setJamClients)
 
   // Single JamHost instance shared across host actions in this panel.
   const jamHostRef = useRef<JamHost | null>(null)
   const [joinAddress, setJoinAddress] = useState('')
   const [jamBusy, setJamBusy] = useState(false)
+  // Editable jam name; default is a random klank-jam-NNNN (never the device name).
+  const [jamName, setJamName] = useState(() => `klank-jam-${Math.floor(1000 + Math.random() * 9000)}`)
+  const [discovered, setDiscovered] = useState<DiscoveredJam[]>([])
+  const [scanning, setScanning] = useState(false)
+  const [showManualJoin, setShowManualJoin] = useState(false)
+
+  const scanForJams = async () => {
+    setScanning(true)
+    try {
+      setDiscovered(await discoverJams())
+    } finally {
+      setScanning(false)
+    }
+  }
+
+  // Auto-scan for nearby jams when not in a jam, and poll the connected count
+  // while hosting so the host sees joins/leaves live.
+  useEffect(() => {
+    if (jamRole === 'off') {
+      scanForJams()
+      return
+    }
+    if (jamRole === 'host') {
+      let cancelled = false
+      const poll = async () => {
+        if (!jamHostRef.current) jamHostRef.current = await createJamHost()
+        const status = await jamHostRef.current.status()
+        if (!cancelled) setJamClients(status.clients)
+      }
+      poll()
+      const id = setInterval(poll, 2000)
+      return () => {
+        cancelled = true
+        clearInterval(id)
+      }
+    }
+    return
+  }, [jamRole, setJamClients])
 
   const getOrCreateJamHost = async (): Promise<JamHost> => {
     if (!jamHostRef.current) {
@@ -92,7 +133,8 @@ export function SettingsPanel() {
     setJamBusy(true)
     try {
       const host = await getOrCreateJamHost()
-      const info = await host.start()
+      const name = jamName.trim() || `klank-jam-${Math.floor(1000 + Math.random() * 9000)}`
+      const info = await host.start(name)
       setJamHosting(info)
     } finally {
       setJamBusy(false)
@@ -492,31 +534,72 @@ export function SettingsPanel() {
 
           {jamRole === 'off' && (
             <>
+              <span className={styles.infoMessage}>
+                Play together on your local network — one device hosts, the others follow along live.
+              </span>
+
               <div className={styles.row}>
-                <span className={styles.label}>Host</span>
-                <button className={styles.button} onClick={handleStartHosting} disabled={jamBusy}>
-                  Host a jam
-                </button>
-              </div>
-              <div className={styles.row}>
-                <span className={styles.label}>Join</span>
+                <span className={styles.label}>Jam name</span>
                 <input
                   className={styles.commitInput}
                   type="text"
-                  placeholder="192.168.1.5:7070"
-                  value={joinAddress}
-                  onChange={(e) => setJoinAddress(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleJoinJam()}
-                  aria-label="Host address"
+                  value={jamName}
+                  onChange={(e) => setJamName(e.target.value)}
+                  aria-label="Jam name"
                 />
-                <button
-                  className={styles.button}
-                  onClick={handleJoinJam}
-                  disabled={!joinAddress.trim()}
-                >
-                  Join
+                <button className={styles.button} onClick={handleStartHosting} disabled={jamBusy}>
+                  Host
                 </button>
               </div>
+
+              <div className={styles.jamSubhead}>
+                <span>Nearby jams</span>
+                <button className={styles.linkButton} onClick={scanForJams} disabled={scanning}>
+                  {scanning ? 'Scanning…' : 'Refresh'}
+                </button>
+              </div>
+
+              {discovered.length === 0 ? (
+                <span className={styles.infoMessage}>
+                  {scanning ? 'Looking for jams on your network…' : 'No open jams found nearby.'}
+                </span>
+              ) : (
+                <div className={styles.jamList}>
+                  {discovered.map((jam) => (
+                    <div key={jam.address} className={styles.jamListRow}>
+                      <span className={styles.jamListName} title={jam.name}>{jam.name}</span>
+                      <span className={styles.jamListAddress}>{jam.address}</span>
+                      <button className={styles.button} onClick={() => setJamGuest(jam.address)}>
+                        Join
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <button className={styles.linkButton} onClick={() => setShowManualJoin((v) => !v)}>
+                {showManualJoin ? 'Hide manual join' : 'Join by address'}
+              </button>
+              {showManualJoin && (
+                <div className={styles.row}>
+                  <input
+                    className={styles.commitInput}
+                    type="text"
+                    placeholder="192.168.1.5:7070"
+                    value={joinAddress}
+                    onChange={(e) => setJoinAddress(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && handleJoinJam()}
+                    aria-label="Host address"
+                  />
+                  <button
+                    className={styles.button}
+                    onClick={handleJoinJam}
+                    disabled={!joinAddress.trim()}
+                  >
+                    Join
+                  </button>
+                </div>
+              )}
             </>
           )}
 
@@ -524,10 +607,18 @@ export function SettingsPanel() {
             <>
               <div className={styles.row}>
                 <span className={styles.label}>Status</span>
-                <span className={styles.jamStatus}>Hosting</span>
+                <span className={styles.jamStatus}>
+                  Hosting{hostedJamName ? ` “${hostedJamName}”` : ''}
+                </span>
                 <button className={styles.button} onClick={handleStopHosting} disabled={jamBusy}>
                   Stop hosting
                 </button>
+              </div>
+              <div className={styles.row}>
+                <span className={styles.label}>Connected</span>
+                <span className={styles.jamStatus}>
+                  {jamClients} {jamClients === 1 ? 'person' : 'people'}
+                </span>
               </div>
               {jamUrls.length > 0 && (
                 <div className={styles.row}>
@@ -549,20 +640,31 @@ export function SettingsPanel() {
                 </div>
               )}
               <span className={styles.infoMessage}>
-                Others on your network can open these URLs in a browser, or join with the app using the ip:port.
+                Others on your network can find this jam in their app, open these URLs in a browser, or join with the ip:port.
               </span>
             </>
           )}
 
           {jamRole === 'guest' && (
-            <div className={styles.row}>
-              <span className={styles.label}>
-                {jamConnected ? `Connected to ${jamHostAddress}` : `Connecting to ${jamHostAddress}…`}
-              </span>
-              <button className={styles.button} onClick={setJamOff}>
-                Leave
-              </button>
-            </div>
+            <>
+              <div className={styles.row}>
+                <span className={styles.label}>Status</span>
+                <span className={styles.jamStatus}>
+                  {jamConnected ? `Connected to ${jamHostAddress}` : `Connecting to ${jamHostAddress}…`}
+                </span>
+                <button className={styles.button} onClick={setJamOff}>
+                  Leave
+                </button>
+              </div>
+              {jamConnected && jamClients > 0 && (
+                <div className={styles.row}>
+                  <span className={styles.label}>Connected</span>
+                  <span className={styles.jamStatus}>
+                    {jamClients} {jamClients === 1 ? 'person' : 'people'}
+                  </span>
+                </div>
+              )}
+            </>
           )}
         </section>
       </div>

--- a/apps/klank/src-tauri/Cargo.lock
+++ b/apps/klank/src-tauri/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "html-escape",
  "log",
  "md5",
+ "mdns-sd",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
@@ -1070,6 +1071,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,6 +2186,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
+name = "mdns-sd"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892f96f6d2ebe1ea641279f986ac52a2a6bac71e8f743bb258315cfe2bd7e88e"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,6 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3621,6 +3659,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3676,6 +3725,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/apps/klank/src-tauri/Cargo.lock
+++ b/apps/klank/src-tauri/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-log",
+ "tauri-plugin-multicast-lock",
  "tauri-plugin-ug-scraper",
  "tokio",
 ]
@@ -62,9 +63,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -127,7 +128,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -253,9 +254,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -311,14 +312,14 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -327,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -352,9 +353,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
-version = "5.2.0"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+checksum = "37bcaa4a0975bed4a760af3efe4368825098ce5f9d37a30c5a021d635dc63d8f"
 dependencies = [
  "rust_decimal",
  "schemars 1.2.1",
@@ -411,7 +412,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -474,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -624,7 +625,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -637,7 +638,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -705,7 +706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -744,7 +745,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -755,7 +756,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -787,7 +788,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -809,7 +809,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -849,7 +849,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -863,7 +863,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -886,7 +886,7 @@ checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1117,7 +1117,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1414,7 +1414,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1442,7 +1442,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1521,14 +1521,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1606,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1979,7 +1979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1994,13 +1994,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2032,7 +2031,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -2202,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -2270,7 +2269,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -2328,7 +2327,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2356,7 +2355,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -2369,7 +2368,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2390,7 +2389,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -2401,7 +2400,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2434,7 +2433,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2461,7 +2460,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -2474,7 +2473,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2485,7 +2484,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2497,7 +2496,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2528,7 +2527,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2671,7 +2670,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2727,7 +2726,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2771,7 +2770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3034,7 +3033,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3065,14 +3064,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3093,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -3252,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -3386,7 +3385,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3407,7 +3406,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cssparser",
  "derive_more",
  "log",
@@ -3469,7 +3468,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3480,7 +3479,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3504,7 +3503,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3539,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3559,14 +3558,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3588,7 +3587,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3654,9 +3653,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket-pktinfo"
@@ -3802,9 +3801,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3828,7 +3827,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3837,7 +3836,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3871,7 +3870,7 @@ version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -3913,7 +3912,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4018,7 +4017,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tauri-utils",
  "thiserror 2.0.18",
  "time",
@@ -4036,7 +4035,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -4143,6 +4142,15 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-multicast-lock"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]
@@ -4291,7 +4299,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4302,17 +4310,16 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -4324,15 +4331,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4386,7 +4393,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4566,7 +4573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4781,9 +4788,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4862,9 +4869,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -4880,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4893,9 +4900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4903,9 +4910,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4913,22 +4920,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -4974,7 +4981,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -4982,9 +4989,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5087,7 +5094,7 @@ checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5214,7 +5221,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5225,7 +5232,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5616,7 +5623,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5632,7 +5639,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5644,7 +5651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -5773,28 +5780,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5814,15 +5821,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -5854,7 +5861,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/apps/klank/src-tauri/Cargo.toml
+++ b/apps/klank/src-tauri/Cargo.toml
@@ -44,6 +44,8 @@ html-escape = "0.2"
 git2 = { version = "0.19", default-features = false, features = ["https", "vendored-libgit2", "vendored-openssl"] }
 # Android-only scraper plugin (self-owned WebView). No-op shell on desktop.
 tauri-plugin-ug-scraper = { path = "tauri-plugin-ug-scraper" }
+# Android-only Wi-Fi MulticastLock for mDNS jam discovery. No-op shell on desktop.
+tauri-plugin-multicast-lock = { path = "tauri-plugin-multicast-lock" }
 
 # Size-optimized release profile. The unstripped native cdylib is the dominant
 # source of APK bloat; `strip` alone reclaims the bulk of it, the rest trims

--- a/apps/klank/src-tauri/Cargo.toml
+++ b/apps/klank/src-tauri/Cargo.toml
@@ -24,6 +24,9 @@ log = "0.4"
 tauri = { version = "2.11.2", features = [] }
 tokio = { version = "1", features = ["sync", "time", "net", "rt-multi-thread", "io-util"] }
 axum = { version = "0.7", default-features = false, features = ["ws", "http1", "tokio"] }
+# LAN jam discovery — advertise/browse a _klank-jam._tcp service. Pure-Rust,
+# cross-compiles to Android (multicast lock still required there at runtime).
+mdns-sd = "0.20"
 tauri-plugin-log = "2.0.0"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2.0"

--- a/apps/klank/src-tauri/permissions/allow-jam.toml
+++ b/apps/klank/src-tauri/permissions/allow-jam.toml
@@ -6,4 +6,5 @@ commands.allow = [
   "jam_stop",
   "jam_broadcast",
   "jam_status",
+  "jam_discover",
 ]

--- a/apps/klank/src-tauri/src/jam-lite.html
+++ b/apps/klank/src-tauri/src/jam-lite.html
@@ -21,6 +21,7 @@
   #dot.connected { background: #4caf50; }
   #dot.reconnecting { background: #f59e0b; }
   #name { font-weight: 600; color: #ddd; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #count { margin-left: auto; color: #4caf50; flex-shrink: 0; }
   #sheet {
     position: absolute; top: 36px; left: 0; right: 0; bottom: 0;
     overflow-y: auto; overflow-x: auto;
@@ -37,12 +38,14 @@
 <div id="header">
   <div id="dot"></div>
   <span id="name">Klank Jam</span>
+  <span id="count"></span>
 </div>
 <div id="sheet"><pre id="content"></pre></div>
 <script>
 (function () {
   var dot = document.getElementById('dot');
   var nameEl = document.getElementById('name');
+  var countEl = document.getElementById('count');
   var pre = document.getElementById('content');
   var sheet = document.getElementById('sheet');
   var ws = null;
@@ -57,6 +60,7 @@
 
   function applySnapshot(s) {
     if (s.name) nameEl.textContent = s.name;
+    if (typeof s.clients === 'number') countEl.textContent = '● ' + s.clients + ' connected';
     // Only rewrite the text node when content actually changes — snapshots
     // stream ~15/sec during scroll, and reflowing a large tab each time janks.
     if (typeof s.content === 'string' && s.content !== lastContent) {

--- a/apps/klank/src-tauri/src/jam.rs
+++ b/apps/klank/src-tauri/src/jam.rs
@@ -3,6 +3,14 @@
 //!
 //! The axum HTTP+WS server runs on a background tokio task. A `watch` channel
 //! holds the latest snapshot JSON so new subscribers receive it immediately.
+//! A second `watch` channel tracks the live connected-guest count, which is
+//! injected into every outgoing frame so all participants can see it.
+//!
+//! Hosts also advertise the jam over mDNS (`_klank-jam._tcp.local.`) so other
+//! klank apps on the same LAN can discover and join without typing an address.
+//! mDNS is best-effort: if the daemon can't start (e.g. multicast blocked, or
+//! a mobile OS without a held multicast lock) hosting still works via the
+//! manual `ip:port` join fallback.
 
 use axum::{
     extract::{
@@ -13,10 +21,16 @@ use axum::{
     routing::get,
     Router,
 };
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Mutex;
+use std::time::Duration;
 use tokio::sync::{oneshot, watch};
+
+/// mDNS service type advertised/browsed for klank jams.
+const SERVICE_TYPE: &str = "_klank-jam._tcp.local.";
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -24,23 +38,38 @@ use tokio::sync::{oneshot, watch};
 pub struct JamState {
     /// The latest snapshot JSON broadcast by the host.
     pub tx: watch::Sender<String>,
+    /// Number of guests currently connected to the host's WebSocket.
+    pub clients: watch::Sender<usize>,
+    inner: Mutex<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
     /// Running server info; None when stopped.
-    inner: Mutex<Option<RunningServer>>,
+    server: Option<RunningServer>,
+    /// Reused mDNS daemon, created lazily on first host/discover.
+    mdns: Option<ServiceDaemon>,
 }
 
 struct RunningServer {
     port: u16,
     urls: Vec<String>,
+    name: String,
     /// Dropping / sending on this kills the axum server.
     shutdown: oneshot::Sender<()>,
+    /// Registered mDNS fullname, if advertising succeeded — used to unregister
+    /// on stop and to filter our own jam out of discovery results.
+    mdns_fullname: Option<String>,
 }
 
 impl Default for JamState {
     fn default() -> Self {
         let (tx, _) = watch::channel("{}".to_string());
+        let (clients, _) = watch::channel(0usize);
         Self {
             tx,
-            inner: Mutex::new(None),
+            clients,
+            inner: Mutex::new(Inner::default()),
         }
     }
 }
@@ -51,6 +80,7 @@ impl Default for JamState {
 pub struct JamInfo {
     pub port: u16,
     pub urls: Vec<String>,
+    pub name: String,
 }
 
 #[derive(Serialize)]
@@ -58,6 +88,17 @@ pub struct JamStatus {
     pub hosting: bool,
     pub port: Option<u16>,
     pub urls: Vec<String>,
+    pub name: Option<String>,
+    /// Guests currently connected (host perspective).
+    pub clients: usize,
+}
+
+/// A jam discovered on the local network.
+#[derive(Serialize)]
+pub struct DiscoveredJam {
+    pub name: String,
+    /// `ip:port` ready to hand to the guest connect flow.
+    pub address: String,
 }
 
 // ── LAN IP detection ─────────────────────────────────────────────────────────
@@ -68,11 +109,64 @@ fn lan_ip() -> Option<std::net::IpAddr> {
     Some(s.local_addr().ok()?.ip())
 }
 
+// ── mDNS helpers ────────────────────────────────────────────────────────────
+
+/// Lazily create (and reuse) the shared mDNS daemon. Returns None when mDNS is
+/// unavailable on this platform/network — callers degrade to manual join.
+fn ensure_mdns(inner: &mut Inner) -> Option<ServiceDaemon> {
+    if inner.mdns.is_none() {
+        match ServiceDaemon::new() {
+            Ok(d) => inner.mdns = Some(d),
+            Err(e) => {
+                log::warn!("mDNS unavailable: {e}");
+                return None;
+            }
+        }
+    }
+    inner.mdns.clone()
+}
+
+/// DNS-safe `<name>.local.` hostname derived from a jam name.
+fn safe_host(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    let trimmed = cleaned.trim_matches('-');
+    if trimmed.is_empty() {
+        "klank-jam.local.".to_string()
+    } else {
+        format!("{trimmed}.local.")
+    }
+}
+
+/// Best-effort advertise of this jam. Returns the registered fullname on success.
+fn advertise(daemon: &ServiceDaemon, name: &str, ip: std::net::IpAddr, port: u16) -> Option<String> {
+    let host = safe_host(name);
+    let props: [(&str, &str); 1] = [("name", name)];
+    let info = match ServiceInfo::new(SERVICE_TYPE, name, &host, ip, port, &props[..]) {
+        Ok(i) => i,
+        Err(e) => {
+            log::warn!("mDNS service info failed: {e}");
+            return None;
+        }
+    };
+    let fullname = info.get_fullname().to_string();
+    match daemon.register(info) {
+        Ok(()) => Some(fullname),
+        Err(e) => {
+            log::warn!("mDNS register failed: {e}");
+            None
+        }
+    }
+}
+
 // ── axum app ─────────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
 struct AppState {
     tx: watch::Sender<String>,
+    clients: watch::Sender<usize>,
 }
 
 async fn root_handler() -> impl IntoResponse {
@@ -80,27 +174,52 @@ async fn root_handler() -> impl IntoResponse {
 }
 
 async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, state.tx))
+    ws.on_upgrade(move |socket| handle_socket(socket, state.tx, state.clients))
 }
 
-async fn handle_socket(mut socket: WebSocket, tx: watch::Sender<String>) {
-    let mut rx = tx.subscribe();
+/// Merge the live client count into a snapshot JSON object so guests and the
+/// browser client see `clients` without a second message type. Falls back to
+/// the raw snapshot if it isn't a JSON object.
+fn frame(snapshot: &str, clients: usize) -> String {
+    match serde_json::from_str::<serde_json::Value>(snapshot) {
+        Ok(serde_json::Value::Object(mut map)) => {
+            map.insert("clients".to_string(), serde_json::Value::from(clients));
+            serde_json::Value::Object(map).to_string()
+        }
+        _ => snapshot.to_string(),
+    }
+}
 
-    // Send current snapshot immediately.
-    let current = rx.borrow().clone();
-    if socket.send(Message::Text(current.into())).await.is_err() {
+async fn handle_socket(
+    mut socket: WebSocket,
+    snap_tx: watch::Sender<String>,
+    clients: watch::Sender<usize>,
+) {
+    // Count this guest in, then subscribe so we also see later changes.
+    clients.send_modify(|c| *c += 1);
+    let mut snap_rx = snap_tx.subscribe();
+    let mut cli_rx = clients.subscribe();
+
+    // Send the current snapshot + count immediately.
+    let initial = frame(&snap_rx.borrow(), *cli_rx.borrow());
+    if socket.send(Message::Text(initial.into())).await.is_err() {
+        clients.send_modify(|c| *c = c.saturating_sub(1));
         return;
     }
 
     loop {
         tokio::select! {
             // New snapshot from host.
-            changed = rx.changed() => {
+            changed = snap_rx.changed() => {
                 if changed.is_err() { break; }
-                let snapshot = rx.borrow().clone();
-                if socket.send(Message::Text(snapshot.into())).await.is_err() {
-                    break;
-                }
+                let f = frame(&snap_rx.borrow(), *cli_rx.borrow());
+                if socket.send(Message::Text(f.into())).await.is_err() { break; }
+            }
+            // Connected-guest count changed (someone joined/left).
+            changed = cli_rx.changed() => {
+                if changed.is_err() { break; }
+                let f = frame(&snap_rx.borrow(), *cli_rx.borrow());
+                if socket.send(Message::Text(f.into())).await.is_err() { break; }
             }
             // Drain inbound messages; detect close.
             msg = socket.recv() => {
@@ -111,10 +230,13 @@ async fn handle_socket(mut socket: WebSocket, tx: watch::Sender<String>) {
             }
         }
     }
+
+    // Count this guest out.
+    clients.send_modify(|c| *c = c.saturating_sub(1));
 }
 
-fn build_router(tx: watch::Sender<String>) -> Router {
-    let state = AppState { tx };
+fn build_router(tx: watch::Sender<String>, clients: watch::Sender<usize>) -> Router {
+    let state = AppState { tx, clients };
     Router::new()
         .route("/", get(root_handler))
         .route("/jam", get(ws_handler))
@@ -126,9 +248,13 @@ fn build_router(tx: watch::Sender<String>) -> Router {
 #[tauri::command]
 pub async fn jam_start(
     state: tauri::State<'_, JamState>,
+    name: String,
 ) -> Result<JamInfo, String> {
     // Stop any existing server first (idempotent).
     jam_stop_inner(&state);
+
+    // Reset the connected count for the fresh session.
+    state.clients.send_modify(|c| *c = 0);
 
     // Bind listener — prefer 7070, fall back to OS-assigned.
     let listener = match tokio::net::TcpListener::bind("0.0.0.0:7070").await {
@@ -141,14 +267,15 @@ pub async fn jam_start(
     let addr: SocketAddr = listener.local_addr().map_err(|e| e.to_string())?;
     let port = addr.port();
 
-    let urls = match lan_ip() {
+    let ip = lan_ip();
+    let urls = match ip {
         Some(ip) => vec![format!("http://{}:{}", ip, port)],
         None => vec![],
     };
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
-    let router = build_router(state.tx.clone());
+    let router = build_router(state.tx.clone(), state.clients.clone());
 
     tauri::async_runtime::spawn(async move {
         let _ = axum::serve(listener, router)
@@ -161,14 +288,22 @@ pub async fn jam_start(
     let info = JamInfo {
         port,
         urls: urls.clone(),
+        name: name.clone(),
     };
 
     {
         let mut guard = state.inner.lock().map_err(|e| e.to_string())?;
-        *guard = Some(RunningServer {
+        // Best-effort mDNS advertise so nearby apps can discover this jam.
+        let mdns_fullname = match (ensure_mdns(&mut guard), ip) {
+            (Some(daemon), Some(ip)) => advertise(&daemon, &name, ip, port),
+            _ => None,
+        };
+        guard.server = Some(RunningServer {
             port,
             urls,
+            name,
             shutdown: shutdown_tx,
+            mdns_fullname,
         });
     }
 
@@ -177,11 +312,16 @@ pub async fn jam_start(
 
 fn jam_stop_inner(state: &tauri::State<'_, JamState>) {
     if let Ok(mut guard) = state.inner.lock() {
-        if let Some(server) = guard.take() {
+        if let Some(server) = guard.server.take() {
+            if let (Some(daemon), Some(fullname)) = (guard.mdns.as_ref(), server.mdns_fullname) {
+                let _ = daemon.unregister(&fullname);
+            }
             // Sending triggers graceful shutdown; ignore errors (already gone).
             let _ = server.shutdown.send(());
         }
     }
+    // No guests remain once the server is down.
+    state.clients.send_modify(|c| *c = 0);
 }
 
 #[tauri::command]
@@ -202,23 +342,87 @@ pub async fn jam_broadcast(
 
 #[tauri::command]
 pub fn jam_status(state: tauri::State<'_, JamState>) -> JamStatus {
+    let clients = *state.clients.borrow();
     match state.inner.lock() {
-        Ok(guard) => match guard.as_ref() {
+        Ok(guard) => match guard.server.as_ref() {
             Some(s) => JamStatus {
                 hosting: true,
                 port: Some(s.port),
                 urls: s.urls.clone(),
+                name: Some(s.name.clone()),
+                clients,
             },
             None => JamStatus {
                 hosting: false,
                 port: None,
                 urls: vec![],
+                name: None,
+                clients: 0,
             },
         },
         Err(_) => JamStatus {
             hosting: false,
             port: None,
             urls: vec![],
+            name: None,
+            clients: 0,
         },
     }
+}
+
+/// Browse the LAN for ~1.5s and return the jams currently being advertised,
+/// excluding our own. Returns an empty list when mDNS is unavailable.
+#[tauri::command]
+pub async fn jam_discover(state: tauri::State<'_, JamState>) -> Result<Vec<DiscoveredJam>, String> {
+    // Pull the daemon out of the lock so we never hold the std Mutex across an
+    // await, and note our own fullname to skip it in the results.
+    let (daemon, own) = {
+        let mut guard = state.inner.lock().map_err(|e| e.to_string())?;
+        let daemon = match ensure_mdns(&mut guard) {
+            Some(d) => d,
+            None => return Ok(vec![]),
+        };
+        let own = guard
+            .server
+            .as_ref()
+            .and_then(|s| s.mdns_fullname.clone());
+        (daemon, own)
+    };
+
+    let receiver = daemon.browse(SERVICE_TYPE).map_err(|e| e.to_string())?;
+    // Keyed by fullname so repeated announcements collapse to one entry.
+    let mut found: HashMap<String, DiscoveredJam> = HashMap::new();
+
+    let _ = tokio::time::timeout(Duration::from_millis(1500), async {
+        loop {
+            match receiver.recv_async().await {
+                Ok(ServiceEvent::ServiceResolved(info)) => {
+                    let fullname = info.get_fullname().to_string();
+                    if own.as_deref() == Some(fullname.as_str()) {
+                        continue;
+                    }
+                    let Some(ip) = info.get_addresses().iter().next() else {
+                        continue;
+                    };
+                    let name = info
+                        .get_property_val_str("name")
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| fullname.clone());
+                    found.insert(
+                        fullname,
+                        DiscoveredJam {
+                            name,
+                            address: format!("{}:{}", ip, info.get_port()),
+                        },
+                    );
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+    })
+    .await;
+
+    let _ = daemon.stop_browse(SERVICE_TYPE);
+    Ok(found.into_values().collect())
 }

--- a/apps/klank/src-tauri/src/jam.rs
+++ b/apps/klank/src-tauri/src/jam.rs
@@ -60,6 +60,9 @@ struct RunningServer {
     /// Registered mDNS fullname, if advertising succeeded — used to unregister
     /// on stop and to filter our own jam out of discovery results.
     mdns_fullname: Option<String>,
+    /// True when an Android multicast lock is held for this session (so stop
+    /// releases exactly what start acquired). Always false off Android.
+    multicast_held: bool,
 }
 
 impl Default for JamState {
@@ -161,6 +164,54 @@ fn advertise(daemon: &ServiceDaemon, name: &str, ip: std::net::IpAddr, port: u16
     }
 }
 
+// ── Android multicast lock ──────────────────────────────────────────────────
+//
+// Android filters inbound multicast by default, so mDNS advertise/browse needs
+// a held Wi-Fi MulticastLock. These helpers are no-ops off Android.
+
+#[cfg(target_os = "android")]
+fn hold_multicast(app: &tauri::AppHandle) -> bool {
+    use tauri_plugin_multicast_lock::MulticastLockExt;
+    match app.multicast_lock().acquire() {
+        Ok(()) => true,
+        Err(e) => {
+            log::warn!("multicast lock acquire failed: {e}");
+            false
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn hold_multicast(_app: &tauri::AppHandle) -> bool {
+    false
+}
+
+#[cfg(target_os = "android")]
+fn release_multicast(app: &tauri::AppHandle) {
+    use tauri_plugin_multicast_lock::MulticastLockExt;
+    if let Err(e) = app.multicast_lock().release() {
+        log::warn!("multicast lock release failed: {e}");
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn release_multicast(_app: &tauri::AppHandle) {}
+
+/// Releases a held multicast lock on drop, so a scan releases on every exit
+/// path (including early `?` returns).
+struct MulticastGuard<'a> {
+    app: &'a tauri::AppHandle,
+    held: bool,
+}
+
+impl Drop for MulticastGuard<'_> {
+    fn drop(&mut self) {
+        if self.held {
+            release_multicast(self.app);
+        }
+    }
+}
+
 // ── axum app ─────────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -248,10 +299,11 @@ fn build_router(tx: watch::Sender<String>, clients: watch::Sender<usize>) -> Rou
 #[tauri::command]
 pub async fn jam_start(
     state: tauri::State<'_, JamState>,
+    app: tauri::AppHandle,
     name: String,
 ) -> Result<JamInfo, String> {
     // Stop any existing server first (idempotent).
-    jam_stop_inner(&state);
+    jam_stop_inner(&state, &app);
 
     // Reset the connected count for the fresh session.
     state.clients.send_modify(|c| *c = 0);
@@ -291,6 +343,9 @@ pub async fn jam_start(
         name: name.clone(),
     };
 
+    // Hold the multicast lock (Android) so mDNS advertise/browse works.
+    let multicast_held = hold_multicast(&app);
+
     {
         let mut guard = state.inner.lock().map_err(|e| e.to_string())?;
         // Best-effort mDNS advertise so nearby apps can discover this jam.
@@ -304,17 +359,22 @@ pub async fn jam_start(
             name,
             shutdown: shutdown_tx,
             mdns_fullname,
+            multicast_held,
         });
     }
 
     Ok(info)
 }
 
-fn jam_stop_inner(state: &tauri::State<'_, JamState>) {
+fn jam_stop_inner(state: &tauri::State<'_, JamState>, app: &tauri::AppHandle) {
     if let Ok(mut guard) = state.inner.lock() {
         if let Some(server) = guard.server.take() {
             if let (Some(daemon), Some(fullname)) = (guard.mdns.as_ref(), server.mdns_fullname) {
                 let _ = daemon.unregister(&fullname);
+            }
+            // Release exactly what jam_start acquired.
+            if server.multicast_held {
+                release_multicast(app);
             }
             // Sending triggers graceful shutdown; ignore errors (already gone).
             let _ = server.shutdown.send(());
@@ -325,8 +385,11 @@ fn jam_stop_inner(state: &tauri::State<'_, JamState>) {
 }
 
 #[tauri::command]
-pub async fn jam_stop(state: tauri::State<'_, JamState>) -> Result<(), String> {
-    jam_stop_inner(&state);
+pub async fn jam_stop(
+    state: tauri::State<'_, JamState>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    jam_stop_inner(&state, &app);
     Ok(())
 }
 
@@ -373,7 +436,15 @@ pub fn jam_status(state: tauri::State<'_, JamState>) -> JamStatus {
 /// Browse the LAN for ~1.5s and return the jams currently being advertised,
 /// excluding our own. Returns an empty list when mDNS is unavailable.
 #[tauri::command]
-pub async fn jam_discover(state: tauri::State<'_, JamState>) -> Result<Vec<DiscoveredJam>, String> {
+pub async fn jam_discover(
+    state: tauri::State<'_, JamState>,
+    app: tauri::AppHandle,
+) -> Result<Vec<DiscoveredJam>, String> {
+    // Hold the multicast lock (Android) for the duration of the scan so we can
+    // receive announcements. The guard releases it on every exit path. Composes
+    // with a host hold via the reference-counted lock.
+    let _multicast = MulticastGuard { app: &app, held: hold_multicast(&app) };
+
     // Pull the daemon out of the lock so we never hold the std Mutex across an
     // await, and note our own fullname to skip it in the results.
     let (daemon, own) = {

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -60,7 +60,8 @@ pub fn run() {
             jam::jam_start,
             jam::jam_stop,
             jam::jam_broadcast,
-            jam::jam_status
+            jam::jam_status,
+            jam::jam_discover
         ]);
     #[cfg(not(desktop))]
     let builder = builder.invoke_handler(tauri::generate_handler![
@@ -84,7 +85,8 @@ pub fn run() {
         jam::jam_start,
         jam::jam_stop,
         jam::jam_broadcast,
-        jam::jam_status
+        jam::jam_status,
+        jam::jam_discover
     ]);
 
     builder

--- a/apps/klank/src-tauri/src/lib.rs
+++ b/apps/klank/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_ug_scraper::init())
+        .plugin(tauri_plugin_multicast_lock::init())
         .manage(jam::JamState::default());
 
     // The hidden-webview import stage (and its IPC) is desktop-only; Android

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/Cargo.toml
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tauri-plugin-multicast-lock"
+version = "0.1.0"
+edition = "2021"
+description = "Android-only Tauri plugin that holds a Wi-Fi MulticastLock so mDNS jam discovery can send and receive multicast on the LAN."
+links = "tauri-plugin-multicast-lock"
+
+[dependencies]
+tauri = { version = "2.11.2" }
+serde = { version = "1", features = ["derive"] }
+
+[build-dependencies]
+tauri-plugin = { version = "2", features = ["build"] }

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/android/.gitignore
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/android/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.tauri

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/android/build.gradle.kts
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/android/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "io.github.hampterworks.klank.multicastlock"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 24
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    // Provided by the Tauri Android template (generated into the app project).
+    implementation(project(":tauri-android"))
+}

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/android/src/main/AndroidManifest.xml
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/android/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Required to acquire a Wi-Fi MulticastLock for mDNS jam discovery. -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+</manifest>

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/android/src/main/java/io/github/hampterworks/klank/multicastlock/MulticastLockPlugin.kt
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/android/src/main/java/io/github/hampterworks/klank/multicastlock/MulticastLockPlugin.kt
@@ -1,0 +1,50 @@
+package io.github.hampterworks.klank.multicastlock
+
+import android.app.Activity
+import android.content.Context
+import android.net.wifi.WifiManager
+import app.tauri.annotation.Command
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSObject
+import app.tauri.plugin.Plugin
+
+/**
+ * Holds a Wi-Fi [WifiManager.MulticastLock] while a jam is hosting or
+ * discovering. Android filters out inbound multicast/broadcast packets by
+ * default to save power, so mDNS (advertise + browse) needs this lock to both
+ * send and receive on the local network.
+ *
+ * The lock is reference-counted: each [acquire] must be matched by one
+ * [release], and the OS only stops filtering once the count reaches zero. This
+ * lets an overlapping host + discovery hold compose without releasing early.
+ */
+@TauriPlugin
+class MulticastLockPlugin(private val activity: Activity) : Plugin(activity) {
+    private val lock: WifiManager.MulticastLock by lazy {
+        val wifi = activity.applicationContext
+            .getSystemService(Context.WIFI_SERVICE) as WifiManager
+        wifi.createMulticastLock("klank-jam").apply { setReferenceCounted(true) }
+    }
+
+    @Command
+    fun acquire(invoke: Invoke) {
+        try {
+            lock.acquire()
+            invoke.resolve(JSObject())
+        } catch (e: Exception) {
+            invoke.reject(e.message ?: "multicast acquire failed")
+        }
+    }
+
+    @Command
+    fun release(invoke: Invoke) {
+        try {
+            // Guard against under-locking: only release while a reference is held.
+            if (lock.isHeld) lock.release()
+            invoke.resolve(JSObject())
+        } catch (e: Exception) {
+            invoke.reject(e.message ?: "multicast release failed")
+        }
+    }
+}

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/build.rs
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/build.rs
@@ -1,0 +1,7 @@
+const COMMANDS: &[&str] = &["acquire", "release"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")
+        .build();
+}

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/permissions/autogenerated/commands/acquire.toml
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/permissions/autogenerated/commands/acquire.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-acquire"
+description = "Enables the acquire command without any pre-configured scope."
+commands.allow = ["acquire"]
+
+[[permission]]
+identifier = "deny-acquire"
+description = "Denies the acquire command without any pre-configured scope."
+commands.deny = ["acquire"]

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/permissions/autogenerated/commands/release.toml
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/permissions/autogenerated/commands/release.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-release"
+description = "Enables the release command without any pre-configured scope."
+commands.allow = ["release"]
+
+[[permission]]
+identifier = "deny-release"
+description = "Denies the release command without any pre-configured scope."
+commands.deny = ["release"]

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/permissions/autogenerated/reference.md
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/permissions/autogenerated/reference.md
@@ -1,0 +1,61 @@
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`multicast-lock:allow-acquire`
+
+</td>
+<td>
+
+Enables the acquire command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`multicast-lock:deny-acquire`
+
+</td>
+<td>
+
+Denies the acquire command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`multicast-lock:allow-release`
+
+</td>
+<td>
+
+Enables the release command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`multicast-lock:deny-release`
+
+</td>
+<td>
+
+Denies the release command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/permissions/schemas/schema.json
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/permissions/schemas/schema.json
@@ -1,0 +1,324 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the acquire command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-acquire",
+          "markdownDescription": "Enables the acquire command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the acquire command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-acquire",
+          "markdownDescription": "Denies the acquire command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the release command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-release",
+          "markdownDescription": "Enables the release command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the release command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-release",
+          "markdownDescription": "Denies the release command without any pre-configured scope."
+        }
+      ]
+    }
+  }
+}

--- a/apps/klank/src-tauri/tauri-plugin-multicast-lock/src/lib.rs
+++ b/apps/klank/src-tauri/tauri-plugin-multicast-lock/src/lib.rs
@@ -1,0 +1,88 @@
+//! Android-only Tauri plugin that holds a Wi-Fi `MulticastLock`.
+//!
+//! Android drops inbound multicast/broadcast packets by default to save power,
+//! so mDNS jam discovery (advertise + browse) can't send and receive on the LAN
+//! unless a `MulticastLock` is held. Jam mode acquires the lock while hosting or
+//! discovering and releases it when done.
+//!
+//! The lock is reference-counted on the Android side: every [`MulticastLock::acquire`]
+//! must be matched by one [`MulticastLock::release`], so an overlapping host +
+//! discovery hold composes correctly.
+//!
+//! On non-Android targets this is a no-op shell so the crate still compiles and
+//! can be registered unconditionally.
+
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Runtime,
+};
+
+#[cfg(target_os = "android")]
+use {
+    serde::{Deserialize, Serialize},
+    tauri::plugin::PluginHandle,
+    tauri::Manager,
+};
+
+/// Empty payload for the no-argument commands.
+#[cfg(target_os = "android")]
+#[derive(Serialize)]
+struct NoArgs {}
+
+/// Empty `{}` resolve from the Android side.
+#[cfg(target_os = "android")]
+#[derive(Deserialize)]
+struct Empty {}
+
+/// Handle to the registered Android plugin.
+#[cfg(target_os = "android")]
+pub struct MulticastLock<R: Runtime>(PluginHandle<R>);
+
+#[cfg(target_os = "android")]
+impl<R: Runtime> MulticastLock<R> {
+    /// Acquire (reference-counted) the Wi-Fi multicast lock.
+    pub fn acquire(&self) -> Result<(), String> {
+        self.0
+            .run_mobile_plugin::<Empty>("acquire", NoArgs {})
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    /// Release one reference of the Wi-Fi multicast lock.
+    pub fn release(&self) -> Result<(), String> {
+        self.0
+            .run_mobile_plugin::<Empty>("release", NoArgs {})
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// Extension trait to reach the plugin from an `AppHandle`/`Manager`.
+#[cfg(target_os = "android")]
+pub trait MulticastLockExt<R: Runtime> {
+    fn multicast_lock(&self) -> &MulticastLock<R>;
+}
+
+#[cfg(target_os = "android")]
+impl<R: Runtime, T: Manager<R>> MulticastLockExt<R> for T {
+    fn multicast_lock(&self) -> &MulticastLock<R> {
+        self.state::<MulticastLock<R>>().inner()
+    }
+}
+
+/// Initializes the plugin. On non-Android targets this is a no-op shell.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("multicast-lock")
+        .setup(|_app, _api| {
+            #[cfg(target_os = "android")]
+            {
+                let handle = _api.register_android_plugin(
+                    "io.github.hampterworks.klank.multicastlock",
+                    "MulticastLockPlugin",
+                )?;
+                _app.manage(MulticastLock(handle));
+            }
+            Ok(())
+        })
+        .build()
+}

--- a/libs/platform-api/src/lib/jam.spec.ts
+++ b/libs/platform-api/src/lib/jam.spec.ts
@@ -5,7 +5,7 @@ import type { Mock } from 'vitest'
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 
 import { invoke } from '@tauri-apps/api/core'
-import { connectJam, createJamHost, type JamSnapshot } from './jam.js'
+import { connectJam, createJamHost, discoverJams, type JamSnapshot } from './jam.js'
 
 const invokeMock = invoke as Mock
 
@@ -24,11 +24,11 @@ const snapshot = (overrides: Partial<JamSnapshot> = {}): JamSnapshot => ({
 describe('createJamHost', () => {
   beforeEach(() => invokeMock.mockReset())
 
-  it('start invokes jam_start and returns the host info', async () => {
-    invokeMock.mockResolvedValue({ port: 7070, urls: ['http://x:7070'] })
+  it('start invokes jam_start with the jam name and returns the host info', async () => {
+    invokeMock.mockResolvedValue({ port: 7070, urls: ['http://x:7070'], name: 'klank-jam-1234' })
     const host = await createJamHost()
-    expect(await host.start()).toEqual({ port: 7070, urls: ['http://x:7070'] })
-    expect(invokeMock).toHaveBeenCalledWith('jam_start')
+    expect(await host.start('klank-jam-1234')).toEqual({ port: 7070, urls: ['http://x:7070'], name: 'klank-jam-1234' })
+    expect(invokeMock).toHaveBeenCalledWith('jam_start', { name: 'klank-jam-1234' })
   })
 
   it('stop invokes jam_stop', async () => {
@@ -48,6 +48,22 @@ describe('createJamHost', () => {
     invokeMock.mockResolvedValue({ hosting: true, port: 7070, urls: [] })
     expect(await (await createJamHost()).status()).toEqual({ hosting: true, port: 7070, urls: [] })
     expect(invokeMock).toHaveBeenCalledWith('jam_status')
+  })
+})
+
+describe('discoverJams', () => {
+  beforeEach(() => invokeMock.mockReset())
+
+  it('invokes jam_discover and returns the discovered jams', async () => {
+    const jams = [{ name: 'klank-jam-1', address: '192.168.1.5:7070' }]
+    invokeMock.mockResolvedValue(jams)
+    expect(await discoverJams()).toEqual(jams)
+    expect(invokeMock).toHaveBeenCalledWith('jam_discover')
+  })
+
+  it('resolves to an empty list when discovery is unavailable', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('not in tauri'))
+    await expect(discoverJams()).resolves.toEqual([])
   })
 })
 

--- a/libs/platform-api/src/lib/jam.ts
+++ b/libs/platform-api/src/lib/jam.ts
@@ -9,26 +9,50 @@ export type JamSnapshot = {
   scrollSpeed: number
   scrolling: boolean
   fraction: number // 0..1 normalized scroll position
+  /** Connected-guest count, injected by the host server (guest-facing only). */
+  clients?: number
 }
 
-export type JamInfo = { port: number; urls: string[] }
+export type JamInfo = { port: number; urls: string[]; name: string }
 
-export type JamStatus = { hosting: boolean; port: number | null; urls: string[] }
+export type JamStatus = {
+  hosting: boolean
+  port: number | null
+  urls: string[]
+  name: string | null
+  /** Guests currently connected (host perspective). */
+  clients: number
+}
+
+/** A jam discovered on the local network via mDNS. */
+export type DiscoveredJam = { name: string; address: string }
 
 export type JamHost = {
-  start: () => Promise<JamInfo>
+  start: (name: string) => Promise<JamInfo>
   stop: () => Promise<void>
   broadcast: (snapshot: JamSnapshot) => Promise<void>
   status: () => Promise<JamStatus>
 }
 
 export const createJamHost = async (): Promise<JamHost> => ({
-  start: () => invoke<JamInfo>('jam_start'),
+  start: (name: string) => invoke<JamInfo>('jam_start', { name }),
   stop: () => invoke<void>('jam_stop'),
   broadcast: (snapshot: JamSnapshot) =>
     invoke<void>('jam_broadcast', { snapshot: JSON.stringify(snapshot) }),
   status: () => invoke<JamStatus>('jam_status'),
 })
+
+/**
+ * Browse the local network for open jams (mDNS). Resolves after a short scan
+ * window. Returns an empty list outside Tauri or when discovery is unavailable.
+ */
+export const discoverJams = async (): Promise<DiscoveredJam[]> => {
+  try {
+    return await invoke<DiscoveredJam[]>('jam_discover')
+  } catch {
+    return []
+  }
+}
 
 // ── Guest / client side ───────────────────────────────────────────────────────
 

--- a/libs/store/src/lib/jam.spec.ts
+++ b/libs/store/src/lib/jam.spec.ts
@@ -25,7 +25,7 @@ const snapshot = (overrides: Partial<JamSnapshot> = {}): JamSnapshot => ({
   ...overrides,
 })
 
-const OFF = { role: 'off', port: null, urls: [], hostAddress: '', connected: false, snapshot: null }
+const OFF = { role: 'off', port: null, urls: [], name: '', hostAddress: '', connected: false, snapshot: null, clients: 0 }
 
 describe('jam store slice', () => {
   beforeEach(() => useKlankStore.getState().setJamOff())
@@ -34,12 +34,29 @@ describe('jam store slice', () => {
     expect(useKlankStore.getState().jam).toEqual(OFF)
   })
 
-  it('setJamHosting → host role carrying port + urls', () => {
-    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://192.168.1.5:7070'] })
+  it('setJamHosting → host role carrying port + urls + name', () => {
+    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://192.168.1.5:7070'], name: 'klank-jam-1234' })
     const { jam } = useKlankStore.getState()
     expect(jam.role).toBe('host')
     expect(jam.port).toBe(7070)
     expect(jam.urls).toEqual(['http://192.168.1.5:7070'])
+    expect(jam.name).toBe('klank-jam-1234')
+  })
+
+  it('setJamClients updates the connected count', () => {
+    useKlankStore.getState().setJamClients(3)
+    expect(useKlankStore.getState().jam.clients).toBe(3)
+  })
+
+  it('setJamSnapshot mirrors the snapshot clients count into state', () => {
+    useKlankStore.getState().setJamSnapshot(snapshot({ clients: 5 }))
+    expect(useKlankStore.getState().jam.clients).toBe(5)
+  })
+
+  it('setJamSnapshot keeps the prior count when the snapshot omits clients', () => {
+    useKlankStore.getState().setJamClients(2)
+    useKlankStore.getState().setJamSnapshot(snapshot())
+    expect(useKlankStore.getState().jam.clients).toBe(2)
   })
 
   it('setJamGuest → guest role and clears any prior connection/snapshot', () => {
@@ -67,7 +84,7 @@ describe('jam store slice', () => {
   })
 
   it('setJamOff fully resets from host', () => {
-    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://x:7070'] })
+    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://x:7070'], name: 'klank-jam-1234' })
     useKlankStore.getState().setJamOff()
     expect(useKlankStore.getState().jam).toEqual(OFF)
   })

--- a/libs/store/src/lib/store-persistence.spec.ts
+++ b/libs/store/src/lib/store-persistence.spec.ts
@@ -70,7 +70,7 @@ describe('klank-storage migration and shape', () => {
     const { useKlankStore } = await import('./store.js')
 
     // Enter host mode (and force a persisted write so the entry is fresh).
-    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://192.168.50.50:7070'] })
+    useKlankStore.getState().setJamHosting({ port: 7070, urls: ['http://192.168.50.50:7070'], name: 'klank-jam-1234' })
     useKlankStore.getState().setTheme('Dark')
 
     const parsed = JSON.parse(localStorageData['klank-storage']) as { state: Record<string, unknown> }

--- a/libs/store/src/lib/store.ts
+++ b/libs/store/src/lib/store.ts
@@ -20,12 +20,16 @@ export type JamState = {
   // host
   port: number | null
   urls: string[]
+  /** Host-chosen jam name advertised on the LAN (host only). */
+  name: string
   // guest
   /** "ip:port" string the user typed, e.g. "192.168.1.5:7070". */
   hostAddress: string
   connected: boolean
   /** Latest snapshot received from the host (guest only). */
   snapshot: JamSnapshot | null
+  /** Live connected-guest count — host polls status, guest reads it from snapshots. */
+  clients: number
 }
 
 export type Mode = "Read" | "Edit"
@@ -210,7 +214,7 @@ type KlankState = {
    */
   jam: JamState
   /** Called when this client becomes the host after jam server starts. */
-  setJamHosting: (info: { port: number; urls: string[] }) => void
+  setJamHosting: (info: { port: number; urls: string[]; name: string }) => void
   /** Called when the user chooses to join as a guest. Sets address, clears snapshot. */
   setJamGuest: (hostAddress: string) => void
   /** Resets jam to the default off state. */
@@ -219,6 +223,8 @@ type KlankState = {
   setJamConnected: (connected: boolean) => void
   /** Stores the latest snapshot received from the host. */
   setJamSnapshot: (snapshot: JamSnapshot) => void
+  /** Updates the live connected-guest count. */
+  setJamClients: (clients: number) => void
 }
 
 /** All valid scroll speed levels (0–9, displayed as 1–10). */
@@ -306,18 +312,18 @@ export const useKlankStore = create<KlankState>()(
         addCustomTuning: (tuning) => set((state) => ({...state, customTunings: [...state.customTunings, tuning]})),
         deleteCustomTuning: (id) => set((state) => ({...state, customTunings: state.customTunings.filter((t) => t.id !== id)})),
         // ── Jam slice (ephemeral — not in partialize) ──────────────────────────
-        jam: { role: 'off', port: null, urls: [], hostAddress: '', connected: false, snapshot: null },
+        jam: { role: 'off', port: null, urls: [], name: '', hostAddress: '', connected: false, snapshot: null, clients: 0 },
         setJamHosting: (info) => set((state) => ({
           ...state,
-          jam: { ...state.jam, role: 'host', port: info.port, urls: info.urls },
+          jam: { ...state.jam, role: 'host', port: info.port, urls: info.urls, name: info.name, clients: 0 },
         })),
         setJamGuest: (hostAddress) => set((state) => ({
           ...state,
-          jam: { ...state.jam, role: 'guest', hostAddress, connected: false, snapshot: null },
+          jam: { ...state.jam, role: 'guest', hostAddress, connected: false, snapshot: null, clients: 0 },
         })),
         setJamOff: () => set((state) => ({
           ...state,
-          jam: { role: 'off', port: null, urls: [], hostAddress: '', connected: false, snapshot: null },
+          jam: { role: 'off', port: null, urls: [], name: '', hostAddress: '', connected: false, snapshot: null, clients: 0 },
         })),
         setJamConnected: (connected) => set((state) => ({
           ...state,
@@ -325,7 +331,17 @@ export const useKlankStore = create<KlankState>()(
         })),
         setJamSnapshot: (snapshot) => set((state) => ({
           ...state,
-          jam: { ...state.jam, snapshot },
+          // The host injects `clients` into each frame; mirror it into state so
+          // guests can show the count without a separate message.
+          jam: {
+            ...state.jam,
+            snapshot,
+            clients: typeof snapshot.clients === 'number' ? snapshot.clients : state.jam.clients,
+          },
+        })),
+        setJamClients: (clients) => set((state) => ({
+          ...state,
+          jam: { ...state.jam, clients },
         })),
         setTabPath: (path) => set((state) => {
           const saved = state.tabSettingByPath[path]


### PR DESCRIPTION
## What & why

Four related improvements to editing and Jam mode, per request.

### 1. Cancel button in edit mode
- Added a **Cancel** button next to **Save** as a floating action group (`Player.tsx`). Cancel discards unsaved edits (`editedContent` → last saved `tabData`) and returns to Read mode without writing to disk.
- Repositions correctly above the mobile bottom toolbar — works on desktop and mobile.

### 2. Connected-user count (everyone sees it)
- The host now tracks live guest connections with a `watch<usize>` channel, incrementing/decrementing on WebSocket connect/disconnect.
- The count is **injected into every snapshot frame** server-side, so guests, the browser jam page (`jam-lite.html`), and the host all see “N connected”.
- The host reads the count from `jam_status` (polled every 2s while hosting in Settings); guests read it from the snapshot.

### 3. LAN jam discovery (mDNS)
- Hosts advertise `_klank-jam._tcp` via the `mdns-sd` crate. Other klank apps (desktop or mobile) browse and join with one tap — no typing an address.
- Each jam advertises an **editable name** (default `klank-jam-NNNN`, a random number — never the device name).
- **Best-effort & graceful:** if multicast/mDNS is unavailable (e.g. Android without a held multicast lock, or a network that blocks multicast), hosting still works and the manual `ip:port` join remains as a fallback.

### 4. Settings Jam UX redesign
- One clear flow per state:
  - **Off:** editable jam name + Host; a live **“Nearby jams”** list (name + tap-to-join) with Refresh; collapsible **“Join by address”** manual fallback.
  - **Host:** status with the jam name, **connected count**, share URLs, stop.
  - **Guest:** connection status, **connected count**, leave.

## New Tauri command
- `jam_discover` → returns `[{ name, address }]` after a ~1.5s scan. Added to the invoke handler (desktop + mobile), the `allow-jam` permission set, and the `@klank/platform-api` wrapper (`discoverJams`).
- `jam_start` now takes a `name` argument.

## Testing
- `pnpm nx run-many -t typecheck` ✓ · `pnpm lint` ✓ · `pnpm nx run-many -t test` ✓ (676 tests).
- Production Vite build ✓.
- Updated/added tests for the store jam slice (name + clients), the platform-api jam wrapper (`start(name)`, `discoverJams`), and persistence.
- The `mdns-sd` 0.20 API and `jam.rs` logic were validated against a standalone compiled harness; the full Tauri Rust build couldn’t be linked in this environment (missing system GTK libs — unrelated to the change), so CI should confirm the Rust compile.

## Notes / follow-ups
- Android mDNS discovery requires a native multicast lock to reliably receive responses; advertising/browsing are wired up and degrade gracefully, but a small mobile-side multicast-lock plugin may be needed for full parity. Manual join works everywhere today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DXPHvJZGyNFiL4xZ51HGu)_