### PR TITLE
Fix release version not incrementing across runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Find the latest published (non-prerelease) release and bump the patch.
-          # Falls back to v2.0.0 if no releases exist yet.
-          LATEST=$(gh release view --repo "$GITHUB_REPOSITORY" --latest --json tagName --jq '.tagName' 2>/dev/null || echo "v2.0.0")
+          # Bump the patch of the latest published release and use that as this
+          # build's version. The REST releases/latest endpoint returns the most
+          # recent release excluding drafts and prereleases (so the pr-* preview
+          # builds are ignored), and 404s when none exist — in which case, or if
+          # the tag isn't semver, we fall back to v2.0.0 and start at v2.0.1.
+          LATEST=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name' 2>/dev/null || echo "v2.0.0")
           LATEST="${LATEST#v}"
+          if [[ ! "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            LATEST="2.0.0"
+          fi
           MAJOR=$(echo "$LATEST" | cut -d. -f1)
           MINOR=$(echo "$LATEST" | cut -d. -f2)
           PATCH=$(echo "$LATEST" | cut -d. -f3)


### PR DESCRIPTION
## Problem

The latest Release run failed at the publish step with:

> a release with the same tag name already exists: v2.0.1

The `version` job logged `Building version: 2.0.1 (bumped from v2.0.0)` — it bumped from the **fallback** `v2.0.0`, not the existing `v2.0.1`, so every build resolves to `2.0.1`.

## Root cause

```bash
LATEST=$(gh release view --repo "$GITHUB_REPOSITORY" --latest --json tagName --jq '.tagName' 2>/dev/null || echo "v2.0.0")
```

`gh release view` has **no `--latest` flag** (that belongs to `gh release list`/the REST API). The command errored on every run, `2>/dev/null` hid it, and `|| echo "v2.0.0"` always won — pinning the version to `2.0.1` forever. The first release only succeeded because no release existed yet.

## Fix

Resolve the previous release via the REST `releases/latest` endpoint, which is explicitly defined to return the most recent **non-draft, non-prerelease** release (so the `pr-*` preview builds are ignored) and 404s cleanly when none exist:

```bash
LATEST=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name' 2>/dev/null || echo "v2.0.0")
```

Also added a semver guard so a non-semver tag (the repo still has old `release-YYYYMMDD-NN` tags) can't crash the patch arithmetic under `bash -e`.

Verified the bump logic locally: `v2.0.1 → 2.0.2`, `v2.0.9 → 2.0.10`, non-semver → safe fallback to start at `v2.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DXPHvJZGyNFiL4xZ51HGu

---
_Generated by [Claude Code](https://claude.ai/code/session_018DXPHvJZGyNFiL4xZ51HGu)_